### PR TITLE
fix(ci): add Python 3.13 support and fix Windows/macOS abi3 wheel builds

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
-          maturin-args: '--release --out dist --find-interpreter --features ext-module,win-webview2'
+          maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2'
           test-wheel: ${{ inputs.test-wheel }}
           artifact-name: 'wheels-windows-${{ matrix.target }}'
 
@@ -98,7 +98,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
-          maturin-args: '--release --out dist --sdist --find-interpreter'
+          maturin-args: '--release --out dist --sdist --find-interpreter --features ext-module,abi3-py38'
           test-wheel: ${{ inputs.test-wheel }}
           artifact-name: 'wheels-macos-${{ matrix.target }}'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.13"]
         include:
           # Additional Python versions on Ubuntu
           - os: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           # Reduce matrix size - test edge versions on all platforms, middle versions on Linux only
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary

This PR fixes Python 3.13 compatibility issues and corrects the wheel build configuration.

## Problem

When running auroraview on Python 3.13, users encountered:
```
ImportError: dynamic module does not define module export function (PyInit__core)
```

## Root Cause

The Windows and macOS wheel builds in `build-wheels.yml` were missing the `abi3-py38` feature flag:

- **Windows**: `--features ext-module,win-webview2` (missing `abi3-py38`)
- **macOS**: No features specified at all

This caused maturin to build version-specific wheels (`cp310`, `cp311`, `cp312`, `cp313`) instead of a single `abi3` wheel that works for all Python 3.8+ versions.

## Changes

1. **build-wheels.yml**:
   - Windows: Added `abi3-py38` to maturin-args
   - macOS: Added `--features ext-module,abi3-py38` to maturin-args

2. **ci.yml & pr-checks.yml**:
   - Added Python 3.13 to the test matrix

3. **pyproject.toml**:
   - Added `Programming Language :: Python :: 3.13` classifier

4. **README.md & README_zh.md**:
   - Updated Python version range from `3.7-3.12` to `3.7-3.13`

## Expected Result

After this fix:
- All platforms will produce proper `abi3` wheels (e.g., `auroraview-0.3.x-cp38-abi3-win_amd64.whl`)
- These wheels will work on Python 3.8, 3.9, 3.10, 3.11, 3.12, and 3.13
- CI will test Python 3.13 compatibility