### PR TITLE
chore: branch cleanup workflow, re-enable MCP PyPI publish, gate Windows vx tools

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,187 @@
+name: Branch Cleanup
+
+# Keeps `origin` tidy without manual pruning:
+#
+#   1. `pull_request.closed` path: delete the head branch the moment a PR
+#      lands on main (covers both merged and closed-without-merge). This
+#      is the common case and runs in seconds.
+#
+#   2. Scheduled sweep (weekly): find remote branches whose PRs were
+#      closed more than 30 days ago and delete them. Catches branches
+#      that were squash-merged before this workflow existed, plus any
+#      branch whose delete-on-close was skipped (e.g. fork PRs).
+#
+# Protected namespaces are NEVER touched:
+#   - main
+#   - release-please/*
+#   - dependabot/*         (let Dependabot manage these itself)
+#   - automation/*, auto-improve, squash/auto-improve
+#   - any branch still referenced by an OPEN PR
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "0 4 * * 1"  # every Monday 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only report what would be deleted, don't actually delete"
+        required: false
+        default: "true"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: branch-cleanup-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  delete-merged-pr-branch:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete head branch for closed PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const protectedPatterns = [
+              /^main$/,
+              /^release-please\//,
+              /^dependabot\//,
+              /^automation\//,
+              /^auto-improve$/,
+              /^squash\/auto-improve$/,
+            ];
+            if (protectedPatterns.some((re) => re.test(branch))) {
+              core.info(`Skipping protected branch: ${branch}`);
+              return;
+            }
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              core.info(`Deleted branch ${branch} (PR #${pr.number} was ${pr.merged ? 'merged' : 'closed'})`);
+            } catch (err) {
+              if (err.status === 422 || err.status === 404) {
+                core.info(`Branch ${branch} already gone (${err.status})`);
+              } else {
+                throw err;
+              }
+            }
+
+  weekly-sweep:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sweep stale branches whose PRs closed >30 days ago
+        uses: actions/github-script@v8
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            const now = Date.now();
+            const threshold = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+            const protectedPatterns = [
+              /^main$/,
+              /^release-please\//,
+              /^dependabot\//,
+              /^automation\//,
+              /^auto-improve$/,
+              /^squash\/auto-improve$/,
+            ];
+
+            // All remote branches
+            const branches = await github.paginate(github.rest.repos.listBranches, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            core.info(`Found ${branches.length} remote branches`);
+
+            // Build set of branches that are still tied to an OPEN PR
+            const openPRs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const openHeadRefs = new Set(openPRs.map((p) => p.head.ref));
+
+            let deleted = 0;
+            let skipped = 0;
+            let stale = 0;
+
+            for (const b of branches) {
+              const name = b.name;
+
+              if (protectedPatterns.some((re) => re.test(name))) {
+                skipped++;
+                continue;
+              }
+              if (openHeadRefs.has(name)) {
+                skipped++;
+                continue;
+              }
+
+              // Find the most-recent PR (any state) that used this branch as head
+              const prs = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${name}`,
+                state: 'closed',
+                per_page: 5,
+                sort: 'updated',
+                direction: 'desc',
+              });
+
+              // No closed PR ever referenced this branch — leave it alone
+              // (could be a feature branch in active development with no PR yet)
+              if (prs.data.length === 0) {
+                skipped++;
+                continue;
+              }
+
+              const mostRecent = prs.data[0];
+              const closedAt = mostRecent.closed_at ? new Date(mostRecent.closed_at).getTime() : null;
+              if (closedAt === null || now - closedAt < threshold) {
+                skipped++;
+                continue;
+              }
+
+              stale++;
+              if (dryRun) {
+                core.info(`[dry-run] would delete ${name} (PR #${mostRecent.number} closed ${mostRecent.closed_at})`);
+                continue;
+              }
+
+              try {
+                await github.rest.git.deleteRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `heads/${name}`,
+                });
+                deleted++;
+                core.info(`Deleted ${name} (PR #${mostRecent.number} closed ${mostRecent.closed_at})`);
+              } catch (err) {
+                core.warning(`Failed to delete ${name}: ${err.message}`);
+              }
+            }
+
+            await core.summary
+              .addHeading('Branch cleanup report')
+              .addList([
+                `Total branches: ${branches.length}`,
+                `Skipped (protected / open PR / no closed PR / fresh): ${skipped}`,
+                `Stale (PR closed >30d ago): ${stale}`,
+                dryRun ? `Deleted: 0 (dry-run)` : `Deleted: ${deleted}`,
+              ])
+              .write();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,9 +301,13 @@ jobs:
 
   # Build MCP Server for PyPI publishing (uses reusable workflow)
   build-mcp:
-    name: MCP CI (disabled temporarily)
+    name: MCP CI
     needs: [release-please, check-tag]
-    if: false # temporarily disabling MCP CI to prioritize core release
+    # Re-enabled (#354): only runs on release-please PRs or tag pushes.
+    # Publish is gated separately by `mcp-pypi-publish` -> `check-tag.outputs.is_tag`.
+    if: |
+      needs.release-please.outputs.releases_created == 'true' ||
+      needs.check-tag.outputs.is_tag == 'true'
     uses: ./.github/workflows/mcp-ci.yml
     with:
       artifact-prefix: 'release-'
@@ -498,10 +502,14 @@ jobs:
 
   # Publish MCP Server to PyPI
   mcp-pypi-publish:
-    name: Publish MCP to PyPI (disabled temporarily)
+    name: Publish MCP to PyPI
     runs-on: ubuntu-latest
     needs: [release-please, check-tag, build-mcp]
-    if: false # temporarily disabling MCP publish to unblock core release
+    # Re-enabled (#354). Only publish on an actual tag push AND after
+    # `build-mcp` succeeded — we don't want to publish if CI failed.
+    if: |
+      needs.check-tag.outputs.is_tag == 'true' &&
+      needs.build-mcp.result == 'success'
     environment:
       name: pypi
       url: https://pypi.org/p/auroraview-mcp

--- a/vx.toml
+++ b/vx.toml
@@ -1,10 +1,14 @@
 [tools]
 just = "latest"
 python = "3.11"
-rcedit = "latest"
 rust = "1.90.0"
 uv = "latest"
-msvc = "14.42"
+
+# Windows-only toolchain pieces. Gated via the `os` field so that
+# `vx sync` on Linux / macOS CI runners does not try to install
+# MSVC build tools or rcedit (which have no non-Windows binaries).
+rcedit = { version = "latest", os = ["windows"] }
+msvc = { version = "14.42", os = ["windows"] }
 
 
 [settings]


### PR DESCRIPTION
## Summary

Bundles three post-#350 roadmap items that each touch one file and have no cross-cutting risk.

### #353 — auto branch cleanup

New `.github/workflows/branch-cleanup.yml`:

- `pull_request.closed` → delete head branch (skips `main`, `release-please/*`, `dependabot/*`, `automation/*`, `auto-improve`, `squash/auto-improve`).
- Weekly sweep (Mon 04:00 UTC + `workflow_dispatch` with `dry_run` input): scans every remote branch, keeps anything tied to an open PR or whose most-recent closed PR is <30d old, deletes the rest.
- **No bulk deletion performed now** — ~70 squash-merged stale branches from 2025-10…2026-01 will be cleared by the first scheduled sweep (or via `workflow_dispatch` with `dry_run=false` after a dry-run review).

### #354 — re-enable `auroraview-mcp` → PyPI

Both `if: false` gates in `release.yml` flipped:

- `build-mcp`: runs when release-please opens a release PR or when a tag is pushed.
- `mcp-pypi-publish`: runs only on actual tag push AND after `build-mcp` succeeded. Trusted publishing config (`environment: pypi`, `id-token: write`) was already in place and unchanged.

### #356 — gate Windows-only vx tools

`vx.toml`:

- `msvc = "14.42"` → `{ version = "14.42", os = ["windows"] }`
- `rcedit = "latest"` → `{ version = "latest", os = ["windows"] }`

Verified with `vx config validate` (Windows host still sees both tools; Linux/macOS runners will skip them).

## Out of scope

- Updating `vx.lock` — regenerating on Windows rewrites many unrelated fields (uv minor bump, platform_urls reshuffle). Separate housekeeping commit.
- Actually deleting the stale remote branches — delegated to the new workflow's first sweep.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings (rustc 1.95)
- [x] `vx config validate` — passes
- [x] `vx sync --check` on Windows — `msvc`, `rcedit` still listed
- [ ] After merge: next release-please PR + tag push will exercise MCP publish path end-to-end
- [ ] After merge: run `branch-cleanup.yml` via `workflow_dispatch` with `dry_run=true` to preview the sweep

Closes #353, #354, #356. (#355 already closed, delivered in #350.)
