### PR TITLE
fix(python): skip core event registration when _core is None in packed mode

### DIFF
--- a/python/auroraview/core/mixins/events.py
+++ b/python/auroraview/core/mixins/events.py
@@ -285,8 +285,13 @@ class WebViewEventMixin:
         conn_id = self.signals.custom.connect(event_str, callback)
         logger.debug(f"Registered callback for event: {event_str} (conn_id: {conn_id})")
 
-        # Register with core
-        self._core.on(event_str, callback)
+        # Register with core (if available - packed mode may not have core)
+        if self._core is not None:
+            self._core.on(event_str, callback)
+        else:
+            logger.debug(
+                f"Skipped core registration for event {event_str} (packed mode or core not available)"
+            )
 
         return conn_id
 


### PR DESCRIPTION
## Summary
Fix `AttributeError: 'NoneType' object has no attribute 'on'` when launching Gallery in packed mode.

In packed mode, `_core.pyd` is not available and `self._core` is set to `None`. The `_setup_lifecycle_events()` method uses `@self.on()` decorators which invoke `register_callback()`, and that unconditionally called `self._core.on()`, causing the Python backend to crash on startup.

## Changes
- Guard `self._core.on()` in `register_callback()` with a `None` check
- Log a debug message when core registration is skipped

## Impact
- `python/auroraview/core/mixins/events.py` only
- Affects packed mode (Gallery, bundled apps) where `_core` is absent
- Normal mode with `_core` present is unchanged

## Verification
- `ruff check python/` passes
- `pytest`: 45 passed (1 pre-existing failure unrelated to this change)

## Risk
Low. The fix is a minimal guard clause; Python-side event subscription (signals + `_event_handlers`) still works correctly in packed mode.