### PR TITLE
fix(ci): rename sdk-assets artifact to avoid conflict

### DIFF
--- a/.github/workflows/build-gallery.yml
+++ b/.github/workflows/build-gallery.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload SDK assets artifact
         uses: actions/upload-artifact@v5
         with:
-          name: sdk-assets
+          name: gallery-sdk-assets
           path: |
             crates/auroraview-core/src/assets/js/core/
             crates/auroraview-core/src/assets/js/plugins/
@@ -78,7 +78,7 @@ jobs:
       - name: Download SDK assets
         uses: actions/download-artifact@v6
         with:
-          name: sdk-assets
+          name: gallery-sdk-assets
           path: crates/auroraview-core/src/assets/js/
 
       - name: Build Wheel


### PR DESCRIPTION
## Problem

The `build-gallery.yml` workflow was using `sdk-assets` as artifact name, which conflicts with `sdk-ci.yml` when both are called from `release.yml`.

Error:
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

## Root Cause

In `release.yml`:
1. `build-sdk` job calls `sdk-ci.yml`, which uploads `sdk-assets` artifact
2. `build-gallery` job calls `build-gallery.yml`, which also uploads `sdk-assets` artifact

This causes a naming conflict.

## Why PR Checks Didn't Catch This

- `build-gallery.yml` is only called during release (from `release.yml`)
- PR checks use `pr-checks.yml` which has its own `gallery-pack` job
- The artifact naming conflict only occurs when both workflows run in the same workflow run

## Solution

Renamed the artifact in `build-gallery.yml` from `sdk-assets` to `gallery-sdk-assets` to avoid the conflict.
