### PR TITLE
fix(ci): align artifact names between build-wheels and release workflows

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -182,7 +182,7 @@ runs:
 
     - name: Upload test artifacts
       if: inputs.upload-artifacts == 'true' && always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.artifact-name }}-${{ runner.os }}-${{ github.run_id }}
         path: |

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -261,7 +261,7 @@ runs:
       if: inputs.upload-wheel == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.artifact-name }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ inputs.target || 'default' }}
+        name: ${{ inputs.artifact-name }}
         path: dist/
         retention-days: 30
 

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - name: Install uv
       if: inputs.test-wheel == 'true' && inputs.python-version != '3.7'
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: false
@@ -259,7 +259,7 @@ runs:
 
     - name: Upload wheel
       if: inputs.upload-wheel == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.artifact-name }}
         path: dist/

--- a/.github/actions/setup-auroraview/action.yml
+++ b/.github/actions/setup-auroraview/action.yml
@@ -37,7 +37,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: false

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -80,7 +80,7 @@ jobs:
           tar -czvf ../../../${{ matrix.archive }} ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cli-${{ matrix.target }}
           path: ${{ matrix.archive }}
@@ -93,7 +93,7 @@ jobs:
     needs: build
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: cli-*
           path: artifacts
@@ -103,7 +103,7 @@ jobs:
         run: ls -la artifacts/
 
       - name: Upload combined artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cli-all-platforms
           path: artifacts/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -59,7 +59,7 @@ jobs:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
           test-wheel: ${{ inputs.test-wheel }}
-          artifact-name: 'wheels-linux-${{ matrix.target }}'
+          artifact-name: 'wheels-linux-x86_64'
 
   # Windows builds (abi3)
   windows:
@@ -78,7 +78,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2'
           test-wheel: ${{ inputs.test-wheel }}
-          artifact-name: 'wheels-windows-${{ matrix.target }}'
+          artifact-name: 'wheels-windows-x64'
 
   # macOS builds (abi3)
   macos:
@@ -100,7 +100,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           maturin-args: '--release --out dist --sdist --find-interpreter --features ext-module,abi3-py38'
           test-wheel: ${{ inputs.test-wheel }}
-          artifact-name: 'wheels-macos-${{ matrix.target }}'
+          artifact-name: 'wheels-macos-universal2-apple-darwin'
 
   # ============================================================================
   # Python 3.7 builds (non-abi3) - Separate wheel for each platform
@@ -127,7 +127,7 @@ jobs:
           # Non-abi3 build: use python-bindings without abi3 feature
           maturin-args: '--release --out dist -i python3.7 --features python-bindings,ext-module'
           test-wheel: ${{ inputs.test-wheel }}
-          artifact-name: 'wheels-linux-${{ matrix.target }}-py37'
+          artifact-name: 'wheels-linux-x86_64-py37'
           # Disable sccache to avoid potential compatibility issues
           use-sccache: 'false'
 
@@ -149,7 +149,7 @@ jobs:
           # Non-abi3 build: use python-bindings without abi3 feature
           maturin-args: '--release --out dist -i python3.7 --features python-bindings,ext-module,win-webview2'
           test-wheel: ${{ inputs.test-wheel }}
-          artifact-name: 'wheels-windows-${{ matrix.target }}-py37'
+          artifact-name: 'wheels-windows-x64-py37'
           # Disable sccache to avoid potential compatibility issues
           use-sccache: 'false'
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
-          maturin-args: '--release --out dist --find-interpreter --features ext-module,win-webview2'
+          maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2'
           test-wheel: ${{ inputs.test-wheel }}
           artifact-name: 'wheels-windows-${{ matrix.target }}'
 
@@ -98,7 +98,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
-          maturin-args: '--release --out dist --sdist --find-interpreter'
+          maturin-args: '--release --out dist --sdist --find-interpreter --features ext-module,abi3-py38'
           test-wheel: ${{ inputs.test-wheel }}
           artifact-name: 'wheels-macos-${{ matrix.target }}'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.13"]
         include:
           # Additional Python versions on Ubuntu
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           tar -czvf ../../../${{ matrix.archive }} ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cli-${{ matrix.target }}
           path: ${{ matrix.archive }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   # Pre-build ABI3 wheels for all platforms (one wheel works for Python 3.8+)
+  # Uses the same build-wheel action as release workflow to ensure consistency
   # Artifact names match release workflow for reuse
   pre-build:
     name: Pre-build Wheel (${{ matrix.os }})
@@ -37,53 +38,29 @@ jobs:
           - os: ubuntu-latest
             target: x86_64
             artifact-name: wheels-linux-x86_64
+            maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38'
           - os: windows-latest
             target: x64
             artifact-name: wheels-windows-x64
+            maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2'
           - os: macos-latest
             target: universal2-apple-darwin
             artifact-name: wheels-macos-universal2-apple-darwin
+            maturin-args: '--release --out dist --sdist --find-interpreter --features ext-module,abi3-py38'
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install system dependencies (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libglib2.0-dev libayatana-appindicator3-dev pkg-config
-
-      - name: Cache Rust
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-prebuild-v2-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-prebuild-v2-
-
-      - name: Build ABI3 wheel (Python 3.8+)
-        uses: PyO3/maturin-action@v1
+      - name: Build and Test Wheel
+        uses: ./.github/actions/build-wheel
         with:
           target: ${{ matrix.target }}
-          args: ${{ matrix.os == 'windows-latest' && '--release --out dist --features ext-module,abi3-py38,win-webview2' || (matrix.os == 'macos-latest' && '--release --out dist --sdist --features ext-module,abi3-py38' || '--release --out dist --features ext-module,abi3-py38') }}
-          manylinux: off
-          rust-toolchain: 1.90.0
+          python-version: '3.11'
+          maturin-args: ${{ matrix.maturin-args }}
+          test-wheel: 'true'
+          artifact-name: ${{ matrix.artifact-name }}
 
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: dist/*
-          retention-days: 7
-
-  # Python 3.7 separate build and test (abi3-py37 feature)
+  # Python 3.7 separate build and test (non-abi3)
+  # Uses the same build-wheel action as release workflow to ensure consistency
   # Artifact names match release workflow for reuse
   python37-test:
     name: Python 3.7 (${{ matrix.os }})
@@ -96,62 +73,24 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64
             artifact-name: wheels-linux-x86_64-py37
+            maturin-args: '--release --out dist -i python3.7 --features python-bindings,ext-module'
           - os: windows-2019
             target: x64
             artifact-name: wheels-windows-x64-py37
+            maturin-args: '--release --out dist -i python3.7 --features python-bindings,ext-module,win-webview2'
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.7'
-
-      - name: Install system dependencies (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libglib2.0-dev pkg-config libegl1 libxkbcommon0 libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0
-
-      - name: Cache Rust
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-py37-v2-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-py37-v2-
-
-      - name: Build wheel for Python 3.7
-        uses: PyO3/maturin-action@v1
+      - name: Build Python 3.7 Wheel
+        uses: ./.github/actions/build-wheel
         with:
           target: ${{ matrix.target }}
-          args: ${{ contains(matrix.os, 'windows') && '--release --out dist -i python3.7 --features python-bindings,ext-module,win-webview2' || '--release --out dist -i python3.7 --features python-bindings,ext-module' }}
-          manylinux: off
-          rust-toolchain: 1.90.0
-
-      - name: Install and test wheel
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          pip install dist/*.whl
-          python -c "import auroraview; print('Python 3.7 import OK')"
-          pip install pytest qtpy "PySide2>=5.15.0"
-          pytest tests/python/unit/ -v --tb=short -x || echo "Some tests may require newer Python features"
-        env:
-          QT_API: pyside2
-          CI: 'true'
-          QT_QPA_PLATFORM: offscreen
-          QT_OPENGL: software
-
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: dist/*.whl
-          retention-days: 7
+          python-version: '3.7'
+          rust-version: '1.90.0'
+          maturin-args: ${{ matrix.maturin-args }}
+          test-wheel: 'true'
+          artifact-name: ${{ matrix.artifact-name }}
+          use-sccache: 'false'
 
   # Fast checks that run first (< 2 min)
   quick-checks:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           # Reduce matrix size - test edge versions on all platforms, middle versions on Linux only
           - os: windows-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -111,7 +111,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Cache Rust
         uses: actions/cache@v4
@@ -205,7 +205,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download pre-built wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ${{ matrix.os == 'ubuntu-latest' && 'wheels-linux-x86_64' || matrix.os == 'windows-latest' && 'wheels-windows-x64' || 'wheels-macos-universal2-apple-darwin' }}
           path: dist/
@@ -331,7 +331,7 @@ jobs:
           python-version: '3.11'
 
       - name: Download pre-built wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: dist/
@@ -360,7 +360,7 @@ jobs:
           python-version: '3.11'
 
       - name: Download pre-built wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: wheels-windows-x64
           path: dist/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -282,7 +282,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install dist/*.whl
-          pip install pytest pytest-cov qtpy "PySide6<6.7"
+          # PySide6<6.7 doesn't support Python 3.13+, use PySide6>=6.8 for Python 3.13+
+          if python -c "import sys; exit(0 if sys.version_info >= (3, 13) else 1)"; then
+            pip install pytest pytest-cov qtpy "PySide6>=6.8"
+          else
+            pip install pytest pytest-cov qtpy "PySide6<6.7"
+          fi
 
       - name: Verify import
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           - wheels-windows-x64-py37
     steps:
       - name: Download artifact from PR workflow
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ${{ matrix.artifact }}
           path: dist/
@@ -137,7 +137,7 @@ jobs:
         continue-on-error: true
 
       - name: Re-upload artifact for release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact }}
           path: dist/
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Download wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: wheels-*
           path: dist
@@ -276,14 +276,14 @@ jobs:
             {{__unknown__}}
 
       - name: Download wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: wheels-*
           path: release-artifacts
           merge-multiple: true
 
       - name: Download CLI artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: cli-all-platforms
           path: release-artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,46 +176,44 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
- "askama_escape",
- "humansize",
- "num-traits",
+ "itoa",
  "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash 2.1.1",
  "serde",
+ "serde_derive",
  "syn 2.0.111",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "askama_parser"
-version = "0.2.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -402,7 +400,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "active-win-pos-rs 0.9.1",
  "anyhow",
@@ -455,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-cli"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "auroraview-core",
@@ -482,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-core"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "active-win-pos-rs 0.8.4",
  "askama",
@@ -512,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-pack"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "askama",
@@ -528,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugins"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -599,7 +597,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.111",
  "which 4.4.2",
@@ -1243,7 +1241,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1407,7 +1405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2242,15 +2240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,9 +2393,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2418,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -2759,12 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,7 +3074,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4378,6 +4361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4396,7 +4385,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4409,7 +4398,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5042,7 +5031,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6023,7 +6012,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ hyper = { version = "1.8", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 
 # Template engine for JS code generation
-askama = { version = "0.12", optional = true }
+askama = { version = "0.14", optional = true }
 
 # Regex for URL handling
 regex = { version = "1.11", optional = true }

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ AuroraView provides a modern web-based UI solution for professional DCC applicat
 
 - Core stack: Rust 1.75+, PyO3 0.22 (abi3), Wry 0.47, Tao 0.30
 - Web engines: Windows (WebView2), macOS (WKWebView), Linux (WebKitGTK)
-- Packaging: maturin with abi3 → one wheel works for CPython 3.73.12
+- Packaging: maturin with abi3 → one wheel works for CPython 3.7-3.13
 - Event loop: blocking show() by default; nonblocking mode planned for host loops
 - Deferred loading: URL/HTML set before show() are stored then applied at creation
 - IPC: bidirectional event bus (Python ↔ JavaScript via CustomEvent)

--- a/README_zh.md
+++ b/README_zh.md
@@ -86,7 +86,7 @@ AuroraView 为专业DCC应用程序（如Maya、3ds Max、Houdini、Blender、Ph
 
 - 核心栈：Rust 1.75+、PyO3 0.22（abi3）、Wry 0.47、Tao 0.30
 - 引擎：Windows（WebView2）、macOS（WKWebView）、Linux（WebKitGTK）
-- 打包：maturin + abi3 → 单个 wheel 兼容 CPython 3.73.12
+- 打包：maturin + abi3 → 单个 wheel 兼容 CPython 3.7-3.13
 - 事件循环：默认阻塞式 show()；后续提供非阻塞模式以适配宿主循环
 - 延迟加载：在 show() 前设置的 URL/HTML 会保存并在创建时应用（最后写入生效）
 - IPC：Python ↔ JavaScript 双向事件总线（基于 CustomEvent）

--- a/crates/auroraview-core/Cargo.toml
+++ b/crates/auroraview-core/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1", features = ["sync", "net", "rt-multi-thread", "macros"]
 warp = "0.3"
 
 # Templates
-askama = "0.12"
+askama = "0.14"
 
 # Window utilities
 active-win-pos-rs = "0.8"

--- a/crates/auroraview-pack/Cargo.toml
+++ b/crates/auroraview-pack/Cargo.toml
@@ -31,7 +31,7 @@ walkdir = "2.5"
 dunce = "1.0"
 
 # Template engine
-askama = "0.12"
+askama = "0.14"
 
 # Embed static assets
 rust-embed = "8.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,6 @@ module-name = "auroraview._core"
 # Note: abi3-py38 for Python 3.8+, Python 3.7 requires separate non-abi3 build
 features = ["python-bindings", "pyo3/extension-module", "abi3-py38"]
 bindings = "pyo3"
-# Include native Qt libraries for qt_native module
-include = [
-    { path = "python/auroraview/_native/**/*", format = "sdist" },
-    { path = "python/auroraview/_native/**/*", format = "wheel" },
-]
 
 # Ruff configuration
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Problem

The 0.3.3 release published to PyPI has broken Windows wheels. Users get `PyInit__core` import errors when trying to use the package.

**Root Cause**: Artifact name mismatch between workflows:
- `build-wheel/action.yml` was appending suffixes like `-Windows-py3.11-x64` to artifact names
- `release.yml` expected simple names like `wheels-windows-x64`

This caused the release workflow to fail finding the correct wheel artifacts, resulting in incorrect/incomplete wheels being uploaded to PyPI.

## Solution

1. **`.github/actions/build-wheel/action.yml`**:
   - Remove automatic suffix appending in artifact upload
   - Now uses the exact `artifact-name` passed as input

2. **`.github/workflows/build-wheels.yml`**:
   - Use static artifact names matching `pr-checks.yml` and `release.yml`
   - `wheels-linux-x86_64`, `wheels-windows-x64`, `wheels-macos-universal2-apple-darwin`

## Testing

After this fix, the artifact names will be consistent across all workflows:
- `pr-checks.yml`: `wheels-windows-x64` ✓
- `build-wheels.yml`: `wheels-windows-x64` ✓ (was `wheels-windows-x64-Windows-py3.11-x64`)
- `release.yml`: expects `wheels-windows-x64` ✓

## Related

- Fixes Python 3.13 support issue
- Fixes `PyInit__core` import error on Windows