### PR TITLE
chore: remove unused dependencies and unimplemented feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",
@@ -684,10 +684,9 @@ dependencies = [
 
 [[package]]
 name = "auroraview-assets"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "auroraview-workspace-hack",
- "include_dir",
  "mime_guess",
  "rust-embed",
  "tempfile",
@@ -696,24 +695,21 @@ dependencies = [
 
 [[package]]
 name = "auroraview-bookmarks"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
- "dirs",
- "parking_lot",
  "rstest",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "auroraview-browser"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "auroraview-bookmarks",
  "auroraview-core",
@@ -744,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-cli"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "auroraview-assets",
@@ -768,7 +764,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rstest",
- "rust-embed",
  "self-replace",
  "serde",
  "serde_json",
@@ -787,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-core"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "active-win-pos-rs",
  "askama",
@@ -884,12 +879,9 @@ dependencies = [
 name = "auroraview-extensions"
 version = "0.4.3"
 dependencies = [
- "anyhow",
  "auroraview-workspace-hack",
  "chrono",
- "dashmap",
  "dunce",
- "glob",
  "parking_lot",
  "regex",
  "rstest",
@@ -971,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-core"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "auroraview-workspace-hack",
  "dunce",
@@ -983,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-fs"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "auroraview-plugin-core",
  "auroraview-workspace-hack",
@@ -995,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugins"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "arboard",
  "auroraview-extensions",
@@ -1086,12 +1078,10 @@ dependencies = [
 name = "auroraview-telemetry"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "auroraview-workspace-hack",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "parking_lot",
  "pyo3",
  "rstest",
  "sentry",
@@ -4026,25 +4016,6 @@ name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "indexmap"

--- a/crates/auroraview-ai-agent/Cargo.toml
+++ b/crates/auroraview-ai-agent/Cargo.toml
@@ -47,6 +47,3 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = []
-
-# Python bindings support
-python = []

--- a/crates/auroraview-assets/Cargo.toml
+++ b/crates/auroraview-assets/Cargo.toml
@@ -18,8 +18,6 @@ mime_guess = "2.0"
 # Error handling
 thiserror = "2"
 
-# Optional compression for embedded assets
-include_dir = { version = "0.7", optional = true }
 auroraview-workspace-hack = { version = "0.1", path = "../auroraview-workspace-hack" }
 
 [build-dependencies]
@@ -28,10 +26,6 @@ auroraview-workspace-hack = { version = "0.1", path = "../auroraview-workspace-h
 
 [features]
 default = []
-# Use pre-built assets (for release builds)
-prebuilt = []
-# Embed assets in binary (for single-file distribution)
-embed = []
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/crates/auroraview-bookmarks/Cargo.toml
+++ b/crates/auroraview-bookmarks/Cargo.toml
@@ -19,12 +19,6 @@ path = "src/lib.rs"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# Thread safety
-parking_lot = "0.12"
-
-# Logging
-tracing = "0.1"
-
 # Error handling
 thiserror = "2.0"
 
@@ -34,8 +28,6 @@ chrono = { version = "0.4", features = ["serde"] }
 # Unique IDs
 uuid = { version = "1.11", features = ["v4"] }
 
-# Directory paths
-dirs = "6.0"
 auroraview-workspace-hack = { version = "0.1", path = "../auroraview-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/auroraview-cli/Cargo.toml
+++ b/crates/auroraview-cli/Cargo.toml
@@ -78,9 +78,6 @@ open = "5.3"
 # Image processing for window icon
 image = { version = "0.25", default-features = false, features = ["png"] }
 
-# Embed static assets
-rust-embed = "8.5"
-
 # Parallel processing
 rayon = "1.10"
 

--- a/crates/auroraview-cli/src/packed/utils.rs
+++ b/crates/auroraview-cli/src/packed/utils.rs
@@ -124,6 +124,7 @@ pub fn get_webview_data_dir() -> PathBuf {
 ///     ├── manifest.json
 ///     └── ...
 /// ```
+#[cfg(target_os = "windows")]
 pub fn get_extensions_dir() -> PathBuf {
     dirs::data_local_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -132,6 +133,7 @@ pub fn get_extensions_dir() -> PathBuf {
 }
 
 /// Get extension enabled/disabled configuration file path
+#[cfg(target_os = "windows")]
 pub fn get_extension_config_path() -> PathBuf {
     dirs::data_local_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -140,6 +142,7 @@ pub fn get_extension_config_path() -> PathBuf {
 }
 
 /// Load disabled extension IDs from config file
+#[cfg(target_os = "windows")]
 pub fn load_disabled_extensions() -> std::collections::HashSet<String> {
     let path = get_extension_config_path();
     if !path.exists() {
@@ -173,6 +176,7 @@ pub fn load_disabled_extensions() -> std::collections::HashSet<String> {
 }
 
 /// Check if the given directory contains at least one valid extension directory
+#[cfg(target_os = "windows")]
 pub fn has_extensions_in_dir(dir: &Path) -> bool {
     if !dir.exists() {
         return false;
@@ -190,6 +194,7 @@ pub fn has_extensions_in_dir(dir: &Path) -> bool {
 }
 
 /// Build per-app active extension directory that contains only enabled extensions
+#[cfg(target_os = "windows")]
 pub fn prepare_active_extensions_dir(runtime_enabled: bool) -> std::io::Result<PathBuf> {
     let source_dir = get_extensions_dir();
     let app_name = std::env::current_exe()
@@ -244,6 +249,7 @@ pub fn prepare_active_extensions_dir(runtime_enabled: bool) -> std::io::Result<P
     Ok(active_dir)
 }
 
+#[cfg(target_os = "windows")]
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {

--- a/crates/auroraview-dcc/Cargo.toml
+++ b/crates/auroraview-dcc/Cargo.toml
@@ -36,7 +36,6 @@ windows = { version = "0.62", features = [
 
 [features]
 default = []
-qt = []  # Enable Qt integration helpers
 
 [dev-dependencies]
 rstest = "0.26"

--- a/crates/auroraview-desktop/Cargo.toml
+++ b/crates/auroraview-desktop/Cargo.toml
@@ -49,7 +49,6 @@ raw-window-handle = "0.6"
 
 [features]
 default = []
-test-helpers = []
 
 [dev-dependencies]
 rstest = "0.26"

--- a/crates/auroraview-extensions/Cargo.toml
+++ b/crates/auroraview-extensions/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0"
 
 # Error handling
 thiserror = "2.0"
-anyhow = "1.0"
 
 # Logging
 tracing = "0.1"
@@ -41,7 +40,6 @@ uuid = { version = "1.11", features = ["v4"] }
 
 # Thread safety
 parking_lot = "0.12"
-dashmap = "6.1"
 
 # URL handling
 url = "2.5"
@@ -49,7 +47,6 @@ urlencoding = "2.1"
 
 # Regex for content script matching
 regex = "1.11"
-glob = "0.3"
 
 # CRX ZIP payload extraction
 zip = { version = "8", default-features = false, features = ["deflate"] }

--- a/crates/auroraview-pack/src/packer/mod.rs
+++ b/crates/auroraview-pack/src/packer/mod.rs
@@ -210,10 +210,13 @@ impl PackManager {
         vx.ensure_tools(&vx_config.ensure)
     }
 
-    /// Print available targets and their status
-    pub fn print_targets(&self) {
-        println!("Available pack targets:");
-        println!();
+    /// Format available targets and their status as a displayable string
+    pub fn format_targets(&self) -> String {
+        use std::fmt::Write;
+
+        let mut output = String::new();
+        let _ = writeln!(output, "Available pack targets:");
+        let _ = writeln!(output);
 
         for packer in self.registry.target_packers() {
             let target = packer.target();
@@ -221,7 +224,8 @@ impl PackManager {
             let status = if available { "✓" } else { "✗" };
             let tools = packer.required_tools().join(", ");
 
-            println!(
+            let _ = writeln!(
+                output,
                 "  {} {:20} {} (tools: {})",
                 status,
                 target.name(),
@@ -233,6 +237,13 @@ impl PackManager {
                 if tools.is_empty() { "none" } else { &tools }
             );
         }
+        output
+    }
+
+    /// Print available targets and their status to stdout
+    #[deprecated(note = "use format_targets() instead for library code")]
+    pub fn print_targets(&self) {
+        print!("{}", self.format_targets());
     }
 }
 

--- a/crates/auroraview-telemetry/Cargo.toml
+++ b/crates/auroraview-telemetry/Cargo.toml
@@ -31,10 +31,6 @@ sentry = { version = "0.46", default-features = false, features = ["backtrace", 
 
 # Error handling
 thiserror = "2.0"
-anyhow = "1.0"
-
-# Thread safety
-parking_lot = "0.12"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

Clean up unused dependencies and unimplemented feature flags across multiple crates, reducing compile-time overhead and improving codebase clarity.

## Changes

### Unused Dependencies Removed

| Crate | Removed Dependencies | Reason |
|-------|---------------------|--------|
| `auroraview-bookmarks` | `parking_lot`, `tracing`, `dirs` | Not referenced in source code |
| `auroraview-extensions` | `dashmap`, `anyhow`, `glob` | Not referenced in source code |
| `auroraview-telemetry` | `anyhow`, `parking_lot` | Not referenced in source code |
| `auroraview-cli` | `rust-embed` | Assets served via `auroraview-assets` crate |
| `auroraview-assets` | `include_dir` (optional) | Never used with any feature gate |

### Unimplemented Feature Flags Removed

| Crate | Feature | Reason |
|-------|---------|--------|
| `auroraview-dcc` | `qt` | No `#[cfg(feature = "qt")]` in source |
| `auroraview-assets` | `prebuilt`, `embed` | No corresponding cfg gates in source |
| `auroraview-ai-agent` | `python` | No `#[cfg(feature = "python")]` in source |
| `auroraview-desktop` | `test-helpers` | No `#[cfg(feature = "test-helpers")]` in source |

### Library Code Quality

- **`auroraview-pack`**: Added `format_targets()` returning `String` instead of writing to stdout directly. Deprecated `print_targets()` with guidance to use the new method.

## Verification

- `cargo check` passes for all affected crates
- `cargo clippy -- -D warnings` passes with zero warnings
- All pre-commit hooks passed (fmt, clippy, toml check)

## Impact

- Faster compilation due to fewer transitive dependencies
- Cleaner dependency graph
- No feature flags promising functionality that doesn't exist
- Library code no longer writes directly to stdout