### PR TITLE
ci: add makeLatest flag to ensure correct release ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,4 +371,5 @@ jobs:
           allowUpdates: true
           skipIfReleaseExists: false
           updateOnlyUnreleased: false
+          makeLatest: true
 


### PR DESCRIPTION
## Problem

GitHub's "Latest" release badge was showing v0.3.9 instead of v0.3.10 due to GitHub's semantic version sorting behavior. When comparing version strings like `0.3.9` vs `0.3.10`, GitHub incorrectly considers `0.3.9` as newer because it uses string comparison ("9" > "1").

## Solution

Add `makeLatest: true` to the `ncipollo/release-action` configuration. This explicitly marks each new release as the "Latest" release, overriding GitHub's default semantic version sorting.

## Changes

- Added `makeLatest: true` parameter to the Create GitHub Release step in `.github/workflows/release.yml`

## Additional Fix Applied

Manually set v0.3.10 as the Latest release using `gh release edit auroraview-v0.3.10 --latest`

## Testing

- Verified v0.3.10 is now showing as "Latest" via GitHub API
- Future releases will automatically be marked as "Latest"