### PR TITLE
fix: add python-bindings feature to all maturin-args in CI workflows

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -17,7 +17,7 @@ inputs:
   maturin-args:
     description: 'Additional arguments for maturin'
     required: false
-    default: '--release --out dist --find-interpreter --features ext-module,abi3-py38'
+    default: '--release --out dist --find-interpreter --features python-bindings,ext-module,abi3-py38'
   test-wheel:
     description: 'Whether to test the built wheel'
     required: false

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
-          maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2'
+          maturin-args: '--release --out dist --find-interpreter --features python-bindings,ext-module,abi3-py38,win-webview2'
           test-wheel: ${{ inputs.test-wheel }}
           artifact-name: 'wheels-windows-x64'
 
@@ -98,7 +98,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           python-version: ${{ inputs.python-version }}
-          maturin-args: '--release --out dist --sdist --find-interpreter --features ext-module,abi3-py38'
+          maturin-args: '--release --out dist --sdist --find-interpreter --features python-bindings,ext-module,abi3-py38'
           test-wheel: ${{ inputs.test-wheel }}
           artifact-name: 'wheels-macos-universal2-apple-darwin'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           test-wheel: 'true'
           upload-wheel: 'true'
           artifact-name: 'wheels-${{ matrix.os }}'
-          maturin-args: ${{ matrix.os == 'windows-latest' && '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2' || '--release --out dist --find-interpreter --features ext-module,abi3-py38' }}
+          maturin-args: ${{ matrix.os == 'windows-latest' && '--release --out dist --find-interpreter --features python-bindings,ext-module,abi3-py38,win-webview2' || '--release --out dist --find-interpreter --features python-bindings,ext-module,abi3-py38' }}
 
   # CLI builds for all platforms
   cli-builds:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,15 +38,15 @@ jobs:
           - os: ubuntu-latest
             target: x86_64
             artifact-name: wheels-linux-x86_64
-            maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38'
+            maturin-args: '--release --out dist --find-interpreter --features python-bindings,ext-module,abi3-py38'
           - os: windows-latest
             target: x64
             artifact-name: wheels-windows-x64
-            maturin-args: '--release --out dist --find-interpreter --features ext-module,abi3-py38,win-webview2'
+            maturin-args: '--release --out dist --find-interpreter --features python-bindings,ext-module,abi3-py38,win-webview2'
           - os: macos-latest
             target: universal2-apple-darwin
             artifact-name: wheels-macos-universal2-apple-darwin
-            maturin-args: '--release --out dist --sdist --find-interpreter --features ext-module,abi3-py38'
+            maturin-args: '--release --out dist --sdist --find-interpreter --features python-bindings,ext-module,abi3-py38'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

The wheel builds since v0.3.3 were broken because the `maturin-args` were missing the `python-bindings` feature, causing PyO3 bindings to not be enabled.

This resulted in nearly empty `.pyd` files (~9KB instead of ~3MB), making the published wheels on PyPI non-functional.

## Root Cause

In `Cargo.toml`, the `pyo3` dependency is optional and only enabled by the `python-bindings` feature:

```toml
pyo3 = { version = "0.27.2", features = ["multiple-pymethods"], optional = true }

[features]
python-bindings = ["pyo3"]
abi3-py38 = ["pyo3/abi3-py38"]
ext-module = ["pyo3/extension-module"]
```

The CI workflows were using `--features ext-module,abi3-py38` without `python-bindings`, so `pyo3` was never enabled.

## Solution

Added `python-bindings` to all `maturin-args` in CI workflows to match the local development configuration in `justfile`.

### Fixed files:
- `.github/actions/build-wheel/action.yml` (default value)
- `.github/workflows/build-wheels.yml` (Windows and macOS jobs)
- `.github/workflows/ci.yml` (wheel-builds job)
- `.github/workflows/pr-checks.yml` (all platform matrix entries)

## Verification

After this fix, the built wheels should have:
- `_core.pyd` file size ~3MB (not ~9KB)
- Working `import auroraview` in Python

## Related

This fixes the broken releases v0.3.3 and v0.3.4 on PyPI.