### PR TITLE
fix(ci): resolve release #266 failures (py37 wheel, SDK E2E, artifact versions)

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -25,3 +25,18 @@ platforms = [
 
 # Write out exact versions rather than a semver range. (Defaults to false.)
 # exact-versions = true
+
+# Exclude abi3-py38 from workspace-hack unification.
+# This feature must remain opt-in because py37 builds cannot use it.
+# When abi3-py38 is unified into workspace-hack, it forces PyO3 to require
+# Python >= 3.8, breaking the py37 wheel build.
+[traversal-excludes]
+# Exclude the entire pyo3 ecosystem from hakari unification to prevent
+# abi3 features from being forcibly enabled across all workspace members.
+third-party = [
+    { name = "pyo3" },
+    { name = "pyo3-ffi" },
+    { name = "pyo3-build-config" },
+    { name = "pyo3-macros" },
+    { name = "pyo3-macros-backend" },
+]

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -156,7 +156,7 @@ runs:
 
     - name: Upload test artifacts
       if: inputs.upload-artifacts == 'true' && always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}-${{ runner.os }}-${{ github.run_id }}
         path: |

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -310,7 +310,7 @@ runs:
 
     - name: Upload wheel
       if: inputs.upload-wheel == 'true'
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
         continue-on-error: true
 
       - name: Re-upload artifact for release
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: dist/
@@ -677,7 +677,7 @@ jobs:
           ls -la dist/
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -229,12 +229,26 @@ jobs:
           install-dependencies: 'false'
           cache-key-suffix: 'sdk-e2e'
 
+      - name: Download SDK package
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact-prefix }}sdk-package
+          path: packages/auroraview-sdk/dist/
+
+      - name: Link SDK dist into E2E test-app
+        run: |
+          # The E2E test HTML imports from '/dist/index.js'.
+          # npx serve roots at tests/e2e/test-app/, so dist/ must exist there.
+          ln -s "${{ github.workspace }}/packages/auroraview-sdk/dist" \
+                packages/auroraview-sdk/tests/e2e/test-app/dist
+          echo "Linked SDK dist into test-app:"
+          ls -la packages/auroraview-sdk/tests/e2e/test-app/dist/
+
       - name: Install Playwright
         run: vx just sdk-playwright-install
 
       - name: Run E2E tests
         run: vx just sdk-test-e2e
-
 
       - name: Upload E2E test results
         if: always()

--- a/crates/auroraview-workspace-hack/Cargo.toml
+++ b/crates/auroraview-workspace-hack/Cargo.toml
@@ -56,8 +56,8 @@ percent-encoding = { version = "2" }
 phf_shared = { version = "0.11" }
 portable-atomic = { version = "1" }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
-pyo3 = { version = "0.27", features = ["abi3-py38", "auto-initialize", "extension-module", "multiple-pymethods"] }
-pyo3-ffi = { version = "0.27", features = ["abi3-py38", "extension-module"] }
+pyo3 = { version = "0.27", features = ["auto-initialize", "extension-module", "multiple-pymethods"] }
+pyo3-ffi = { version = "0.27", features = ["extension-module"] }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 rand_chacha = { version = "0.9", default-features = false, features = ["std"] }
@@ -108,7 +108,7 @@ log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 phf_shared = { version = "0.11" }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
-pyo3-build-config = { version = "0.27", features = ["abi3-py38", "extension-module", "resolve-config"] }
+pyo3-build-config = { version = "0.27", features = ["extension-module", "resolve-config"] }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }

--- a/justfile
+++ b/justfile
@@ -923,14 +923,19 @@ sdk-test-cov: sdk-install
 
 # Run SDK E2E tests (requires Playwright)
 [unix]
-sdk-test-e2e: sdk-playwright-install
+sdk-test-e2e: sdk-playwright-install sdk-build
     @echo "Running SDK E2E tests..."
+    @# E2E test HTML imports from /dist/index.js; npx serve roots at test-app/
+    @ln -sfn "{{justfile_directory()}}/packages/auroraview-sdk/dist" \
+             "{{justfile_directory()}}/packages/auroraview-sdk/tests/e2e/test-app/dist"
     cd packages/auroraview-sdk; vx bun run test:e2e
     @echo "[OK] SDK E2E tests passed!"
 
 [windows]
-sdk-test-e2e: sdk-playwright-install
+sdk-test-e2e: sdk-playwright-install sdk-build
     @echo "Running SDK E2E tests..."
+    # E2E test HTML imports from /dist/index.js; npx serve roots at test-app/
+    if (!(Test-Path "packages/auroraview-sdk/tests/e2e/test-app/dist")) { cmd /c mklink /D "packages\auroraview-sdk\tests\e2e\test-app\dist" "{{justfile_directory()}}\packages\auroraview-sdk\dist" }
     cd packages/auroraview-sdk; vx bun run test:e2e
     @echo "[OK] SDK E2E tests passed!"
 


### PR DESCRIPTION
## Summary

Fixes the three failures in [Release #266](https://github.com/loonghao/auroraview/actions/runs/15033988397).

## Root Causes & Fixes

### 1. `build-wheels / windows-py37 (x64)` — maturin exit code 1

**Root cause**: `cargo hakari generate` unified all workspace pyo3 features into `crates/auroraview-workspace-hack/Cargo.toml`, including `abi3-py38`. Since workspace-hack is a dependency of every crate, this forced `abi3-py38` on even when building py37 wheels (where the build-wheel action strips `abi3-py38` from maturin args). PyO3 then detected Python 3.7 < 3.8 and refused to compile.

**Fix**:
- Removed `abi3-py38` from pyo3, pyo3-ffi, and pyo3-build-config entries in `crates/auroraview-workspace-hack/Cargo.toml`
- Added `[traversal-excludes]` to `.config/hakari.toml` to exclude the entire pyo3 ecosystem from hakari unification, preventing `abi3-py38` from being re-introduced on future `cargo hakari generate` runs

### 2. `SDK CI / E2E Tests` — exit code 1

**Root cause**: Recent commit removed the `|| echo "E2E tests not configured yet"` fallback from the E2E test step and added `e2e-tests` to the `sdk-ready` gate job. The E2E test HTML (`tests/e2e/test-app/index.html`) imports SDK from `/dist/index.js`, but `npx serve` roots at `tests/e2e/test-app/` where no `dist/` directory exists.

**Fix**:
- Added a step in `sdk-ci.yml` E2E job to download the SDK build artifact and symlink `dist/` into the test-app serve root
- Updated `justfile` `sdk-test-e2e` to depend on `sdk-build` and create the symlink, ensuring local development parity

### 3. `upload-artifact` version inconsistency

**Root cause**: Some workflows used `actions/upload-artifact@v6` while others used `@v7`.

**Fix**: Unified all `upload-artifact` to `@v7` across:
- `.github/actions/build-wheel/action.yml`
- `.github/actions/build-and-test/action.yml`
- `.github/workflows/release.yml` (2 occurrences)

## Files Changed

| File | Change |
|------|--------|
| `crates/auroraview-workspace-hack/Cargo.toml` | Remove `abi3-py38` from pyo3 entries |
| `.config/hakari.toml` | Exclude pyo3 ecosystem from hakari traversal |
| `.github/workflows/sdk-ci.yml` | Download SDK artifact + symlink for E2E |
| `justfile` | `sdk-test-e2e` depends on `sdk-build` + creates symlink |
| `.github/actions/build-wheel/action.yml` | `upload-artifact@v6` -> `@v7` |
| `.github/actions/build-and-test/action.yml` | `upload-artifact@v6` -> `@v7` |
| `.github/workflows/release.yml` | `upload-artifact@v6` -> `@v7` (2x) |
