### PR TITLE
refactor: replace eprintln! with tracing macros for structured logging

### DIFF
--- a/src/bindings/timer.rs
+++ b/src/bindings/timer.rs
@@ -119,7 +119,7 @@ impl PyTimer {
                 // Call the Python callback
                 Python::attach(|py| {
                     if let Err(e) = callback.call0(py) {
-                        eprintln!("Error calling timer callback: {:?}", e);
+                        tracing::error!("Error calling timer callback: {:?}", e);
                     }
                 });
             }

--- a/src/webview/child_window.rs
+++ b/src/webview/child_window.rs
@@ -38,14 +38,16 @@ pub fn create_child_webview_window(
     use tao::platform::windows::EventLoopBuilderExtWindows;
 
     let url = url.to_string();
-    eprintln!(
+    tracing::info!(
         "[ChildWindow] Creating child window for: {} ({}x{})",
-        url, width, height
+        url,
+        width,
+        height
     );
 
     // Spawn a new thread for the child window's event loop
     std::thread::spawn(move || {
-        eprintln!("[ChildWindow] Thread started for: {}", url);
+        tracing::debug!("[ChildWindow] Thread started for: {}", url);
 
         // Create event loop for this child window
         let event_loop = EventLoopBuilder::new().with_any_thread(true).build();
@@ -59,12 +61,12 @@ pub fn create_child_webview_window(
         {
             Ok(w) => w,
             Err(e) => {
-                eprintln!("[ChildWindow] Failed to create window: {}", e);
+                tracing::error!("[ChildWindow] Failed to create window: {}", e);
                 return;
             }
         };
 
-        eprintln!("[ChildWindow] Window created, creating WebView...");
+        tracing::debug!("[ChildWindow] Window created, creating WebView...");
 
         // Create WebView
         let webview = match WebViewBuilder::new()
@@ -74,12 +76,12 @@ pub fn create_child_webview_window(
         {
             Ok(wv) => wv,
             Err(e) => {
-                eprintln!("[ChildWindow] Failed to create WebView: {}", e);
+                tracing::error!("[ChildWindow] Failed to create WebView: {}", e);
                 return;
             }
         };
 
-        eprintln!("[ChildWindow] WebView created successfully!");
+        tracing::debug!("[ChildWindow] WebView created successfully!");
 
         // State for tracking window
         let state = Arc::new(Mutex::new(ChildWindowState {
@@ -100,7 +102,7 @@ pub fn create_child_webview_window(
                     event: WindowEvent::CloseRequested,
                     ..
                 } => {
-                    eprintln!("[ChildWindow] Close requested");
+                    tracing::debug!("[ChildWindow] Close requested");
                     if let Ok(mut s) = state_clone.lock() {
                         s.should_close = true;
                     }
@@ -110,7 +112,7 @@ pub fn create_child_webview_window(
                     event: WindowEvent::Destroyed,
                     ..
                 } => {
-                    eprintln!("[ChildWindow] Window destroyed");
+                    tracing::debug!("[ChildWindow] Window destroyed");
                     *control_flow = ControlFlow::Exit;
                 }
                 Event::MainEventsCleared => {
@@ -125,7 +127,7 @@ pub fn create_child_webview_window(
             }
         });
 
-        eprintln!("[ChildWindow] Event loop exited for: {}", url);
+        tracing::debug!("[ChildWindow] Event loop exited for: {}", url);
     });
 
     Ok(())

--- a/src/webview/desktop.rs
+++ b/src/webview/desktop.rs
@@ -473,22 +473,18 @@ pub fn create_desktop(
     // Handle new window requests (window.open())
     // The behavior depends on the new_window_mode configuration
     let new_window_mode = config.new_window_mode;
-    eprintln!("[Rust] new_window_mode = {:?}", new_window_mode);
+    tracing::debug!("[standalone] new_window_mode = {:?}", new_window_mode);
     match new_window_mode {
         NewWindowMode::Deny => {
-            eprintln!("[Rust] Setting up Deny mode handler");
             tracing::debug!("[standalone] New windows blocked (Deny mode)");
             webview_builder = webview_builder.with_new_window_req_handler(|url, _features| {
-                eprintln!("[Rust] Deny handler called for: {}", url);
                 tracing::debug!("[standalone] Blocked new window request: {}", url);
                 wry::NewWindowResponse::Deny
             });
         }
         NewWindowMode::SystemBrowser => {
-            eprintln!("[Rust] Setting up SystemBrowser mode handler");
             tracing::info!("[standalone] New windows open in system browser");
             webview_builder = webview_builder.with_new_window_req_handler(|url, _features| {
-                eprintln!("[Rust] SystemBrowser handler called for: {}", url);
                 tracing::info!("[standalone] Opening in system browser: {}", url);
                 if let Err(e) = open::that(&url) {
                     tracing::error!("[standalone] Failed to open URL in browser: {}", e);
@@ -497,13 +493,11 @@ pub fn create_desktop(
             });
         }
         NewWindowMode::ChildWebView => {
-            eprintln!("[Rust] Setting up ChildWebView mode handler");
             tracing::info!("[standalone] New windows create child WebView");
             // ChildWebView mode: Create a new independent WebView window in a separate thread
             // This avoids WebView2's threading restrictions by creating a completely new
             // WebView instance with its own event loop
             webview_builder = webview_builder.with_new_window_req_handler(move |url, features| {
-                eprintln!("[Rust] ChildWebView handler called for: {}", url);
                 tracing::info!("[standalone] Creating child WebView window for: {}", url);
 
                 // Get window size from features or use defaults
@@ -515,7 +509,6 @@ pub fn create_desktop(
                 if let Err(e) =
                     super::child_window::create_child_webview_window(&url, width, height)
                 {
-                    eprintln!("[Rust] Failed to create child window: {}", e);
                     tracing::error!("[standalone] Failed to create child window: {}", e);
                 }
 

--- a/src/webview/js_assets.rs
+++ b/src/webview/js_assets.rs
@@ -248,7 +248,7 @@ fn build_api_registration_script(
         api_methods: entries,
     };
     template.render().unwrap_or_else(|e| {
-        eprintln!(
+        tracing::error!(
             "[AuroraView] Failed to render API registration template: {}",
             e
         );
@@ -430,7 +430,7 @@ pub fn build_emit_event_script(event_name: &str, event_data: &str) -> String {
         event_data,
     };
     template.render().unwrap_or_else(|e| {
-        eprintln!("[AuroraView] Failed to render emit event template: {}", e);
+        tracing::error!("[AuroraView] Failed to render emit event template: {}", e);
         // Fallback to legacy method
         get_emit_event_js()
             .replace("{EVENT_NAME}", event_name)
@@ -532,7 +532,7 @@ pub fn build_eval_js_async_script(script: &str, callback_id: u64) -> String {
 pub fn build_load_url_script(url: &str) -> String {
     let template = LoadUrlTemplate { url };
     template.render().unwrap_or_else(|e| {
-        eprintln!("[AuroraView] Failed to render load URL template: {}", e);
+        tracing::error!("[AuroraView] Failed to render load URL template: {}", e);
         // Fallback to legacy method
         get_load_url_js().replace("{URL}", url)
     })


### PR DESCRIPTION
## Summary

Replace all production `eprintln!` calls with appropriate `tracing` macros across 4 files, improving log consistency and enabling structured logging.

## Changes

### Files Modified

| File | eprintln! removed | Replacement |
|------|-------------------|-------------|
| `src/webview/child_window.rs` | 8 | `tracing::info!`, `tracing::debug!`, `tracing::error!` |
| `src/webview/desktop.rs` | 9 | Removed duplicates where both `eprintln!` and `tracing` existed |
| `src/webview/js_assets.rs` | 3 | `tracing::error!` for template render fallbacks |
| `src/bindings/timer.rs` | 1 | `tracing::error!` for callback error |

### Tracing Level Strategy

- **`tracing::info!`** - Important lifecycle events (window creation, mode setup)
- **`tracing::debug!`** - Detailed lifecycle events (thread start, close, destroy)
- **`tracing::error!`** - Failure conditions (window/webview creation failures, template errors)

### Not Changed

- `src/webview/protocol_handlers.rs` - 6 `eprintln!` calls are all `#[cfg(test)]` gated, kept as test diagnostics (they already have proper `tracing` calls in the production path)

## Motivation

- `eprintln!` writes directly to stderr with no log levels, timestamps, or spans
- `tracing` provides structured logging with configurable levels and subscribers
- Several locations had **duplicate** logging (`eprintln!` + `tracing` for the same message), which is now cleaned up
- Consistent with the rest of the codebase which already uses `tracing` extensively

## Testing

- `cargo check` passes
- `cargo clippy` passes with no warnings
- All pre-commit hooks pass (fmt, clippy)