### PR TITLE
refactor(cli): deduplicate normalize_url and rewrite_html_for_custom_protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,6 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
- "url",
  "urlencoding",
  "webview2-com 0.39.1",
  "windows 0.62.2",

--- a/crates/auroraview-cli/Cargo.toml
+++ b/crates/auroraview-cli/Cargo.toml
@@ -57,7 +57,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # URL handling
-url = "2.5"
 urlencoding = "2.1"
 regex = "1.11"
 

--- a/crates/auroraview-cli/src/cli/run.rs
+++ b/crates/auroraview-cli/src/cli/run.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use tao::event_loop::{ControlFlow, EventLoop};
 use wry::{WebContext, WebViewBuilder as WryWebViewBuilder};
 
+use auroraview_core::cli::rewrite_html_for_custom_protocol;
+
 use crate::{get_webview_data_dir, load_window_icon, normalize_url, protocol_handlers};
 
 /// Arguments for the 'run' subcommand
@@ -50,79 +52,6 @@ pub struct RunArgs {
     /// Keep window always on top
     #[arg(long)]
     pub always_on_top: bool,
-}
-
-/// Rewrite HTML to use auroraview:// protocol for relative paths
-fn rewrite_html_for_custom_protocol(html: &str) -> String {
-    use regex::Regex;
-
-    let mut result = html.to_string();
-
-    // Helper function to check if a path is relative (not absolute URL or data URI)
-    fn is_relative_path(path: &str) -> bool {
-        !path.starts_with("http://")
-            && !path.starts_with("https://")
-            && !path.starts_with("data:")
-            && !path.starts_with("//") // Protocol-relative URLs
-            && !path.starts_with("auroraview://") // Already rewritten
-    }
-
-    // Rewrite link href - match any href attribute
-    let link_re = Regex::new(r#"<link\s+([^>]*)href="([^"]+)""#).unwrap();
-    result = link_re
-        .replace_all(&result, |caps: &regex::Captures| {
-            let attrs = &caps[1];
-            let path = &caps[2];
-            if is_relative_path(path) {
-                format!(r#"<link {}href="auroraview://{}""#, attrs, path)
-            } else {
-                caps[0].to_string()
-            }
-        })
-        .to_string();
-
-    // Rewrite script src
-    let script_re = Regex::new(r#"<script\s+([^>]*)src="([^"]+)""#).unwrap();
-    result = script_re
-        .replace_all(&result, |caps: &regex::Captures| {
-            let attrs = &caps[1];
-            let path = &caps[2];
-            if is_relative_path(path) {
-                format!(r#"<script {}src="auroraview://{}""#, attrs, path)
-            } else {
-                caps[0].to_string()
-            }
-        })
-        .to_string();
-
-    // Rewrite img src
-    let img_re = Regex::new(r#"<img\s+([^>]*)src="([^"]+)""#).unwrap();
-    result = img_re
-        .replace_all(&result, |caps: &regex::Captures| {
-            let attrs = &caps[1];
-            let path = &caps[2];
-            if is_relative_path(path) {
-                format!(r#"<img {}src="auroraview://{}""#, attrs, path)
-            } else {
-                caps[0].to_string()
-            }
-        })
-        .to_string();
-
-    // Rewrite CSS url()
-    let css_url_re = Regex::new(r#"url\(["']?([^"':)]+)["']?\)"#).unwrap();
-    result = css_url_re
-        .replace_all(&result, |caps: &regex::Captures| {
-            let path = &caps[1];
-            if is_relative_path(path) {
-                format!(r#"url("auroraview://{}")"#, path)
-            } else {
-                caps[0].to_string()
-            }
-        })
-        .to_string();
-
-    result
 }
 
 /// Detect assets root directory based on browser save patterns

--- a/crates/auroraview-cli/src/lib.rs
+++ b/crates/auroraview-cli/src/lib.rs
@@ -33,19 +33,10 @@ pub fn load_window_icon_from_bytes(png_bytes: &[u8]) -> Option<tao::window::Icon
     tao::window::Icon::from_rgba(rgba, width, height).ok()
 }
 
-/// Normalize URL by adding https:// prefix if missing
+/// Normalize URL by adding https:// prefix if missing.
+///
+/// Delegates to [`auroraview_core::cli::normalize_url`] and converts the error
+/// to [`anyhow::Error`] for convenience.
 pub fn normalize_url(url_str: &str) -> anyhow::Result<String> {
-    use anyhow::Context;
-    use url::Url;
-
-    // If it already has a scheme, validate and return
-    if url_str.contains("://") {
-        let url = Url::parse(url_str).with_context(|| format!("Invalid URL: {}", url_str))?;
-        return Ok(url.to_string());
-    }
-
-    // Add https:// prefix for URLs without scheme
-    let with_scheme = format!("https://{}", url_str);
-    let url = Url::parse(&with_scheme).with_context(|| format!("Invalid URL: {}", url_str))?;
-    Ok(url.to_string())
+    auroraview_core::cli::normalize_url(url_str).map_err(|e| anyhow::anyhow!("{}", e))
 }


### PR DESCRIPTION
## Summary

Deduplicate two functions that had identical implementations across `auroraview-cli` and `auroraview-core`.

## Changes

### 1. `normalize_url` deduplication
- **Before**: `auroraview-cli/src/lib.rs` had its own `normalize_url` implementation (using `anyhow::Context` + `url::Url::parse`), duplicating the logic in `auroraview_core::cli::url_utils::normalize_url`
- **After**: `auroraview-cli::normalize_url` now delegates to `auroraview_core::cli::normalize_url` and converts the `UrlError` to `anyhow::Error`
- All existing call sites (`cli/run.rs`, `packed/webview.rs`) and tests continue to work unchanged

### 2. `rewrite_html_for_custom_protocol` deduplication
- **Before**: `auroraview-cli/src/cli/run.rs` had a local copy of `rewrite_html_for_custom_protocol` that **recompiled 4 `Regex::new()` patterns on every call**
- **After**: Uses `auroraview_core::cli::rewrite_html_for_custom_protocol` which uses `LazyLock` static patterns (compiled once)
- This also fixes a subtle behavioral difference: the core version handles `./` prefix normalization and anchor links (`#`) correctly

### 3. Dependency cleanup
- Removed direct `url` crate dependency from `auroraview-cli` (now only used transitively via `auroraview-core`)

## Impact

- **-89 lines** of duplicated code, **+7 lines** of delegation
- Minor runtime improvement: regex patterns are now compiled once (LazyLock) instead of on every call
- Single source of truth for URL normalization and HTML rewriting logic

## Verification

- `cargo check --workspace` passes
- `cargo clippy -p auroraview-cli -- -D warnings` passes
- `cargo test -p auroraview-cli` - all 42 tests pass
- `cargo hakari verify` passes