### PR TITLE
docs: add Python 3.7 Windows CLI workaround for uv/uvx

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,11 @@ auroraview --url https://example.com --title "My App" --width 1024 --height 768
 uvx auroraview --url https://example.com
 ```
 
+> **Note for Python 3.7 on Windows**: Due to a [uv/uvx limitation](https://github.com/astral-sh/uv/issues/10165), use `python -m auroraview` instead:
+> ```bash
+> uvx --python 3.7 --from auroraview python -m auroraview --url https://example.com
+> ```
+
 **[See CLI Documentation](./docs/CLI.md)** for more details.
 
 ### Custom Window Icon

--- a/README_zh.md
+++ b/README_zh.md
@@ -361,6 +361,11 @@ auroraview --url https://example.com --title "我的应用" --width 1024 --heigh
 uvx auroraview --url https://example.com
 ```
 
+> **Python 3.7 Windows 用户注意**：由于 [uv/uvx 的限制](https://github.com/astral-sh/uv/issues/10165)，请使用 `python -m auroraview` 代替：
+> ```bash
+> uvx --python 3.7 --from auroraview python -m auroraview --url https://example.com
+> ```
+
 **[查看 CLI 文档](./docs/CLI.md)** 了解更多详情。
 
 ### 自定义窗口图标

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -123,6 +123,27 @@ sudo pacman -S webkit2gtk
 
 ## Troubleshooting
 
+### Python 3.7 on Windows with uvx
+
+Due to a [known limitation](https://github.com/astral-sh/uv/issues/10165) in uv/uvx, the `auroraview` command does not work with Python 3.7 on Windows. You will see an error like:
+
+```
+SyntaxError: Non-UTF-8 code starting with '\xe8' in file ...\auroraview.exe
+```
+
+**Workaround**: Use `python -m auroraview` instead:
+
+```bash
+# Instead of: uvx --python 3.7 auroraview --url https://example.com
+# Use:
+uvx --python 3.7 --from auroraview python -m auroraview --url https://example.com
+
+# Or with pip-installed package:
+python -m auroraview --url https://example.com
+```
+
+This issue only affects Python 3.7 on Windows. Python 3.8+ works correctly with the `auroraview` command.
+
 ### Binary Not Found
 
 If you get "auroraview: command not found", ensure the package is properly installed:


### PR DESCRIPTION
## Summary

Document the known uv/uvx limitation where the `auroraview` command fails with Python 3.7 on Windows.

## Problem

When using `uvx --python 3.7 auroraview --url URL`, users see:

```
SyntaxError: Non-UTF-8 code starting with '\xe8' in file ...\auroraview.exe
```

This is caused by uv/uvx generating entry point wrappers that are incompatible with Python 3.7 on Windows. The issue is tracked at: https://github.com/astral-sh/uv/issues/10165

## Solution

Document the workaround: use `python -m auroraview` instead:

```bash
uvx --python 3.7 --from auroraview python -m auroraview --url https://example.com
```

## Changes

- `README.md`: Added note about Python 3.7 Windows workaround
- `README_zh.md`: Added Chinese translation of the note
- `docs/CLI.md`: Added detailed troubleshooting section

## Testing

Verified that the workaround works:

```bash
# This fails:
uvx --python 3.7 auroraview --url https://example.com

# This works:
uvx --python 3.7 --from auroraview python -m auroraview --url https://example.com
```