### PR TITLE
feat: auto-convert relative paths to auroraview:// protocol and add always_on_top

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "coverage[toml]>=7.0",
+    "websockets>=10.0",
 ]
 dev = [
     { include-group = "test" },

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,10 +1,6 @@
 """Tests for auroraview.bridge module."""
 
-import asyncio
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 
 class TestBridgeCreation:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,254 @@
+"""Tests for auroraview.bridge module."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestBridgeCreation:
+    """Tests for Bridge class creation and initialization."""
+
+    def test_bridge_import(self):
+        """Test that Bridge can be imported."""
+        from auroraview import Bridge
+
+        assert Bridge is not None
+
+    def test_bridge_creation_default(self):
+        """Test Bridge creation with default parameters."""
+        from auroraview import Bridge
+
+        bridge = Bridge()
+        assert bridge.host == "localhost"
+        assert bridge.port == 9001
+        assert bridge.protocol == "json"
+        assert bridge.is_running is False
+        assert bridge.client_count == 0
+
+    def test_bridge_creation_custom_port(self):
+        """Test Bridge creation with custom port."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=8888)
+        assert bridge.port == 8888
+
+    def test_bridge_creation_custom_host(self):
+        """Test Bridge creation with custom host."""
+        from auroraview import Bridge
+
+        bridge = Bridge(host="0.0.0.0", port=9002)
+        assert bridge.host == "0.0.0.0"
+        assert bridge.port == 9002
+
+    def test_bridge_repr(self):
+        """Test Bridge string representation."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9003)
+        repr_str = repr(bridge)
+        assert "Bridge" in repr_str
+        assert "9003" in repr_str
+        assert "stopped" in repr_str
+
+    def test_bridge_clients_property(self):
+        """Test Bridge clients property."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9004)
+        assert isinstance(bridge.clients, set)
+        assert len(bridge.clients) == 0
+
+
+class TestBridgeHandlers:
+    """Tests for Bridge handler registration."""
+
+    def test_register_handler(self):
+        """Test registering a message handler."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9005)
+
+        async def my_handler(data, client):
+            return {"status": "ok"}
+
+        bridge.register_handler("test_action", my_handler)
+        assert "test_action" in bridge._handlers
+
+    def test_on_decorator(self):
+        """Test @bridge.on() decorator."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9006)
+
+        @bridge.on("layer_created")
+        async def handle_layer(data, client):
+            return {"status": "ok"}
+
+        assert "layer_created" in bridge._handlers
+        assert bridge._handlers["layer_created"] == handle_layer
+
+    def test_multiple_handlers(self):
+        """Test registering multiple handlers."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9007)
+
+        @bridge.on("action1")
+        async def handler1(data, client):
+            pass
+
+        @bridge.on("action2")
+        async def handler2(data, client):
+            pass
+
+        assert len(bridge._handlers) == 2
+        assert "action1" in bridge._handlers
+        assert "action2" in bridge._handlers
+
+
+class TestBridgeWebViewCallback:
+    """Tests for WebView callback integration."""
+
+    def test_set_webview_callback(self):
+        """Test setting WebView callback."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9008)
+
+        def my_callback(action, data, result):
+            pass
+
+        bridge.set_webview_callback(my_callback)
+        assert bridge._webview_callback == my_callback
+
+
+class TestBridgeExecuteCommand:
+    """Tests for execute_command method."""
+
+    def test_execute_command_without_loop(self):
+        """Test execute_command when event loop is not running."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9009)
+        # Should not raise, just log warning
+        bridge.execute_command("test_command", {"param1": "value1"})
+
+    def test_execute_command_with_params(self):
+        """Test execute_command with parameters."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9010)
+        # Mock the loop
+        bridge._loop = MagicMock()
+        bridge._loop.is_running.return_value = False
+
+        bridge.execute_command("create_layer", {"name": "Test Layer"})
+        # Should not raise
+
+
+class TestBridgeServiceDiscovery:
+    """Tests for service discovery integration."""
+
+    def test_service_discovery_property(self):
+        """Test service_discovery property."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9011)
+        # Without service discovery enabled, should be None
+        assert bridge.service_discovery is None
+
+
+class TestBridgeProtocol:
+    """Tests for Bridge protocol handling."""
+
+    def test_default_protocol(self):
+        """Test default protocol is json."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9012)
+        assert bridge.protocol == "json"
+
+    def test_custom_protocol(self):
+        """Test custom protocol setting."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9013, protocol="msgpack")
+        assert bridge.protocol == "msgpack"
+
+
+class TestBridgeIsRunning:
+    """Tests for Bridge is_running property."""
+
+    def test_is_running_initially_false(self):
+        """Test is_running is False initially."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9014)
+        assert bridge.is_running is False
+
+
+class TestBridgeClientCount:
+    """Tests for Bridge client_count property."""
+
+    def test_client_count_initially_zero(self):
+        """Test client_count is 0 initially."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9015)
+        assert bridge.client_count == 0
+
+
+class TestBridgeHandlerRegistration:
+    """Tests for handler registration logging."""
+
+    def test_register_handler_logs(self):
+        """Test that register_handler logs the action."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9016)
+
+        async def handler(data, client):
+            pass
+
+        bridge.register_handler("test_action", handler)
+        assert "test_action" in bridge._handlers
+
+
+class TestBridgeWebViewCallbackLogging:
+    """Tests for WebView callback logging."""
+
+    def test_set_webview_callback_logs(self):
+        """Test that set_webview_callback logs."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9017)
+
+        def callback(action, data, result):
+            pass
+
+        bridge.set_webview_callback(callback)
+        assert bridge._webview_callback is callback
+
+
+class TestBridgeLoop:
+    """Tests for Bridge event loop handling."""
+
+    def test_loop_initially_none(self):
+        """Test _loop is None initially."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9018)
+        assert bridge._loop is None
+
+
+class TestBridgeThread:
+    """Tests for Bridge thread handling."""
+
+    def test_thread_initially_none(self):
+        """Test _thread is None initially."""
+        from auroraview import Bridge
+
+        bridge = Bridge(port=9019)
+        assert bridge._thread is None

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -1,0 +1,289 @@
+"""Tests for auroraview.framework module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestAuroraViewCreation:
+    """Tests for AuroraView class creation."""
+
+    def test_auroraview_import(self):
+        """Test that AuroraView can be imported."""
+        from auroraview.framework import AuroraView
+
+        assert AuroraView is not None
+
+    def test_auroraview_creation_with_url(self):
+        """Test AuroraView creation with URL."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView") as mock_webview:
+            mock_instance = MagicMock()
+            mock_webview.return_value = mock_instance
+
+            tool = AuroraView(url="http://localhost:3000", title="Test Tool")
+
+            assert tool._url == "http://localhost:3000"
+            assert tool._title == "Test Tool"
+            mock_webview.assert_called_once()
+
+    def test_auroraview_creation_with_html(self):
+        """Test AuroraView creation with HTML content."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView") as mock_webview:
+            mock_instance = MagicMock()
+            mock_webview.return_value = mock_instance
+
+            html_content = "<html><body>Hello</body></html>"
+            tool = AuroraView(html=html_content)
+
+            assert tool._html == html_content
+
+    def test_auroraview_creation_with_custom_view(self):
+        """Test AuroraView creation with custom view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        assert tool._view == mock_view
+
+    def test_auroraview_default_dimensions(self):
+        """Test AuroraView default dimensions."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView"):
+            tool = AuroraView()
+
+            assert tool._width == 800
+            assert tool._height == 600
+
+    def test_auroraview_custom_dimensions(self):
+        """Test AuroraView with custom dimensions."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView"):
+            tool = AuroraView(width=1024, height=768)
+
+            assert tool._width == 1024
+            assert tool._height == 768
+
+
+class TestAuroraViewKeepAlive:
+    """Tests for AuroraView keep-alive registry."""
+
+    def test_instance_registered(self):
+        """Test that instance is registered in keep-alive registry."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView"):
+            initial_count = len(AuroraView._instances)
+            tool = AuroraView()
+
+            assert tool in AuroraView._instances
+            assert len(AuroraView._instances) == initial_count + 1
+
+            # Cleanup
+            tool.close()
+
+    def test_instance_unregistered_on_close(self):
+        """Test that instance is unregistered on close."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView"):
+            tool = AuroraView()
+            assert tool in AuroraView._instances
+
+            tool.close()
+            assert tool not in AuroraView._instances
+
+
+class TestAuroraViewDelegation:
+    """Tests for AuroraView delegation methods."""
+
+    def test_view_property(self):
+        """Test view property returns underlying view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        assert tool.view == mock_view
+        tool.close()
+
+    def test_emit_delegates_to_view(self):
+        """Test emit delegates to underlying view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.emit = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        tool.emit("test_event", {"data": "value"})
+
+        mock_view.emit.assert_called_once_with("test_event", {"data": "value"})
+        tool.close()
+
+    def test_bind_call_delegates_to_view(self):
+        """Test bind_call delegates to underlying view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.bind_call = MagicMock(return_value=None)
+        tool = AuroraView(_view=mock_view)
+
+        def my_func():
+            pass
+
+        tool.bind_call("my_method", my_func)
+
+        mock_view.bind_call.assert_called_once_with("my_method", my_func)
+        tool.close()
+
+    def test_bind_call_raises_without_support(self):
+        """Test bind_call raises if view doesn't support it."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock(spec=[])  # No bind_call
+        tool = AuroraView(_view=mock_view)
+
+        with pytest.raises(RuntimeError, match="does not support bind_call"):
+            tool.bind_call("method", lambda: None)
+
+        tool.close()
+
+    def test_bind_api_delegates_to_view(self):
+        """Test bind_api delegates to underlying view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.bind_api = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        # Reset mock after __init__ auto-binding
+        mock_view.bind_api.reset_mock()
+
+        api_obj = MagicMock()
+        tool.bind_api(api_obj, namespace="myapi")
+
+        mock_view.bind_api.assert_called_once_with(api_obj, namespace="myapi")
+        tool.close()
+
+    def test_bind_api_raises_without_support(self):
+        """Test bind_api raises if view doesn't support it."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock(spec=[])  # No bind_api
+        tool = AuroraView(_view=mock_view)
+
+        with pytest.raises(RuntimeError, match="does not support bind_api"):
+            tool.bind_api(MagicMock())
+
+        tool.close()
+
+
+class TestAuroraViewShow:
+    """Tests for AuroraView show method."""
+
+    def test_show_delegates_to_view(self):
+        """Test show delegates to underlying view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.show = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        tool.show()
+
+        mock_view.show.assert_called_once()
+        tool.close()
+
+    def test_show_with_args(self):
+        """Test show passes arguments to underlying view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.show = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        tool.show(wait=False)
+
+        mock_view.show.assert_called_once_with(wait=False)
+        tool.close()
+
+
+class TestAuroraViewClose:
+    """Tests for AuroraView close method."""
+
+    def test_close_with_different_keep_alive_root(self):
+        """Test close when keep_alive_root differs from view."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.close = MagicMock()
+        mock_root = MagicMock()
+        mock_root.close = MagicMock()
+
+        tool = AuroraView(_view=mock_view, _keep_alive_root=mock_root)
+        tool.close()
+
+        mock_root.close.assert_called_once()
+        mock_view.close.assert_called_once()
+
+    def test_close_idempotent(self):
+        """Test that close can be called multiple times safely."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        tool = AuroraView(_view=mock_view)
+
+        tool.close()
+        tool.close()  # Should not raise
+
+        assert tool not in AuroraView._instances
+
+
+class TestAuroraViewAutoShow:
+    """Tests for AuroraView auto_show parameter."""
+
+    def test_auto_show_true(self):
+        """Test that _auto_show=True calls show automatically."""
+        from auroraview.framework import AuroraView
+
+        mock_view = MagicMock()
+        mock_view.show = MagicMock()
+
+        tool = AuroraView(_view=mock_view, _auto_show=True)
+
+        mock_view.show.assert_called_once()
+        tool.close()
+
+
+class TestAuroraViewFullscreen:
+    """Tests for AuroraView fullscreen parameter."""
+
+    def test_fullscreen_parameter(self):
+        """Test fullscreen parameter is stored."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView"):
+            tool = AuroraView(fullscreen=True)
+
+            assert tool._fullscreen is True
+            tool.close()
+
+
+class TestAuroraViewDebug:
+    """Tests for AuroraView debug parameter."""
+
+    def test_debug_parameter(self):
+        """Test debug parameter is stored."""
+        from auroraview.framework import AuroraView
+
+        with patch("auroraview.framework.WebView"):
+            tool = AuroraView(debug=True)
+
+            assert tool._debug is True
+            tool.close()

--- a/tests/test_init_module.py
+++ b/tests/test_init_module.py
@@ -1,0 +1,249 @@
+"""Tests for auroraview.__init__ module exports and utilities."""
+
+import pytest
+
+
+class TestModuleExports:
+    """Tests for module exports."""
+
+    def test_version_available(self):
+        """Test that __version__ is available."""
+        import auroraview
+
+        assert hasattr(auroraview, "__version__")
+        assert isinstance(auroraview.__version__, str)
+
+    def test_author_available(self):
+        """Test that __author__ is available."""
+        import auroraview
+
+        assert hasattr(auroraview, "__author__")
+        assert isinstance(auroraview.__author__, str)
+
+    def test_webview_exported(self):
+        """Test that WebView is exported."""
+        from auroraview import WebView
+
+        assert WebView is not None
+
+    def test_auroraview_exported(self):
+        """Test that AuroraView is exported."""
+        from auroraview import AuroraView
+
+        assert AuroraView is not None
+
+    def test_bridge_exported(self):
+        """Test that Bridge is exported."""
+        from auroraview import Bridge
+
+        assert Bridge is not None
+
+    def test_event_timer_exported(self):
+        """Test that EventTimer is exported."""
+        from auroraview import EventTimer
+
+        assert EventTimer is not None
+
+    def test_timer_backends_exported(self):
+        """Test that timer backends are exported."""
+        from auroraview import (
+            QtTimerBackend,
+            ThreadTimerBackend,
+            TimerBackend,
+            get_available_backend,
+            list_registered_backends,
+            register_timer_backend,
+        )
+
+        assert TimerBackend is not None
+        assert QtTimerBackend is not None
+        assert ThreadTimerBackend is not None
+        assert callable(register_timer_backend)
+        assert callable(get_available_backend)
+        assert callable(list_registered_backends)
+
+    def test_file_protocol_utilities_exported(self):
+        """Test that file protocol utilities are exported."""
+        from auroraview import path_to_file_url, prepare_html_with_local_assets
+
+        assert callable(path_to_file_url)
+        assert callable(prepare_html_with_local_assets)
+
+
+class TestOnEventDecorator:
+    """Tests for on_event decorator."""
+
+    def test_on_event_decorator(self):
+        """Test on_event decorator registers handlers."""
+        import auroraview
+
+        # Clear any existing handlers
+        auroraview._EVENT_HANDLERS.clear()
+
+        @auroraview.on_event("test_event")
+        def my_handler(data):
+            return data
+
+        assert "test_event" in auroraview._EVENT_HANDLERS
+        assert my_handler in auroraview._EVENT_HANDLERS["test_event"]
+
+    def test_on_event_multiple_handlers(self):
+        """Test on_event with multiple handlers for same event."""
+        import auroraview
+
+        auroraview._EVENT_HANDLERS.clear()
+
+        @auroraview.on_event("multi_event")
+        def handler1(data):
+            pass
+
+        @auroraview.on_event("multi_event")
+        def handler2(data):
+            pass
+
+        assert len(auroraview._EVENT_HANDLERS["multi_event"]) == 2
+
+
+class TestWindowUtilities:
+    """Tests for window utility functions."""
+
+    def test_window_info_available(self):
+        """Test that WindowInfo is available."""
+        from auroraview import WindowInfo
+
+        assert WindowInfo is not None
+
+    def test_get_foreground_window_available(self):
+        """Test that get_foreground_window is available."""
+        from auroraview import get_foreground_window
+
+        assert get_foreground_window is not None
+
+    def test_find_windows_by_title_available(self):
+        """Test that find_windows_by_title is available."""
+        from auroraview import find_windows_by_title
+
+        assert find_windows_by_title is not None
+
+    def test_get_all_windows_available(self):
+        """Test that get_all_windows is available."""
+        from auroraview import get_all_windows
+
+        assert get_all_windows is not None
+
+
+class TestCliUtilities:
+    """Tests for CLI utility functions."""
+
+    def test_normalize_url_available(self):
+        """Test that normalize_url is available."""
+        from auroraview import normalize_url
+
+        assert normalize_url is not None
+
+    def test_rewrite_html_for_custom_protocol_available(self):
+        """Test that rewrite_html_for_custom_protocol is available."""
+        from auroraview import rewrite_html_for_custom_protocol
+
+        assert rewrite_html_for_custom_protocol is not None
+
+    def test_run_standalone_available(self):
+        """Test that run_standalone is available."""
+        from auroraview import run_standalone
+
+        assert run_standalone is not None
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility aliases."""
+
+    def test_auroraview_qt_alias(self):
+        """Test that AuroraViewQt is an alias for QtWebView."""
+        from auroraview import AuroraViewQt, QtWebView
+
+        assert AuroraViewQt is QtWebView
+
+
+class TestAllExports:
+    """Tests for __all__ exports."""
+
+    def test_all_exports_accessible(self):
+        """Test that all items in __all__ are accessible."""
+        import auroraview
+
+        for name in auroraview.__all__:
+            assert hasattr(auroraview, name), f"Missing export: {name}"
+
+
+class TestServiceDiscovery:
+    """Tests for ServiceDiscovery exports."""
+
+    def test_service_discovery_available(self):
+        """Test that ServiceDiscovery is available."""
+        from auroraview import ServiceDiscovery
+
+        assert ServiceDiscovery is not None
+
+    def test_service_info_available(self):
+        """Test that ServiceInfo is available."""
+        from auroraview import ServiceInfo
+
+        assert ServiceInfo is not None
+
+
+class TestWindowUtilitiesExtended:
+    """Extended tests for window utility functions."""
+
+    def test_find_window_by_exact_title_available(self):
+        """Test that find_window_by_exact_title is available."""
+        from auroraview import find_window_by_exact_title
+
+        assert find_window_by_exact_title is not None
+
+    def test_close_window_by_hwnd_available(self):
+        """Test that close_window_by_hwnd is available."""
+        from auroraview import close_window_by_hwnd
+
+        assert close_window_by_hwnd is not None
+
+    def test_destroy_window_by_hwnd_available(self):
+        """Test that destroy_window_by_hwnd is available."""
+        from auroraview import destroy_window_by_hwnd
+
+        assert destroy_window_by_hwnd is not None
+
+
+class TestOnEventDecoratorExtended:
+    """Extended tests for on_event decorator."""
+
+    def test_on_event_returns_original_function(self):
+        """Test that on_event returns the original function."""
+        import auroraview
+
+        auroraview._EVENT_HANDLERS.clear()
+
+        def original_handler(data):
+            return data * 2
+
+        decorated = auroraview.on_event("test_return")(original_handler)
+
+        assert decorated is original_handler
+        assert decorated(5) == 10
+
+    def test_on_event_different_events(self):
+        """Test on_event with different event names."""
+        import auroraview
+
+        auroraview._EVENT_HANDLERS.clear()
+
+        @auroraview.on_event("event_a")
+        def handler_a(data):
+            pass
+
+        @auroraview.on_event("event_b")
+        def handler_b(data):
+            pass
+
+        assert "event_a" in auroraview._EVENT_HANDLERS
+        assert "event_b" in auroraview._EVENT_HANDLERS
+        assert len(auroraview._EVENT_HANDLERS) == 2

--- a/tests/test_init_module.py
+++ b/tests/test_init_module.py
@@ -1,7 +1,5 @@
 """Tests for auroraview.__init__ module exports and utilities."""
 
-import pytest
-
 
 class TestModuleExports:
     """Tests for module exports."""

--- a/tests/test_testing_module.py
+++ b/tests/test_testing_module.py
@@ -1,6 +1,6 @@
 """Tests for auroraview.testing module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -850,6 +850,19 @@ class TestInitModuleMoreCoverage:
         assert ServiceInfo is not None
 
 
+# Check if websockets is available for Bridge tests
+try:
+    import websockets  # noqa: F401
+
+    HAS_WEBSOCKETS = True
+except ImportError:
+    HAS_WEBSOCKETS = False
+
+
+@pytest.mark.skipif(
+    not HAS_WEBSOCKETS,
+    reason="websockets library is required for Bridge tests",
+)
 class TestBridgeMoreCoverage:
     """Additional tests for bridge.py coverage."""
 

--- a/tests/test_testing_module.py
+++ b/tests/test_testing_module.py
@@ -1,0 +1,943 @@
+"""Tests for auroraview.testing module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestWebViewBot:
+    """Tests for WebViewBot class."""
+
+    def test_webview_bot_import(self):
+        """Test that WebViewBot can be imported."""
+        from auroraview.testing import WebViewBot
+
+        assert WebViewBot is not None
+
+    def test_webview_bot_creation(self):
+        """Test WebViewBot creation with mock WebView."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        bot = WebViewBot(mock_webview)
+
+        assert bot.webview is mock_webview
+        assert bot.events == []
+        assert bot._monitoring_active is False
+
+    def test_webview_bot_click(self):
+        """Test click method calls eval_js."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        bot.click("#testBtn")
+
+        mock_webview.eval_js.assert_called_once()
+        call_args = mock_webview.eval_js.call_args[0][0]
+        assert "querySelector" in call_args
+        assert "#testBtn" in call_args
+        assert "click()" in call_args
+
+    def test_webview_bot_type(self):
+        """Test type method calls eval_js."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        bot.type("#inputField", "Hello World")
+
+        mock_webview.eval_js.assert_called_once()
+        call_args = mock_webview.eval_js.call_args[0][0]
+        assert "querySelector" in call_args
+        assert "#inputField" in call_args
+        assert "Hello World" in call_args
+
+    def test_webview_bot_drag(self):
+        """Test drag method calls eval_js."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        bot.drag("#dragElement", (10, 20))
+
+        mock_webview.eval_js.assert_called_once()
+        call_args = mock_webview.eval_js.call_args[0][0]
+        assert "querySelector" in call_args
+        assert "#dragElement" in call_args
+
+    def test_webview_bot_element_exists(self):
+        """Test element_exists method."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        result = bot.element_exists("#myElement")
+
+        assert result is True
+        mock_webview.eval_js.assert_called_once()
+
+    def test_webview_bot_element_exists_exception(self):
+        """Test element_exists returns False on exception."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+        bot = WebViewBot(mock_webview)
+
+        result = bot.element_exists("#myElement")
+
+        assert result is False
+
+    def test_webview_bot_get_element_text(self):
+        """Test get_element_text method."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        result = bot.get_element_text("#output")
+
+        assert result == "Test Page"  # Default placeholder
+        mock_webview.eval_js.assert_called_once()
+
+    def test_webview_bot_get_element_text_exception(self):
+        """Test get_element_text returns empty string on exception."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+        bot = WebViewBot(mock_webview)
+
+        result = bot.get_element_text("#output")
+
+        assert result == ""
+
+    def test_webview_bot_inject_monitoring_script(self):
+        """Test inject_monitoring_script method."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        bot.inject_monitoring_script()
+
+        assert bot._monitoring_active is True
+        mock_webview.eval_js.assert_called_once()
+
+    def test_webview_bot_assert_event_emitted(self):
+        """Test assert_event_emitted method."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        # Should not raise
+        bot.assert_event_emitted("test_event")
+
+    def test_webview_bot_assert_event_emitted_exception(self):
+        """Test assert_event_emitted raises on JS error."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+        bot = WebViewBot(mock_webview)
+
+        with pytest.raises(AssertionError, match="Failed to check event"):
+            bot.assert_event_emitted("test_event")
+
+
+class TestEventRecord:
+    """Tests for EventRecord dataclass."""
+
+    def test_event_record_creation(self):
+        """Test EventRecord creation."""
+        from auroraview.testing.webview_bot import EventRecord
+
+        record = EventRecord(name="test_event", data={"key": "value"}, timestamp=123.456)
+
+        assert record.name == "test_event"
+        assert record.data == {"key": "value"}
+        assert record.timestamp == 123.456
+
+    def test_event_record_defaults(self):
+        """Test EventRecord default values."""
+        from auroraview.testing.webview_bot import EventRecord
+
+        record = EventRecord(name="test_event")
+
+        assert record.name == "test_event"
+        assert record.data is None
+        assert record.timestamp == 0.0
+
+
+class TestAssertions:
+    """Tests for assertion helpers."""
+
+    def test_assertions_import(self):
+        """Test that assertions can be imported."""
+        from auroraview.testing.assertions import (
+            assert_element_exists,
+            assert_element_hidden,
+            assert_element_text,
+            assert_element_visible,
+            assert_event_emitted,
+            assert_window_title,
+        )
+
+        assert callable(assert_element_exists)
+        assert callable(assert_element_visible)
+        assert callable(assert_element_hidden)
+        assert callable(assert_element_text)
+        assert callable(assert_event_emitted)
+        assert callable(assert_window_title)
+
+    def test_assert_element_exists_success(self):
+        """Test assert_element_exists with existing element."""
+        from auroraview.testing.assertions import assert_element_exists
+
+        mock_bot = MagicMock()
+        mock_bot.element_exists = MagicMock(return_value=True)
+
+        # Should not raise
+        assert_element_exists(mock_bot, "#existingElement")
+
+    def test_assert_element_text_success(self):
+        """Test assert_element_text with valid text."""
+        from auroraview.testing.assertions import assert_element_text
+
+        mock_bot = MagicMock()
+        mock_bot.get_element_text = MagicMock(return_value="Hello World")
+
+        # Should not raise
+        assert_element_text(mock_bot, "#element", "Hello")
+
+    def test_assert_window_title_success(self):
+        """Test assert_window_title success."""
+        from auroraview.testing.assertions import assert_window_title
+
+        mock_bot = MagicMock()
+        mock_bot.webview = MagicMock()
+        mock_bot.webview.eval_js = MagicMock()
+
+        # Should not raise
+        assert_window_title(mock_bot, "Test Title")
+
+    def test_assert_window_title_exception(self):
+        """Test assert_window_title raises on JS error."""
+        from auroraview.testing.assertions import assert_window_title
+
+        mock_bot = MagicMock()
+        mock_bot.webview = MagicMock()
+        mock_bot.webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+
+        with pytest.raises(AssertionError, match="Failed to execute title check"):
+            assert_window_title(mock_bot, "Test Title")
+
+    def test_assert_element_visible_success(self):
+        """Test assert_element_visible success."""
+        from auroraview.testing.assertions import assert_element_visible
+
+        mock_bot = MagicMock()
+        mock_bot.webview = MagicMock()
+        mock_bot.webview.eval_js = MagicMock()
+
+        # Should not raise
+        assert_element_visible(mock_bot, "#visibleElement")
+
+    def test_assert_element_visible_exception(self):
+        """Test assert_element_visible raises on JS error."""
+        from auroraview.testing.assertions import assert_element_visible
+
+        mock_bot = MagicMock()
+        mock_bot.webview = MagicMock()
+        mock_bot.webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+
+        with pytest.raises(AssertionError, match="Failed to check visibility"):
+            assert_element_visible(mock_bot, "#element")
+
+    def test_assert_element_hidden_success(self):
+        """Test assert_element_hidden success."""
+        from auroraview.testing.assertions import assert_element_hidden
+
+        mock_bot = MagicMock()
+        mock_bot.webview = MagicMock()
+        mock_bot.webview.eval_js = MagicMock()
+
+        # Should not raise
+        assert_element_hidden(mock_bot, "#hiddenElement")
+
+    def test_assert_element_hidden_exception(self):
+        """Test assert_element_hidden raises on JS error."""
+        from auroraview.testing.assertions import assert_element_hidden
+
+        mock_bot = MagicMock()
+        mock_bot.webview = MagicMock()
+        mock_bot.webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+
+        with pytest.raises(AssertionError, match="Failed to check visibility"):
+            assert_element_hidden(mock_bot, "#element")
+
+    def test_assert_event_emitted_delegates(self):
+        """Test assert_event_emitted delegates to bot."""
+        from auroraview.testing.assertions import assert_event_emitted
+
+        mock_bot = MagicMock()
+        mock_bot.assert_event_emitted = MagicMock()
+
+        assert_event_emitted(mock_bot, "test_event")
+
+        mock_bot.assert_event_emitted.assert_called_once_with("test_event")
+
+
+class TestFixtures:
+    """Tests for fixture functionality."""
+
+    def test_fixtures_import(self):
+        """Test that fixtures module can be imported."""
+        from auroraview.testing import fixtures
+
+        assert fixtures is not None
+
+    def test_test_html_fixture_content(self):
+        """Test that test_html fixture returns valid HTML."""
+        # Simulate the fixture
+        test_html = """
+        <html>
+            <head>
+                <title>Test Page</title>
+            </head>
+            <body>
+                <h1>Test Page</h1>
+                <button id="testBtn">Test Button</button>
+            </body>
+        </html>
+        """
+
+        assert "<html>" in test_html
+        assert "<body>" in test_html
+        assert "testBtn" in test_html
+
+    def test_draggable_window_html_fixture(self):
+        """Test draggable_window_html fixture content."""
+        # Simulate the fixture content
+        html = """
+        <html>
+            <head>
+                <style>
+                    .title-bar {
+                        background: #333;
+                        color: white;
+                        padding: 10px;
+                        cursor: move;
+                        user-select: none;
+                    }
+                </style>
+            </head>
+            <body>
+                <div class="title-bar" id="titleBar">Draggable Window</div>
+                <div id="content">
+                    <p>This window can be dragged by the title bar.</p>
+                </div>
+            </body>
+        </html>
+        """
+
+        assert "title-bar" in html
+        assert "titleBar" in html
+        assert "Draggable Window" in html
+
+
+class TestWebViewBotWaitForEvent:
+    """Tests for WebViewBot wait_for_event method."""
+
+    def test_wait_for_event_returns_true(self):
+        """Test wait_for_event returns True after timeout."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock()
+        bot = WebViewBot(mock_webview)
+
+        # With a very short timeout, it should return True
+        result = bot.wait_for_event("test_event", timeout=0.1)
+
+        assert result is True
+
+    def test_wait_for_event_handles_exception(self):
+        """Test wait_for_event handles JS exceptions gracefully."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        mock_webview.on = MagicMock(return_value=lambda f: f)
+        mock_webview.eval_js = MagicMock(side_effect=Exception("JS error"))
+        bot = WebViewBot(mock_webview)
+
+        # Should not raise, just return True after timeout
+        result = bot.wait_for_event("test_event", timeout=0.1)
+
+        assert result is True
+
+
+class TestEventTimerEdgeCases:
+    """Tests for EventTimer edge cases."""
+
+    def test_event_timer_import(self):
+        """Test that EventTimer can be imported."""
+        from auroraview.event_timer import EventTimer
+
+        assert EventTimer is not None
+
+    def test_event_timer_creation(self):
+        """Test EventTimer creation with mock webview."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview, interval_ms=100)
+
+        assert timer._webview is mock_webview
+        assert timer._interval_ms == 100
+        assert timer._running is False
+
+    def test_event_timer_on_close_callback(self):
+        """Test on_close callback registration."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview)
+
+        callback_called = []
+
+        def my_callback():
+            callback_called.append(True)
+
+        timer.on_close(my_callback)
+
+        assert my_callback in timer._close_callbacks
+
+    def test_event_timer_is_running_property(self):
+        """Test is_running property."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview)
+
+        assert timer.is_running is False
+
+    def test_event_timer_stop_when_not_running(self):
+        """Test stop when timer is not running."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview)
+
+        # Should not raise
+        timer.stop()
+
+        assert timer._running is False
+
+    def test_event_timer_start_already_running(self):
+        """Test start raises when already running."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview)
+        timer._running = True
+
+        with pytest.raises(RuntimeError, match="already running"):
+            timer.start()
+
+    def test_event_timer_check_window_valid_no_core(self):
+        """Test _check_window_valid when webview has no _core."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock(spec=[])  # No _core attribute
+        timer = EventTimer(mock_webview)
+
+        result = timer._check_window_valid()
+
+        assert result is True
+
+    def test_event_timer_check_window_valid_with_core(self):
+        """Test _check_window_valid when webview has _core."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        mock_webview._core = MagicMock()
+        mock_webview._core.is_window_valid = MagicMock(return_value=True)
+        timer = EventTimer(mock_webview)
+
+        result = timer._check_window_valid()
+
+        assert result is True
+        mock_webview._core.is_window_valid.assert_called_once()
+
+    def test_event_timer_check_window_valid_exception(self):
+        """Test _check_window_valid handles exceptions."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        mock_webview._core = MagicMock()
+        mock_webview._core.is_window_valid = MagicMock(side_effect=Exception("Error"))
+        timer = EventTimer(mock_webview)
+
+        result = timer._check_window_valid()
+
+        assert result is False
+
+
+class TestTimerBackendsEdgeCases:
+    """Tests for timer_backends edge cases."""
+
+    def test_timer_backends_import(self):
+        """Test that timer_backends can be imported."""
+        from auroraview import timer_backends
+
+        assert timer_backends is not None
+
+    def test_thread_timer_backend_import(self):
+        """Test ThreadTimerBackend import."""
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        assert ThreadTimerBackend is not None
+
+    def test_thread_timer_backend_creation(self):
+        """Test ThreadTimerBackend creation."""
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        backend = ThreadTimerBackend()
+
+        assert backend.get_name() == "ThreadTimer"
+
+    def test_thread_timer_backend_start_stop(self):
+        """Test ThreadTimerBackend start and stop."""
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        backend = ThreadTimerBackend()
+        callback_count = []
+
+        def callback():
+            callback_count.append(1)
+
+        handle = backend.start(50, callback)
+        assert handle is not None
+
+        # Wait a bit for callback to be called
+        import time
+
+        time.sleep(0.1)
+
+        backend.stop(handle)
+
+        # Callback should have been called at least once
+        assert len(callback_count) >= 1
+
+    def test_get_available_backend(self):
+        """Test get_available_backend function."""
+        from auroraview.timer_backends import get_available_backend
+
+        backend = get_available_backend()
+
+        # Should return a backend (ThreadTimerBackend is always available)
+        assert backend is not None
+
+    def test_register_timer_backend(self):
+        """Test register_timer_backend function."""
+        from auroraview.timer_backends import (
+            ThreadTimerBackend,
+            get_available_backend,
+            register_timer_backend,
+        )
+
+        # Register a new backend with high priority
+        register_timer_backend(ThreadTimerBackend, priority=1000)
+
+        # Should be able to get it
+        available = get_available_backend()
+        assert available is not None
+
+
+class TestWebViewBotQueryHandlers:
+    """Tests for WebViewBot query handlers."""
+
+    def test_setup_query_handlers_element_exists(self):
+        """Test _element_exists_result handler."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        handlers = {}
+
+        def mock_on(event_name):
+            def decorator(func):
+                handlers[event_name] = func
+                return func
+
+            return decorator
+
+        mock_webview.on = mock_on
+        bot = WebViewBot(mock_webview)
+
+        # Verify handlers were registered
+        assert "_element_exists_result" in handlers
+        assert "_element_text_result" in handlers
+
+        # Test element_exists handler
+        handlers["_element_exists_result"]({"exists": True})
+        assert bot._query_results.get("element_exists") is True
+
+    def test_setup_query_handlers_element_text(self):
+        """Test _element_text_result handler."""
+        from auroraview.testing import WebViewBot
+
+        mock_webview = MagicMock()
+        handlers = {}
+
+        def mock_on(event_name):
+            def decorator(func):
+                handlers[event_name] = func
+                return func
+
+            return decorator
+
+        mock_webview.on = mock_on
+        bot = WebViewBot(mock_webview)
+
+        # Test element_text handler
+        handlers["_element_text_result"]({"text": "Hello World"})
+        assert bot._query_results.get("element_text") == "Hello World"
+
+
+class TestMainModuleEdgeCases:
+    """Tests for __main__.py edge cases."""
+
+    def test_main_module_import(self):
+        """Test that __main__ module can be imported."""
+        from auroraview import __main__
+
+        assert __main__ is not None
+
+    def test_main_function_exists(self):
+        """Test that main function exists."""
+        from auroraview.__main__ import main
+
+        assert callable(main)
+
+
+class TestTimerBackendsMoreCoverage:
+    """Additional tests for timer_backends coverage."""
+
+    def test_timer_backend_abstract_methods(self):
+        """Test TimerBackend abstract class."""
+        from auroraview.timer_backends import TimerBackend
+
+        # TimerBackend is abstract, cannot be instantiated directly
+        with pytest.raises(TypeError):
+            TimerBackend()
+
+    def test_thread_timer_backend_stop_invalid_handle(self):
+        """Test ThreadTimerBackend stop with invalid handle."""
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        backend = ThreadTimerBackend()
+
+        # Should not raise with invalid handle
+        backend.stop(None)
+
+    def test_thread_timer_backend_is_available(self):
+        """Test ThreadTimerBackend is_available."""
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        backend = ThreadTimerBackend()
+
+        # Thread backend is always available
+        assert backend.is_available() is True
+
+    def test_qt_timer_backend_not_available(self):
+        """Test QtTimerBackend when Qt is not available."""
+        from auroraview.timer_backends import QtTimerBackend
+
+        backend = QtTimerBackend()
+
+        # Qt may or may not be available depending on environment
+        # Just verify the method works
+        result = backend.is_available()
+        assert isinstance(result, bool)
+
+
+class TestEventTimerMoreCoverage:
+    """Additional tests for event_timer coverage."""
+
+    def test_event_timer_with_custom_backend(self):
+        """Test EventTimer with custom backend."""
+        from auroraview.event_timer import EventTimer
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        mock_webview = MagicMock()
+        backend = ThreadTimerBackend()
+        timer = EventTimer(mock_webview, backend=backend)
+
+        assert timer._backend is backend
+
+    def test_event_timer_interval_property(self):
+        """Test EventTimer interval_ms property."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview, interval_ms=50)
+
+        assert timer.interval_ms == 50
+
+    def test_event_timer_webview_attribute(self):
+        """Test EventTimer _webview attribute."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview)
+
+        assert timer._webview is mock_webview
+
+    def test_event_timer_check_window_validity_flag(self):
+        """Test EventTimer check_window_validity flag."""
+        from auroraview.event_timer import EventTimer
+
+        mock_webview = MagicMock()
+        timer = EventTimer(mock_webview, check_window_validity=True)
+
+        assert timer._check_validity is True
+
+    def test_event_timer_backend_attribute(self):
+        """Test EventTimer _backend attribute."""
+        from auroraview.event_timer import EventTimer
+        from auroraview.timer_backends import ThreadTimerBackend
+
+        mock_webview = MagicMock()
+        backend = ThreadTimerBackend()
+        timer = EventTimer(mock_webview, backend=backend)
+
+        assert timer._backend is backend
+
+
+class TestFileProtocolCoverage:
+    """Tests for file_protocol module coverage."""
+
+    def test_file_protocol_import(self):
+        """Test file_protocol module import."""
+        from auroraview import file_protocol
+
+        assert file_protocol is not None
+
+    def test_path_to_file_url(self):
+        """Test path_to_file_url function."""
+        from auroraview.file_protocol import path_to_file_url
+
+        result = path_to_file_url("test.html")
+        assert result.startswith("file://")
+        assert "test.html" in result
+
+    def test_prepare_html_with_local_assets(self):
+        """Test prepare_html_with_local_assets function."""
+        from auroraview.file_protocol import prepare_html_with_local_assets
+
+        html = '<img src="{{IMAGE_PATH}}">'
+        result = prepare_html_with_local_assets(html, {"IMAGE_PATH": "test.png"})
+        assert "file://" in result
+        assert "{{IMAGE_PATH}}" not in result
+
+    def test_prepare_html_with_manifest_path(self):
+        """Test prepare_html_with_local_assets with manifest_path."""
+        from auroraview.file_protocol import prepare_html_with_local_assets
+
+        html = '<iframe src="{{MANIFEST_PATH}}"></iframe>'
+        result = prepare_html_with_local_assets(html, manifest_path="index.html")
+        assert "file://" in result
+        assert "{{MANIFEST_PATH}}" not in result
+
+
+class TestInitModuleMoreCoverage:
+    """Additional tests for __init__.py coverage."""
+
+    def test_version_attribute(self):
+        """Test __version__ attribute exists."""
+        import auroraview
+
+        assert hasattr(auroraview, "__version__")
+        assert isinstance(auroraview.__version__, str)
+
+    def test_author_attribute(self):
+        """Test __author__ attribute exists."""
+        import auroraview
+
+        assert hasattr(auroraview, "__author__")
+        assert isinstance(auroraview.__author__, str)
+
+    def test_webview_class_exported(self):
+        """Test WebView class is exported."""
+        from auroraview import WebView
+
+        assert WebView is not None
+
+    def test_aurora_view_class_exported(self):
+        """Test AuroraView class is exported."""
+        from auroraview import AuroraView
+
+        assert AuroraView is not None
+
+    def test_event_timer_exported(self):
+        """Test EventTimer is exported."""
+        from auroraview import EventTimer
+
+        assert EventTimer is not None
+
+    def test_timer_backends_exported(self):
+        """Test timer backends are exported."""
+        from auroraview import (
+            QtTimerBackend,
+            ThreadTimerBackend,
+            TimerBackend,
+            get_available_backend,
+            list_registered_backends,
+            register_timer_backend,
+        )
+
+        assert TimerBackend is not None
+        assert ThreadTimerBackend is not None
+        assert QtTimerBackend is not None
+        assert callable(get_available_backend)
+        assert callable(list_registered_backends)
+        assert callable(register_timer_backend)
+
+    def test_file_protocol_exported(self):
+        """Test file protocol functions are exported."""
+        from auroraview import path_to_file_url, prepare_html_with_local_assets
+
+        assert callable(path_to_file_url)
+        assert callable(prepare_html_with_local_assets)
+
+    def test_bridge_class_exported(self):
+        """Test Bridge class is exported (may be placeholder)."""
+        from auroraview import Bridge
+
+        assert Bridge is not None
+
+    def test_service_discovery_exported(self):
+        """Test ServiceDiscovery is exported (may be placeholder)."""
+        from auroraview import ServiceDiscovery, ServiceInfo
+
+        assert ServiceDiscovery is not None
+        assert ServiceInfo is not None
+
+
+class TestBridgeMoreCoverage:
+    """Additional tests for bridge.py coverage."""
+
+    def test_bridge_creation_with_defaults(self):
+        """Test Bridge creation with default parameters."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+        assert bridge is not None
+        assert bridge.host == "localhost"
+        # Default port is 9001
+        assert bridge.port == 9001
+
+    def test_bridge_creation_with_custom_port(self):
+        """Test Bridge creation with custom port."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge(port=9000)
+        assert bridge.port == 9000
+
+    def test_bridge_creation_with_custom_host(self):
+        """Test Bridge creation with custom host."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge(host="0.0.0.0")
+        assert bridge.host == "0.0.0.0"
+
+    def test_bridge_on_decorator(self):
+        """Test Bridge on decorator."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+
+        @bridge.on("test_command")
+        async def test_handler(data, client):
+            return {"result": "ok"}
+
+        assert "test_command" in bridge._handlers
+
+    def test_bridge_register_handler(self):
+        """Test Bridge register_handler method."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+
+        async def test_handler(data, client):
+            return {"result": "ok"}
+
+        bridge.register_handler("test_action", test_handler)
+        assert "test_action" in bridge._handlers
+
+    def test_bridge_is_running_property(self):
+        """Test Bridge is_running property."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+        assert bridge.is_running is False
+
+    def test_bridge_client_count_property(self):
+        """Test Bridge client_count property."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+        assert bridge.client_count == 0
+
+    def test_bridge_protocol_property(self):
+        """Test Bridge protocol property."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+        # Default protocol is 'json'
+        assert bridge.protocol == "json"
+
+    def test_bridge_protocol_custom(self):
+        """Test Bridge with custom protocol."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge(protocol="msgpack")
+        assert bridge.protocol == "msgpack"
+
+    def test_bridge_set_webview_callback(self):
+        """Test Bridge set_webview_callback method."""
+        from auroraview.bridge import Bridge
+
+        bridge = Bridge()
+
+        def callback(action, data, result):
+            pass
+
+        bridge.set_webview_callback(callback)
+        assert bridge._webview_callback is callback

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "auroraview"
-version = "0.2.19"
+version = "0.2.20"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },


### PR DESCRIPTION
## Summary

This PR enhances the resource path resolution functionality and adds window always-on-top support.

## Changes

### Path Resolution
- Add `html_path` and `rewrite_relative_paths` parameters to `run_standalone`
- Auto-derive `asset_root` from HTML file directory when not explicitly set
- Convert relative paths (`./xxx`, `../xxx`) to `auroraview://` protocol URLs
- Preserve absolute URLs, data URIs, and existing `auroraview://` paths

### Always On Top
- Add `always_on_top` parameter to `WebView.__init__()` and `WebView.create()`
- Add `set_always_on_top()` method for dynamic toggling after window creation
- Implement platform-specific always-on-top behavior (Windows/macOS/Linux)

## Usage

### Auto Path Conversion
```python
from auroraview import WebView

# HTML file with relative paths like ./script.js will be auto-converted
webview = WebView.create(title="My App")
webview.load_local_html("dist/index.html")  # asset_root auto-derived from dist/
webview.show()
```

### Window Always On Top
```python
from auroraview import WebView

# Set at creation time
webview = WebView.create(title="Floating Tool", always_on_top=True)
webview.show()

# Or toggle dynamically
webview.set_always_on_top(True)   # Pin to top
webview.set_always_on_top(False)  # Unpin
```

## Testing
- Added comprehensive tests for path rewriting functionality
- Updated existing tests to include `always_on_top` parameter