### PR TITLE
fix: add x-release-please-version tag to version fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.22"
+version = "0.2.22" # x-release-please-version
 edition = "2021"
 # CXX-Qt 0.7 requires Rust 1.77+ for cargo:: syntax in build scripts
 rust-version = "1.77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "auroraview"
-version = "0.2.22"
+version = "0.2.22" # x-release-please-version
 description = "AuroraView: Rust-powered WebView for Python apps & DCC embedding"
 authors = [
     {name = "Hal Long", email = "hal.long@outlook.com"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,7 @@
         {
           "type": "toml",
           "path": "Cargo.toml",
-          "jsonpath": "$.package.version"
+          "jsonpath": "$.workspace.package.version"
         },
         {
           "type": "toml",


### PR DESCRIPTION
## Summary

Fix release-please configuration error: `value at path package.version is not tagged`

## Changes

- Add `x-release-please-version` comment to `Cargo.toml` `workspace.package.version`
- Add `x-release-please-version` comment to `pyproject.toml` `project.version`
- Update `release-please-config.json` jsonpath from `$.package.version` to `$.workspace.package.version`

## Why

Release-please requires version fields to be marked with `x-release-please-version` comment so it can identify and update them during releases. The previous configuration pointed to `$.package.version` which uses `version.workspace = true` and cannot be directly updated.