### PR TITLE
feat: support Windows absolute paths in auroraview:// protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",
@@ -164,6 +164,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
+ "path-clean",
  "proptest",
  "pyo3",
  "raw-window-handle",
@@ -2519,6 +2520,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "peeking_take_while"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # URL handling
 url = "2.5"
 
+# Path normalization (cross-platform)
+path-clean = "1.0"
+
 # MIME type detection
 mime_guess = "2.0"
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where `auroraview://` protocol URLs with Windows absolute paths fail to load. The protocol handler was incorrectly treating absolute paths as relative and joining them with `asset_root`, resulting in invalid file paths.

## Problem

URLs like the following were failing:
```
auroraview://c/users/username/projects/myapp/0.1.0/assets/images/logo.gif
```

The root cause was that the protocol handler always joined the extracted path with `asset_root`, regardless of whether it was absolute or relative.
## Summary

This PR fixes the issue where `auroraview://` protocol URLs with Windows absolute paths fail to load. The protocol handler was incorrectly treating absolute paths as relative and joining them with `asset_root`, resulting in invalid file paths.

## Problem

URLs like the following were failing:
```
auroraview://c/users/username/projects/myapp/0.1.0/assets/images/logo.gif
```

The root cause was that the protocol handler always joined the extracted path with `asset_root`, regardless of whether it was absolute or relative.

## Solution

### 1. Added Cross-Platform Path Handling
- Added `path-clean` crate for reliable path normalization across platforms
- Implemented `parse_protocol_path()` to intelligently handle both relative and absolute paths
- Used standard library's `Path::is_absolute()` for platform-native absolute path detection

### 2. Windows-Specific Path Support
- Implemented `is_windows_absolute_path_without_colon()` to detect Windows paths in URL format (e.g., `c/users/...`)
- Implemented `normalize_windows_path_without_colon()` to convert URL-format paths to standard Windows format (e.g., `c/users/...` → `C:/users/...`)

### 3. Comprehensive Testing
- Moved all tests to integration test file following Rust best practices
- Added 10 comprehensive test cases covering:
  - Windows path detection and normalization
  - Relative path handling
  - Absolute path handling (both Windows and Unix)
  - Path cleaning (handling `..` segments)
  - Real-world scenario simulation

## Changes

### Modified Files
- `Cargo.toml`: Added `path-clean = "1.0"` dependency
- `src/webview/protocol_handlers.rs`: 
  - Added path parsing helper functions
  - Modified `handle_auroraview_protocol` to use new path logic
- `tests/protocol_handlers_integration_tests.rs`: Added comprehensive path parsing tests

### Code Quality
- ✅ All tests passing (10/10)
- ✅ `cargo fmt` passed
- ✅ `cargo clippy` passed with no warnings
- ✅ Follows Rust best practices

## Testing

```bash
cargo test --test protocol_handlers_integration_tests
```

All 10 tests pass:
- `test_is_windows_absolute_path_without_colon`
- `test_normalize_windows_path_without_colon`
- `test_parse_protocol_path_relative`
- `test_parse_protocol_path_absolute_unix`
- `test_parse_protocol_path_absolute_windows`
- `test_parse_protocol_path_with_dots`
- `test_auroraview_protocol_with_windows_absolute_path`
- `test_auroraview_protocol_with_subdirectories`
- `test_handle_auroraview_protocol_security`
- `test_custom_protocol_with_various_responses`

## Breaking Changes

None. This is a backward-compatible enhancement that adds support for absolute paths while maintaining existing relative path behavior.

## Related Issues

Fixes the file protocol issue where Windows absolute paths in `auroraview://` URLs were not being resolved correctly.
