### PR TITLE
ci: update vx action to v0.6.4 with github-token

### DIFF
--- a/.github/actions/setup-auroraview/action.yml
+++ b/.github/actions/setup-auroraview/action.yml
@@ -30,12 +30,16 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Install vx
+      uses: loonghao/vx@vx-v0.6.4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        cache: false
+
     - name: Setup vx
       id: setup-vx
-      uses: loonghao/vx@main
-      with:
-        setup: 'true'
-        cache: 'true'
+      shell: bash
+      run: vx setup --ci
 
     - name: Show installed tools
       shell: bash


### PR DESCRIPTION
## Changes

- Update `loonghao/vx` action from `@main` to `@vx-v0.6.4`
- Add `github-token` parameter for API rate limiting
- Set `cache: false` to use separate caching strategy
- Split vx installation and setup into separate steps

## Why

Align with other projects using vx action with fixed version for consistency and stability.