### PR TITLE
feat(mcp): add crates/auroraview-mcp adapter skeleton over CDP (Phase 2 of #364)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "auroraview-mcp"
+version = "0.4.19"
+dependencies = [
+ "auroraview-workspace-hack",
+ "base64",
+ "dcc-mcp-protocols",
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tracing",
+]
+
+[[package]]
 name = "auroraview-notifications"
 version = "0.4.19"
 dependencies = [
@@ -980,7 +997,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "url",
 ]
@@ -2153,6 +2170,28 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "dcc-mcp-protocols"
+version = "0.13.2"
+source = "git+https://github.com/loonghao/dcc-mcp-core.git?tag=v0.13.2#d163d76c6dc763f731ee132795e0c3fb25c7741d"
+dependencies = [
+ "dcc-mcp-utils",
+ "parking_lot",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dcc-mcp-utils"
+version = "0.13.2"
+source = "git+https://github.com/loonghao/dcc-mcp-core.git?tag=v0.13.2#d163d76c6dc763f731ee132795e0c3fb25c7741d"
+dependencies = [
+ "dirs",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "debugid"
@@ -8002,6 +8041,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -8366,6 +8417,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ members = [
     "crates/auroraview-pack",
     # Telemetry (OpenTelemetry-based observability)
     "crates/auroraview-telemetry",
+    # MCP / dcc-mcp-core adapter crate (Epic #364)
+    "crates/auroraview-mcp",
     # Workspace dependency unification
     "crates/auroraview-workspace-hack",
 ]

--- a/crates/auroraview-mcp/Cargo.toml
+++ b/crates/auroraview-mcp/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "auroraview-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "AuroraView adapter crate for dcc-mcp-core — exposes an AuroraView instance as a DccAdapter over CDP WebSocket"
+keywords = ["auroraview", "mcp", "dcc", "cdp", "webview"]
+categories = ["api-bindings", "gui"]
+
+[lib]
+name = "auroraview_mcp"
+
+[dependencies]
+# dcc-mcp-core protocols (DccAdapter trait + types). Pinned to v0.13.2; not
+# yet published to crates.io, so depend via git.
+dcc-mcp-protocols = { git = "https://github.com/loonghao/dcc-mcp-core.git", tag = "v0.13.2" }
+
+# Async runtime + WebSocket for CDP transport.
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "sync", "time", "macros"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+
+# JSON for CDP messages.
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Base64 decoding of Page.captureScreenshot responses.
+base64 = "0.22"
+
+# HTTP client for CDP target discovery (`http://<host>:<port>/json/version`).
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# Error handling + logging.
+thiserror = "2.0"
+tracing = "0.1"
+
+# Workspace dep unification (same as every other crate in this workspace).
+auroraview-workspace-hack = { version = "0.1", path = "../auroraview-workspace-hack" }
+
+[dev-dependencies]
+tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }

--- a/crates/auroraview-mcp/src/cdp.rs
+++ b/crates/auroraview-mcp/src/cdp.rs
@@ -1,0 +1,194 @@
+//! Minimal async CDP (Chrome DevTools Protocol) client for the AuroraView adapter.
+//!
+//! Only implements the handful of commands the adapter skeleton needs:
+//!
+//! - `Browser.getVersion` — health check.
+//! - `Page.captureScreenshot` — viewport capture.
+//!
+//! Target discovery (`GET http://host:port/json/version`) is handled via
+//! `reqwest`, then we open a single WebSocket to the browser-level endpoint.
+//!
+//! The client is deliberately tiny: one request in flight at a time, no
+//! event subscription plumbing. That is enough to back `DccSnapshot` and
+//! `DccConnection::health_check`.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    connect_async, tungstenite::protocol::Message, MaybeTlsStream, WebSocketStream,
+};
+
+/// Errors produced by the CDP client.
+#[derive(Debug, thiserror::Error)]
+pub enum CdpError {
+    #[error("HTTP target discovery failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("WebSocket error: {0}")]
+    WebSocket(#[from] tokio_tungstenite::tungstenite::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("base64 decode error: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("CDP returned an error response: {0}")]
+    Remote(String),
+    #[error("unexpected CDP response: missing `{0}` field")]
+    MalformedResponse(&'static str),
+    #[error("CDP connection closed before a response was received")]
+    ConnectionClosed,
+    #[error("CDP request timed out after {0:?}")]
+    Timeout(Duration),
+}
+
+/// `http://<host>:<port>/json/version` response shape (subset we care about).
+#[derive(Debug, Deserialize)]
+struct VersionInfo {
+    #[serde(rename = "webSocketDebuggerUrl")]
+    web_socket_debugger_url: String,
+    #[serde(rename = "Browser", default)]
+    browser: String,
+    #[serde(rename = "Protocol-Version", default)]
+    protocol_version: String,
+}
+
+/// Static information returned by `Browser.getVersion`.
+#[derive(Debug, Clone)]
+pub struct BrowserVersion {
+    pub product: String,
+    pub protocol_version: String,
+}
+
+/// Async CDP client holding a single browser-level WebSocket.
+pub struct CdpClient {
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    next_id: u64,
+    /// Endpoint URL we connected to, kept around for diagnostics.
+    pub endpoint: String,
+}
+
+impl CdpClient {
+    /// Connect to a CDP endpoint on `http://host:port`.
+    ///
+    /// Performs `GET /json/version` to discover the browser-level WebSocket
+    /// debugger URL, then opens a WebSocket to it.
+    pub async fn connect(http_endpoint: &str) -> Result<Self, CdpError> {
+        let url = format!("{}/json/version", http_endpoint.trim_end_matches('/'));
+        let info: VersionInfo = reqwest::get(&url).await?.error_for_status()?.json().await?;
+        tracing::debug!(
+            browser = %info.browser,
+            protocol = %info.protocol_version,
+            ws = %info.web_socket_debugger_url,
+            "resolved CDP target"
+        );
+
+        let (ws, _resp) = connect_async(&info.web_socket_debugger_url).await?;
+        Ok(Self {
+            ws,
+            next_id: 1,
+            endpoint: info.web_socket_debugger_url,
+        })
+    }
+
+    /// Send a CDP command and wait for its matching response.
+    ///
+    /// Any events received while waiting are dropped — the skeleton adapter
+    /// is request/response only.
+    pub async fn call(
+        &mut self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, CdpError> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let request = json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        self.ws.send(Message::Text(request.to_string())).await?;
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(CdpError::Timeout(timeout));
+            }
+            let msg = match tokio::time::timeout(remaining, self.ws.next()).await {
+                Ok(Some(m)) => m?,
+                Ok(None) => return Err(CdpError::ConnectionClosed),
+                Err(_) => return Err(CdpError::Timeout(timeout)),
+            };
+
+            let text = match msg {
+                Message::Text(t) => t,
+                Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {
+                    continue
+                }
+                Message::Close(_) => return Err(CdpError::ConnectionClosed),
+            };
+
+            let value: Value = serde_json::from_str(&text)?;
+            // Events have no `id` — skip them in this minimal client.
+            match value.get("id").and_then(Value::as_u64) {
+                Some(resp_id) if resp_id == id => {
+                    if let Some(err) = value.get("error") {
+                        return Err(CdpError::Remote(err.to_string()));
+                    }
+                    return value
+                        .get("result")
+                        .cloned()
+                        .ok_or(CdpError::MalformedResponse("result"));
+                }
+                _ => continue,
+            }
+        }
+    }
+
+    /// `Browser.getVersion` — lightweight liveness probe.
+    pub async fn get_version(&mut self, timeout: Duration) -> Result<BrowserVersion, CdpError> {
+        let result = self.call("Browser.getVersion", json!({}), timeout).await?;
+        Ok(BrowserVersion {
+            product: result
+                .get("product")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned(),
+            protocol_version: result
+                .get("protocolVersion")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned(),
+        })
+    }
+
+    /// `Page.captureScreenshot` — returns raw image bytes.
+    ///
+    /// `format` is passed straight through (`"png"` / `"jpeg"` / `"webp"`).
+    /// Callers are expected to pre-validate it.
+    pub async fn capture_screenshot(
+        &mut self,
+        format: &str,
+        timeout: Duration,
+    ) -> Result<Vec<u8>, CdpError> {
+        let params = json!({
+            "format": format,
+            "captureBeyondViewport": false,
+            "fromSurface": true,
+        });
+        let result = self.call("Page.captureScreenshot", params, timeout).await?;
+        let data_b64 = result
+            .get("data")
+            .and_then(Value::as_str)
+            .ok_or(CdpError::MalformedResponse("data"))?;
+        let bytes = <base64::engine::general_purpose::GeneralPurpose as base64::Engine>::decode(
+            &base64::engine::general_purpose::STANDARD,
+            data_b64,
+        )?;
+        Ok(bytes)
+    }
+}

--- a/crates/auroraview-mcp/src/lib.rs
+++ b/crates/auroraview-mcp/src/lib.rs
@@ -1,0 +1,385 @@
+//! AuroraView adapter for `dcc-mcp-core`.
+//!
+//! This crate exposes a running AuroraView instance as a
+//! [`DccAdapter`](dcc_mcp_protocols::adapters::DccAdapter), so that
+//! `dcc-mcp-server` (from `dcc-mcp-core v0.13+`) can discover it via
+//! `FileRegistry` and call into it over the Chrome DevTools Protocol.
+//!
+//! # Status
+//!
+//! **Skeleton / Phase 2 of Epic #364.** The crate currently implements:
+//!
+//! - [`CdpAuroraViewAdapter::info`] — static [`DccInfo`] for `dcc_type = "auroraview"`.
+//! - [`CdpAuroraViewAdapter::capabilities`] — advertises
+//!   `snapshot = true`, `has_embedded_python = false`,
+//!   [`BridgeKind::WebSocket`], and a WebSocket `bridge_endpoint`.
+//! - [`DccConnection`] — `connect` / `disconnect` / `health_check` against
+//!   the CDP browser-level WebSocket.
+//! - [`DccSnapshot`] — `capture_viewport` via `Page.captureScreenshot`.
+//!
+//! Deliberately **not yet wired**:
+//!
+//! - [`DccScriptEngine`] — blocked on upstream
+//!   [`dcc-mcp-core#222`](https://github.com/loonghao/dcc-mcp-core/issues/222)
+//!   adding `ScriptLanguage::JavaScript`. Once that lands, `Runtime.evaluate`
+//!   becomes a one-screen implementation.
+//! - [`DccSceneInfo`] / scene-manager / hierarchy / transform — AuroraView is
+//!   a web view, not a 3D DCC, so these stay `None` unless a skill explicitly
+//!   opts in.
+//!
+//! # Wiring
+//!
+//! The `auroraview-cli run` path (Phase 3 of #364) is responsible for opening
+//! a CDP debug port and constructing a [`CdpAuroraViewAdapter`] pointing at
+//! it, then handing that adapter to `dcc-mcp-server`'s registry.
+
+pub mod cdp;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use dcc_mcp_protocols::adapters::{
+    BridgeKind, CaptureResult, DccAdapter, DccCapabilities, DccConnection, DccError, DccErrorCode,
+    DccInfo, DccResult, DccSnapshot, ScriptLanguage,
+};
+use tokio::runtime::{Handle, Runtime};
+
+use crate::cdp::{CdpClient, CdpError};
+
+/// Default timeout for any single CDP call the adapter makes.
+const DEFAULT_CDP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Configuration for wiring the adapter to a running AuroraView CDP port.
+#[derive(Debug, Clone)]
+pub struct CdpAdapterConfig {
+    /// `http://host:port` of the AuroraView CDP devtools HTTP endpoint.
+    pub http_endpoint: String,
+    /// `ws://host:port` form, used purely as the `bridge_endpoint` value we
+    /// advertise via [`DccCapabilities`]. This is what `dcc-mcp-server` will
+    /// surface in its `ServiceEntry.extras` for other skills to consume.
+    pub ws_endpoint: String,
+    /// Optional window title for observability.
+    pub window_title: Option<String>,
+    /// Platform string (e.g. `"windows"`, `"linux"`, `"macos"`). Defaults to
+    /// the value of `std::env::consts::OS` when [`CdpAuroraViewAdapter::new`]
+    /// is called.
+    pub platform: String,
+    /// PID of the AuroraView process, if known; 0 otherwise.
+    pub pid: u32,
+    /// AuroraView version string (typically `CARGO_PKG_VERSION`).
+    pub version: String,
+}
+
+impl CdpAdapterConfig {
+    /// Build a config pointing at the standard AuroraView CDP layout:
+    /// `http://127.0.0.1:<port>` and `ws://127.0.0.1:<port>`.
+    #[must_use]
+    pub fn localhost(port: u16, version: impl Into<String>) -> Self {
+        Self {
+            http_endpoint: format!("http://127.0.0.1:{port}"),
+            ws_endpoint: format!("ws://127.0.0.1:{port}"),
+            window_title: None,
+            platform: std::env::consts::OS.to_owned(),
+            pid: std::process::id(),
+            version: version.into(),
+        }
+    }
+}
+
+/// Adapter that speaks to a running AuroraView instance over CDP.
+pub struct CdpAuroraViewAdapter {
+    config: CdpAdapterConfig,
+    info: DccInfo,
+    /// Tokio runtime used to block on async CDP calls from the sync trait
+    /// methods. We lazily create an owned runtime iff there is no ambient
+    /// runtime we can reuse.
+    runtime: Arc<AdapterRuntime>,
+    /// Live CDP client, populated by [`DccConnection::connect`].
+    client: Mutex<Option<CdpClient>>,
+}
+
+impl std::fmt::Debug for CdpAuroraViewAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CdpAuroraViewAdapter")
+            .field("config", &self.config)
+            .field("info", &self.info)
+            .field(
+                "connected",
+                &self.client.lock().map(|g| g.is_some()).unwrap_or(false),
+            )
+            .finish()
+    }
+}
+
+enum AdapterRuntime {
+    /// We are inside a running tokio runtime — reuse it.
+    Borrowed(Handle),
+    /// No ambient runtime; we own a multi-thread runtime.
+    Owned(Runtime),
+}
+
+impl AdapterRuntime {
+    fn current_or_owned() -> std::io::Result<Self> {
+        if let Ok(handle) = Handle::try_current() {
+            Ok(Self::Borrowed(handle))
+        } else {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_io()
+                .enable_time()
+                .worker_threads(1)
+                .thread_name("auroraview-mcp")
+                .build()?;
+            Ok(Self::Owned(rt))
+        }
+    }
+
+    fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
+        match self {
+            Self::Borrowed(h) => {
+                // `Handle::block_on` panics if we're currently on a runtime
+                // thread, so we offload to a temporary blocking task.
+                tokio::task::block_in_place(|| h.block_on(fut))
+            }
+            Self::Owned(rt) => rt.block_on(fut),
+        }
+    }
+}
+
+impl CdpAuroraViewAdapter {
+    /// Create a new adapter. Does not yet establish a CDP connection —
+    /// callers must invoke [`DccConnection::connect`] (or let the MCP
+    /// framework do so) before calling snapshot/script-engine APIs.
+    pub fn new(config: CdpAdapterConfig) -> std::io::Result<Self> {
+        let info = DccInfo {
+            dcc_type: "auroraview".to_owned(),
+            version: config.version.clone(),
+            // AuroraView itself does not embed Python; the host DCC might.
+            python_version: None,
+            platform: config.platform.clone(),
+            pid: config.pid,
+            metadata: {
+                let mut m = std::collections::HashMap::new();
+                if let Some(t) = &config.window_title {
+                    m.insert("window_title".to_owned(), t.clone());
+                }
+                m.insert("cdp_http".to_owned(), config.http_endpoint.clone());
+                m.insert("cdp_ws".to_owned(), config.ws_endpoint.clone());
+                m
+            },
+        };
+        Ok(Self {
+            config,
+            info,
+            runtime: Arc::new(AdapterRuntime::current_or_owned()?),
+            client: Mutex::new(None),
+        })
+    }
+
+    fn map_cdp_err(kind: DccErrorCode, err: CdpError) -> DccError {
+        DccError {
+            code: kind,
+            message: err.to_string(),
+            details: None,
+            recoverable: matches!(
+                kind,
+                DccErrorCode::ConnectionFailed
+                    | DccErrorCode::Timeout
+                    | DccErrorCode::NotResponding
+            ),
+        }
+    }
+
+    fn with_client<T>(&self, f: impl FnOnce(&mut CdpClient) -> DccResult<T>) -> DccResult<T> {
+        let mut guard = self.client.lock().map_err(|_| DccError {
+            code: DccErrorCode::Internal,
+            message: "adapter mutex poisoned".to_owned(),
+            details: None,
+            recoverable: false,
+        })?;
+        let client = guard.as_mut().ok_or(DccError {
+            code: DccErrorCode::ConnectionFailed,
+            message: "CDP client is not connected".to_owned(),
+            details: None,
+            recoverable: true,
+        })?;
+        f(client)
+    }
+}
+
+impl DccConnection for CdpAuroraViewAdapter {
+    fn connect(&mut self) -> DccResult<()> {
+        let endpoint = self.config.http_endpoint.clone();
+        let fut = CdpClient::connect(&endpoint);
+        let client = self
+            .runtime
+            .block_on(fut)
+            .map_err(|e| Self::map_cdp_err(DccErrorCode::ConnectionFailed, e))?;
+        *self.client.lock().map_err(|_| DccError {
+            code: DccErrorCode::Internal,
+            message: "adapter mutex poisoned".to_owned(),
+            details: None,
+            recoverable: false,
+        })? = Some(client);
+        Ok(())
+    }
+
+    fn disconnect(&mut self) -> DccResult<()> {
+        if let Ok(mut guard) = self.client.lock() {
+            guard.take();
+        }
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.client.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    fn health_check(&self) -> DccResult<u64> {
+        self.with_client(|client| {
+            let start = std::time::Instant::now();
+            self.runtime
+                .block_on(client.get_version(DEFAULT_CDP_TIMEOUT))
+                .map_err(|e| Self::map_cdp_err(DccErrorCode::NotResponding, e))?;
+            Ok(start.elapsed().as_millis() as u64)
+        })
+    }
+}
+
+impl DccSnapshot for CdpAuroraViewAdapter {
+    fn capture_viewport(
+        &self,
+        _viewport: Option<&str>,
+        _width: Option<u32>,
+        _height: Option<u32>,
+        format: &str,
+    ) -> DccResult<CaptureResult> {
+        match format {
+            "png" | "jpeg" | "webp" => {}
+            other => {
+                return Err(DccError {
+                    code: DccErrorCode::InvalidInput,
+                    message: format!("unsupported capture format: {other}"),
+                    details: None,
+                    recoverable: false,
+                });
+            }
+        }
+        self.with_client(|client| {
+            let bytes = self
+                .runtime
+                .block_on(client.capture_screenshot(format, DEFAULT_CDP_TIMEOUT))
+                .map_err(|e| Self::map_cdp_err(DccErrorCode::Internal, e))?;
+            // Resolution re-negotiation (Page.setDeviceMetricsOverride) is a
+            // later-phase concern; for now we just report what CDP returned
+            // and leave width/height as 0 ("unknown").
+            Ok(CaptureResult {
+                data: bytes,
+                width: 0,
+                height: 0,
+                format: format.to_owned(),
+                viewport: Some("auroraview".to_owned()),
+            })
+        })
+    }
+}
+
+impl DccAdapter for CdpAuroraViewAdapter {
+    fn info(&self) -> &DccInfo {
+        &self.info
+    }
+
+    fn capabilities(&self) -> DccCapabilities {
+        DccCapabilities {
+            // AuroraView is JS-first. Until dcc-mcp-core#222 lands a
+            // `ScriptLanguage::JavaScript` variant, we advertise the empty
+            // set rather than lie about supporting Python/MEL.
+            script_languages: Vec::<ScriptLanguage>::new(),
+            scene_info: false,
+            snapshot: true,
+            undo_redo: false,
+            progress_reporting: false,
+            file_operations: false,
+            selection: false,
+            scene_manager: false,
+            transform: false,
+            render_capture: false,
+            hierarchy: false,
+            has_embedded_python: false,
+            bridge_kind: Some(BridgeKind::WebSocket),
+            bridge_endpoint: Some(self.config.ws_endpoint.clone()),
+            extensions: Default::default(),
+        }
+    }
+
+    fn as_connection(&mut self) -> Option<&mut dyn DccConnection> {
+        Some(self)
+    }
+
+    fn as_script_engine(&self) -> Option<&dyn dcc_mcp_protocols::adapters::DccScriptEngine> {
+        // See the top-of-file note on dcc-mcp-core#222.
+        None
+    }
+
+    fn as_scene_info(&self) -> Option<&dyn dcc_mcp_protocols::adapters::DccSceneInfo> {
+        None
+    }
+
+    fn as_snapshot(&self) -> Option<&dyn DccSnapshot> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_carries_cdp_metadata() {
+        let cfg = CdpAdapterConfig::localhost(9222, "0.4.19");
+        let adapter = CdpAuroraViewAdapter::new(cfg).expect("build adapter");
+        let info = adapter.info();
+        assert_eq!(info.dcc_type, "auroraview");
+        assert_eq!(info.version, "0.4.19");
+        assert_eq!(
+            info.metadata.get("cdp_http").unwrap(),
+            "http://127.0.0.1:9222"
+        );
+        assert_eq!(info.metadata.get("cdp_ws").unwrap(), "ws://127.0.0.1:9222");
+    }
+
+    #[test]
+    fn capabilities_advertise_websocket_bridge() {
+        let cfg = CdpAdapterConfig::localhost(9222, "0.4.19");
+        let adapter = CdpAuroraViewAdapter::new(cfg).expect("build adapter");
+        let caps = adapter.capabilities();
+        assert!(caps.snapshot);
+        assert!(!caps.has_embedded_python);
+        assert!(matches!(caps.bridge_kind, Some(BridgeKind::WebSocket)));
+        assert_eq!(caps.bridge_endpoint.as_deref(), Some("ws://127.0.0.1:9222"));
+        assert!(
+            caps.script_languages.is_empty(),
+            "JavaScript variant still blocked on dcc-mcp-core#222"
+        );
+    }
+
+    #[test]
+    fn disconnected_snapshot_returns_connection_error() {
+        let cfg = CdpAdapterConfig::localhost(9222, "0.4.19");
+        let adapter = CdpAuroraViewAdapter::new(cfg).expect("build adapter");
+        assert!(!adapter.is_connected());
+        let err = adapter
+            .capture_viewport(None, None, None, "png")
+            .expect_err("must fail without a live connection");
+        assert_eq!(err.code, DccErrorCode::ConnectionFailed);
+    }
+
+    #[test]
+    fn snapshot_rejects_unknown_format() {
+        let cfg = CdpAdapterConfig::localhost(9222, "0.4.19");
+        let adapter = CdpAuroraViewAdapter::new(cfg).expect("build adapter");
+        let err = adapter
+            .capture_viewport(None, None, None, "bmp")
+            .expect_err("bmp is not supported");
+        assert_eq!(err.code, DccErrorCode::InvalidInput);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of Epic #364. Introduces `crates/auroraview-mcp`, a new Rust crate
that exposes a running AuroraView instance as a
`dcc-mcp-protocols::adapters::DccAdapter`, so that `dcc-mcp-server`
(dcc-mcp-core v0.13.2) can discover it via `FileRegistry` and drive it
over the Chrome DevTools Protocol.

### What this PR lands

- `CdpAuroraViewAdapter` implementing `DccAdapter`, `DccConnection`, and
  `DccSnapshot`.
- `DccCapabilities` advertising `BridgeKind::WebSocket` + `bridge_endpoint`
  (`ws://host:port`), `has_embedded_python = false`, `snapshot = true`.
- Tiny async CDP client (`cdp.rs`) on `tokio-tungstenite` covering only
  `Browser.getVersion` (health_check) and `Page.captureScreenshot`
  (capture_viewport). Target resolution via `GET /json/version`.
- Runtime shim that reuses the ambient tokio runtime via
  `block_in_place` when available, and owns a minimal multi-thread
  runtime otherwise, so the sync adapter traits work from any context.
- 4 unit tests: info metadata, capabilities advertisement, disconnected
  snapshot error, unsupported format error.

### Explicitly deferred

- `DccScriptEngine` is `None` until
  [dcc-mcp-core#222](https://github.com/loonghao/dcc-mcp-core/issues/222)
  adds `ScriptLanguage::JavaScript`. `script_languages` is intentionally
  empty rather than claim Python/MEL we cannot actually execute.
- Scene / transform / hierarchy / render-capture adapters: AuroraView is
  a web surface, not a 3D DCC. Will be exposed only via SKILL.md packages
  (Phase 4, #368).
- The CLI `run` integration that spawns/joins `dcc-mcp-server` and
  registers `ServiceEntry { cdp_port, url, window_title }` — that is
  Phase 3, tracked in #367.

### Dependency note

`dcc-mcp-protocols` is not yet on crates.io, so it is pulled as a git
dependency pinned to tag `v0.13.2`. Swap to a crates.io version once
upstream publishes.

## Test plan

- [x] `cargo fmt -p auroraview-mcp`
- [x] `cargo check --workspace --lib` (whole workspace still builds)
- [x] `cargo test -p auroraview-mcp --lib` — 4 tests pass
- [x] `cargo clippy -p auroraview-mcp --all-targets -- -D warnings`
- [ ] End-to-end integration against a live AuroraView + `dcc-mcp-server`
      — deferred to Phase 3 (#367) where the wiring actually exists.

Refs #364 #366
