### PR TITLE
fix(ci): resolve artifact name conflicts in release workflow

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,12 +35,51 @@ permissions:
 jobs:
   # ============================================================================
   # Build SDK assets first (shared by all wheel builds)
-  # Uses reusable SDK CI workflow
+  # Build assets directly instead of calling sdk-ci.yml to avoid artifact conflicts
   # ============================================================================
   sdk-assets:
-    name: SDK Assets
-    uses: ./.github/workflows/sdk-ci.yml
-    secrets: inherit
+    name: Build SDK Assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install SDK dependencies
+        run: |
+          cd packages/auroraview-sdk
+          rm -rf node_modules package-lock.json
+          npm install
+
+      - name: Build SDK assets
+        run: |
+          cd packages/auroraview-sdk
+          npm run build:assets
+
+      - name: Verify assets outputs
+        run: |
+          echo "Checking generated assets..."
+          ls -la crates/auroraview-core/src/assets/js/core/
+          ls -la crates/auroraview-core/src/assets/js/plugins/
+          
+          # Verify core files
+          test -f crates/auroraview-core/src/assets/js/core/event_bridge.js || (echo "Missing event_bridge.js" && exit 1)
+          test -f crates/auroraview-core/src/assets/js/core/state_bridge.js || (echo "Missing state_bridge.js" && exit 1)
+          
+          echo "All SDK assets verified!"
+
+      - name: Upload SDK assets artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: wheels-sdk-assets
+          path: |
+            crates/auroraview-core/src/assets/js/core/
+            crates/auroraview-core/src/assets/js/plugins/
+          retention-days: 7
 
   # ============================================================================
   # ABI3 builds (Python 3.8+) - Single wheel works for all Python 3.8+ versions
@@ -60,7 +99,7 @@ jobs:
       - name: Download SDK assets
         uses: actions/download-artifact@v6
         with:
-          name: sdk-assets
+          name: wheels-sdk-assets
           path: crates/auroraview-core/src/assets/js/
 
       - name: Build and Test Wheel
@@ -85,7 +124,7 @@ jobs:
       - name: Download SDK assets
         uses: actions/download-artifact@v6
         with:
-          name: sdk-assets
+          name: wheels-sdk-assets
           path: crates/auroraview-core/src/assets/js/
 
       - name: Build and Test Wheel
@@ -114,7 +153,7 @@ jobs:
       - name: Download SDK assets
         uses: actions/download-artifact@v6
         with:
-          name: sdk-assets
+          name: wheels-sdk-assets
           path: crates/auroraview-core/src/assets/js/
 
       - name: Build and Test Wheel
@@ -145,7 +184,7 @@ jobs:
       - name: Download SDK assets
         uses: actions/download-artifact@v6
         with:
-          name: sdk-assets
+          name: wheels-sdk-assets
           path: crates/auroraview-core/src/assets/js/
 
       - name: Build Python 3.7 Wheel
@@ -176,7 +215,7 @@ jobs:
       - name: Download SDK assets
         uses: actions/download-artifact@v6
         with:
-          name: sdk-assets
+          name: wheels-sdk-assets
           path: crates/auroraview-core/src/assets/js/
 
       - name: Build Python 3.7 Wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,8 @@ jobs:
       ((needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true') ||
        (needs.check-tag.result == 'success' && needs.check-tag.outputs.is_tag == 'true'))
     uses: ./.github/workflows/sdk-ci.yml
+    with:
+      artifact-prefix: 'release-'
     secrets: inherit
 
   # Publish SDK to npm
@@ -316,7 +318,7 @@ jobs:
       - name: Download SDK artifact
         uses: actions/download-artifact@v6
         with:
-          name: sdk-package
+          name: release-sdk-package
           path: packages/auroraview-sdk/dist/
 
       - name: Sync version from release tag

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -15,10 +15,16 @@ on:
       - '.github/workflows/sdk-ci.yml'
   workflow_dispatch:
   workflow_call:
+    inputs:
+      artifact-prefix:
+        description: "Prefix for artifact names to avoid conflicts"
+        required: false
+        type: string
+        default: ''
     outputs:
       sdk-assets-artifact:
         description: "Name of the SDK assets artifact"
-        value: sdk-assets
+        value: ${{ jobs.build-assets.outputs.artifact-name }}
 
 permissions:
   contents: read
@@ -130,7 +136,7 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v5
         with:
-          name: sdk-coverage-report
+          name: ${{ inputs.artifact-prefix }}sdk-coverage-report
           path: packages/auroraview-sdk/coverage/
           retention-days: 7
 
@@ -180,7 +186,7 @@ jobs:
       - name: Upload SDK package artifact
         uses: actions/upload-artifact@v5
         with:
-          name: sdk-package
+          name: ${{ inputs.artifact-prefix }}sdk-package
           path: packages/auroraview-sdk/dist/
           retention-days: 7
 
@@ -190,6 +196,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [typecheck]
+    outputs:
+      artifact-name: ${{ steps.upload.outputs.artifact-name }}
     steps:
       - uses: actions/checkout@v6
 
@@ -233,13 +241,17 @@ jobs:
           echo "All SDK assets verified!"
 
       - name: Upload SDK assets artifact
+        id: upload
         uses: actions/upload-artifact@v5
         with:
-          name: sdk-assets
+          name: ${{ inputs.artifact-prefix }}sdk-assets
           path: |
             crates/auroraview-core/src/assets/js/core/
             crates/auroraview-core/src/assets/js/plugins/
           retention-days: 7
+
+      - name: Set artifact name output
+        run: echo "artifact-name=${{ inputs.artifact-prefix }}sdk-assets" >> $GITHUB_OUTPUT
 
   # E2E tests - test SDK integration with real browser
   e2e-tests:
@@ -279,7 +291,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: sdk-e2e-results
+          name: ${{ inputs.artifact-prefix }}sdk-e2e-results
           path: packages/auroraview-sdk/test-results/
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## Problem

Multiple workflows uploading artifacts with same names caused conflicts during release:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

### Root Cause

In `release.yml`, multiple workflows were called that all uploaded artifacts with the same names:
1. `build-sdk` job calls `sdk-ci.yml` → uploads `sdk-assets`, `sdk-coverage-report`, etc.
2. `build-wheels` job calls `build-wheels.yml` → which also called `sdk-ci.yml` → duplicate artifacts!
3. `build-gallery` job calls `build-gallery.yml` → which also uploaded `sdk-assets` (fixed in previous PR)

## Solution

1. **Add `artifact-prefix` input to `sdk-ci.yml`**: Allows callers to specify a unique prefix for artifact names
2. **Modify `build-wheels.yml`**: Build SDK assets directly instead of calling `sdk-ci.yml`, using `wheels-sdk-assets` artifact name
3. **`build-gallery.yml`**: Already uses `gallery-sdk-assets` (from previous fix #136)
4. **`release.yml`**: Now passes `release-` prefix to `sdk-ci.yml`

### Artifact Naming Convention

| Workflow | Artifact Names |
|----------|---------------|
| PR checks (`sdk-ci.yml` direct) | `sdk-assets`, `sdk-coverage-report`, etc. |
| `build-wheels.yml` | `wheels-sdk-assets` |
| `build-gallery.yml` | `gallery-sdk-assets` |
| `release.yml` → `build-sdk` | `release-sdk-assets`, `release-sdk-coverage-report`, etc. |

## Why PR Checks Didn't Catch This

- `build-wheels.yml` is only called during release (from `release.yml`)
- PR checks use `pr-checks.yml` which has its own build logic
- The artifact naming conflict only occurs when multiple workflows run in the same workflow run

## Testing

After this fix:
- Each workflow uses unique artifact names
- No conflicts when multiple workflows run in the same workflow run during releases
