### PR TITLE
refactor: remove dead single-variant BackendType enum and unused WebViewBackend alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-assets"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "auroraview-workspace-hack",
  "include_dir",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-bookmarks"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-browser"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "auroraview-bookmarks",
  "auroraview-core",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-cli"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "auroraview-assets",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-core"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "active-win-pos-rs",
  "askama",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-core"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "auroraview-workspace-hack",
  "dunce",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-fs"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "auroraview-plugin-core",
  "auroraview-workspace-hack",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugins"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "arboard",
  "auroraview-extensions",

--- a/src/webview/backend/mod.rs
+++ b/src/webview/backend/mod.rs
@@ -66,7 +66,7 @@ pub use auroraview_core::backend::{
     // Factory and types
     BackendConfig,
     BackendFactory,
-    BackendType as CoreBackendType,
+    BackendType,
     // Core traits and types
     CookieInfo,
     EmbeddableBackend,
@@ -239,39 +239,4 @@ pub trait PyBindingsBackend {
 
     /// Request close
     fn request_close(&self) -> Result<(), Box<dyn std::error::Error>>;
-}
-
-// Keep the old trait name as an alias for backwards compatibility
-#[allow(dead_code)]
-pub trait WebViewBackend: PyBindingsBackend {}
-impl<T: PyBindingsBackend> WebViewBackend for T {}
-
-/// Backend type enum for runtime selection
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BackendType {
-    /// Native embedding mode (using platform-specific wry/tao)
-    Native,
-}
-
-#[allow(dead_code)]
-impl BackendType {
-    /// Create a native backend
-    pub fn native() -> Self {
-        BackendType::Native
-    }
-
-    /// Parse backend type from string
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "native" => Some(Self::native()),
-            _ => None,
-        }
-    }
-
-    /// Auto-detect the best backend for the current environment
-    pub fn auto_detect() -> Self {
-        Self::native()
-    }
 }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -36,8 +36,7 @@ pub mod tray; // System tray support
 pub mod window_manager; // Multi-window support
 
 // Public exports
-#[allow(unused_imports)]
-pub use backend::{BackendType, WebViewBackend};
+pub use backend::BackendType;
 pub use config::{
     NewWindowMode, TrayConfig, TrayMenuItem, TrayMenuItemType, WebViewBuilder, WebViewConfig,
 };


### PR DESCRIPTION
## Summary

Removes dead code from `src/webview/backend/mod.rs`:

1. **Dead `BackendType` enum** (29 lines) — a single-variant enum (`Native`) that was never meaningfully used. The canonical multi-variant `BackendType` from `auroraview-core` (`Wry`, `WebView2`, `WKWebView`, `WebKitGTK`) was already re-exported as `CoreBackendType`.

2. **Dead `WebViewBackend` trait alias** (4 lines) — a passthrough to `PyBindingsBackend` with zero consumers outside its own module.

## Changes

| File | Change |
|------|--------|
| `src/webview/backend/mod.rs` | Remove dead `BackendType` enum + `WebViewBackend` alias; rename `CoreBackendType` re-export to `BackendType` |
| `src/webview/mod.rs` | Simplify re-export: `pub use backend::BackendType` (was `{BackendType, WebViewBackend}` with `#[allow(unused_imports)]`) |
| `Cargo.lock` | Sync workspace versions |

## Verification

- `cargo check` ✅
- `cargo clippy --all-features` ✅  
- `cargo hakari verify` ✅
- All pre-commit hooks passed

## Impact

- **Net: -36 lines** of dead code removed
- No runtime behavior change
- `backend::BackendType` now resolves directly to `auroraview_core::backend::BackendType` (the proper multi-variant enum)
- Compile test in `src/lib.rs::test_webview_submodules` continues to work unchanged