### PR TITLE
docs: refactor AGENTS.md as progressive map and add AI-facing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,125 +1,72 @@
-# AGENTES
+# AuroraView — AI Agent 导航图
 
-面向本仓库 AI/自动化代理与贡献者的执行约定。
+> 渐进式披露入口。先读此图，再按任务类型跳转到对应深度文档。
 
-## 1. 命令与环境约束
+## 项目一句话
 
-- 所有工具命令统一通过 `vx` 执行，不直接调用裸命令。
-- 任务编排统一使用 `justfile`，入口为 `vx just <task>`。
-- 常用命令示例：
-  - `vx just build`
-  - `vx just test`
-  - `vx just lint`
-  - `vx python`
-  - `vx uv`
-  - `vx cargo`
-  - `vx git`
-  - `vx npm` / `vx npx`
+AuroraView 是一个面向 DCC（Maya/Houdini/Blender 等）的轻量 WebView 框架，Rust 核心 + PyO3 Python 绑定，Windows 优先使用 WebView2 嵌入 Qt 宿主。
 
-## 2. 开发与校验流程（建议）
+---
 
-在提交前，优先按以下顺序执行：
+## 按任务快速导航
 
-1. `vx just format`
-2. `vx just lint`
-3. `vx just test`
-4. `vx just build`
+| 你的任务 | 先去这里 | 说明 |
+|---|---|---|
+| **了解整体架构与约定** | `llms.txt` | AI 友好的核心用法索引（5 分钟速读） |
+| **写代码 / 改逻辑 / Review** | `.codebuddy/rules/` | 8 个按主题划分的执行约定，是 CI 与本地开发的真实约束 |
+| **查完整 API 与架构细节** | `llms-full.txt` | 完整用法索引，包含所有 API 签名与模块说明 |
+| **给人看的详细文档** | `docs/` | VitePress 站点，含 DCC 集成指南、API 文档、RFC |
+| **了解打包/发布/CI** | `.codebuddy/rules/08-architecture.mdc` | 项目结构、auroraview-pack 打包系统、CI 流程 |
+| **前端 JS ↔ Python 通信** | `.codebuddy/rules/05-frontend-api.mdc` + `.codebuddy/rules/07-event-system.mdc` | `window.auroraview` 协议与事件分发 |
+| **Python 层接口** | `.codebuddy/rules/06-python-api.mdc` | `AuroraView` 基类、`bind_call`、`emit` |
+| **测试策略** | `.codebuddy/rules/03-testing.mdc` | rstest / pytest、CI 矩阵、性能基线 |
 
-要求本地与 CI 使用同一套 `just` 入口，避免“本地通过、CI 失败”的流程分叉。
+---
 
-## 3. 兼容性与实现约束
+## 30 秒项目速览
 
-- Python 代码需兼容 **Python 3.7+**（DCC 环境优先）。
-- 优先使用成熟依赖与业内标准方案，避免重复造轮子。
-- Rust 测试尽量放在各 crate 的 `tests/` 目录，优先采用 `rstest`。
+- **命令入口**：所有工具命令通过 `vx` 执行，任务编排通过 `vx just <task>`。
+- **兼容底线**：Python 3.7+，不引入第三方 Python 依赖（仅一个 `.pyd`）。
+- **测试入口**：`vx just test`（统一本地与 CI）。
+- **构建入口**：`vx just build`。
+- **技术栈**：Rust（windows-rs / webview2-com / PyO3）+ Python ABI3 wheel + TypeScript SDK。
+- **事件循环**：Qt 宿主负责事件循环，Rust 不接管消息泵。
 
-## 4. WebView / DCC 项目约定（摘要）
+---
 
-- Windows 优先 WebView2 后端（Rust + `webview2-com`）。
-- DCC 嵌入场景由 Qt 宿主负责事件循环，Rust 不接管 Qt 消息泵。
-- 前端统一使用 `window.auroraview` 命名空间与桥接协议。
+## 目录结构地图
 
-## 5. E2E 测试与可视化验证
-
-本项目使用 **ProofShot** + **agent-browser** 进行 E2E 测试和自我迭代。
-
-### 工具链
-
-| 工具 | 职责 | 安装 |
-|------|------|------|
-| [ProofShot](https://github.com/AmElmo/proofshot) | 会话录制、截图、错误收集、PR 证据上传 | `npm install -g proofshot` |
-| [agent-browser](https://github.com/vercel-labs/agent-browser) | 无头浏览器控制（CDP） | 随 ProofShot 一同安装 |
-
-### 常用命令
-
-```bash
-# 安装工具链
-vx just e2e-install
-
-# 快速 E2E 验证（打包 Gallery + CDP 测试 + 截图证据）
-vx just e2e-proofshot
-
-# 自我迭代循环（检测 → 分析 → 修复 → 重新验证）
-vx just e2e-iterate
-
-# 上传验证证据到 PR
-vx just e2e-pr
-
-# 手动探索（交互式快照）
-vx just e2e-snapshot
+```
+├── crates/                 Rust crates
+│   ├── auroraview-core/    核心协议与 WebView 后端抽象
+│   ├── auroraview-cli/     CLI 工具与 Skills 分发
+│   └── ...
+├── python/auroraview/      Python 包（AuroraView 基类、DCC 宿主层）
+├── packages/               TS/JS 包（前端 SDK）
+│   └── auroraview-sdk/
+├── gallery/                Gallery 演示应用（E2E 验证基准）
+├── examples/               示例代码
+├── docs/                   面向开发者的详细文档（VitePress）
+├── submodules/             Git submodules（pack / protect / signals / extensions）
+└── .codebuddy/rules/       AI 代理执行约定（真相之源）
 ```
 
-### 自我迭代流程
+---
 
-Agent 在开发过程中应遵循如下 E2E 自我迭代循环：
+## 关键约定速查（不可违背）
 
-1. **构建** → `vx just gallery-pack-debug`
-2. **启动** → `vx just e2e-start`（启动 Gallery + 等待 CDP）
-3. **验证** → `vx just e2e-snapshot` / `vx just e2e-screenshot`
-4. **分析** → 审查截图、控制台错误、SUMMARY.md
-5. **修复** → 根据发现修改代码
-6. **重复** → 回到步骤 1，直到所有检查通过
-7. **记录** → 将非显而易见的发现记录到 `.learnings/`
+1. **禁止裸命令**：永远 `vx just build`，不要直接 `cargo build` 或 `pytest`。
+2. **禁止代码内 emoji**：保持专业风格。
+3. **函数命名**：简短精炼，使用行业标准术语，避免 `optimized`、`fixed` 等词。
+4. **测试位置**：Rust 集成测试放在各 crate 的 `tests/` 目录，使用 `rstest`；不要内联单元测试。
+5. **Skills 真相源**：官方 Skills 在 `crates/auroraview-cli/skills/<name>/SKILL.md`；`.cursor/skills/`、`.claude/skills/` 只是本地镜像，禁止复制。
+6. **JS 事件统一**：Rust 层事件分发统一使用 `window.auroraview.trigger()`，不混用原生 `CustomEvent`。
 
-### E2E 验证清单
+---
 
-- Gallery 无控制台错误启动
-- 页面导航正常
-- `auroraview.api.*` 调用无 rejection
-- 事件系统 (`auroraview.on/emit`) 工作正常
-- 视觉回归检查通过 (`proofshot diff`)
+## 外部参考
 
-## 6. Skills 分发（AuroraView 自有技能）
-
-AuroraView 的官方技能（如 `qt-to-auroraview-migration`）内嵌在 `auroraview-cli` 二进制里，单一源为
-`crates/auroraview-cli/skills/<skill-name>/SKILL.md`。Agent 不要从仓库里直接复制 `.cursor/skills/`、
-`.claude/skills/` 等位置的副本 —— 那些是各工具自举生成的本地镜像，不是真相之源。
-
-```bash
-# 列出当前二进制内置的技能
-auroraview-cli skills list
-
-# 安装到某个 agent 工具的约定目录（项目内）
-auroraview-cli skills install --target claude
-auroraview-cli skills install --target cursor
-auroraview-cli skills install --target all          # 覆盖所有已知工具
-
-# 安装到任意路径
-auroraview-cli skills install --path ./some/dir
-
-# 安装到用户全局（~/.claude/skills/ 等）
-auroraview-cli skills install --target cursor --global
-
-# 打印某工具的解析路径而不实际写入
-auroraview-cli skills path --target cursor
-```
-
-新增技能只需往 `crates/auroraview-cli/skills/` 丢一个 `<name>/SKILL.md`，`include_dir!` 在构建时自动打包，
-不需要改任何 Rust 代码。镜像目录（`.claude/skills/` 等）已加入 `.gitignore`，避免各工具的 bootstrap 重新污染仓库。
-
-## 7. 提交与 PR 约定
-
-- 提交前确保关键检查通过（lint/test/build）。
-- PR 描述需包含：改动目标、影响范围、验证方式、风险点。
-- 若改动涉及文档或流程，请同步更新相关说明文件。
-- UI 变更的 PR 建议附带 ProofShot 证据（`vx just e2e-pr`）。
+- **仓库**: https://github.com/loonghao/auroraview
+- **PyPI**: https://pypi.org/project/auroraview
+- **CHANGELOG**: `./CHANGELOG.md`
+- **CONTRIBUTING**: `./CONTRIBUTING.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Claude Agent Guide — AuroraView
+
+> 本项目所有 AI 代理的约定与导航入口统一在 `AGENTS.md`。
+> 请先阅读 `AGENTS.md`，再按任务类型跳转到对应的深度文档（`.codebuddy/rules/`、`llms.txt`、`docs/` 等）。
+
+## 快速链接
+
+- [AGENTS.md](./AGENTS.md) — 渐进式披露导航图（必读）
+- [llms.txt](./llms.txt) — 核心 AI 用法索引
+- [llms-full.txt](./llms-full.txt) — 完整用法索引
+- [.codebuddy/rules/](./.codebuddy/rules/) — 执行约定与约束

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,11 @@
+# Gemini Agent Guide — AuroraView
+
+> 本项目所有 AI 代理的约定与导航入口统一在 `AGENTS.md`。
+> 请先阅读 `AGENTS.md`，再按任务类型跳转到对应的深度文档（`.codebuddy/rules/`、`llms.txt`、`docs/` 等）。
+
+## 快速链接
+
+- [AGENTS.md](./AGENTS.md) — 渐进式披露导航图（必读）
+- [llms.txt](./llms.txt) — 核心 AI 用法索引
+- [llms-full.txt](./llms-full.txt) — 完整用法索引
+- [.codebuddy/rules/](./.codebuddy/rules/) — 执行约定与约束

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -15,7 +15,7 @@ AuroraView is built with a modular, backend-agnostic architecture that supports 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                     Python API Layer                        │
-│  (WebView, QtWebView)                                      │
+│  (create_webview, WebView, QtWebView, AuroraView)          │
 └─────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -33,15 +33,16 @@ AuroraView is built with a modular, backend-agnostic architecture that supports 
                 ┌───────────┴───────────┐
                 ▼                       ▼
 ┌───────────────────────┐   ┌───────────────────────┐
-│   Native Backend      │   │    Qt Backend         │
-│  (Platform-specific)  │   │  (Qt integration)     │
+│   Native Backend      │   │    Qt Host Layer      │
+│  (Standalone / HWND)  │   │  (Qt widget container)│
 └───────────────────────┘   └───────────────────────┘
                 │                       │
-                ▼                       ▼
-┌───────────────────────┐   ┌───────────────────────┐
-│   Wry WebView         │   │  Qt WebEngine         │
-│  (WebView2/WebKit)    │   │  (QWebEngineView)     │
-└───────────────────────┘   └───────────────────────┘
+                └───────────┬───────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│              System WebView Engines                         │
+│   Windows: WebView2  │  macOS: WKWebView  │  Linux: WebKitGTK │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ## Core Components
@@ -141,9 +142,9 @@ The `NativeBackend` uses platform-specific APIs for window embedding:
 - `Child`: WS_CHILD style (same-thread parenting required)
 - `Owner`: GWLP_HWNDPARENT (safe for cross-thread usage)
 
-### Qt Backend
+### Qt Host Layer
 
-The `QtBackend` integrates with Qt's widget system for seamless DCC integration.
+The Qt integration layer embeds the system WebView as a child window inside a Qt QWidget container. Qt handles the event loop and window chrome, while the actual rendering is delegated to the platform's native WebView engine (WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux).
 
 ## Integration Modes
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -15,7 +15,7 @@ AuroraView 采用模块化、后端无关的架构设计，支持多种窗口集
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                     Python API 层                           │
-│  (WebView, QtWebView)                                      │
+│  (create_webview, WebView, QtWebView, AuroraView)          │
 └─────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -33,15 +33,16 @@ AuroraView 采用模块化、后端无关的架构设计，支持多种窗口集
                 ┌───────────┴───────────┐
                 ▼                       ▼
 ┌───────────────────────┐   ┌───────────────────────┐
-│   原生后端            │   │    Qt 后端            │
-│  (平台特定)           │   │  (Qt 集成)            │
+│   原生后端            │   │    Qt 宿主层          │
+│  (Standalone / HWND)  │   │  (Qt widget 容器)     │
 └───────────────────────┘   └───────────────────────┘
                 │                       │
-                ▼                       ▼
-┌───────────────────────┐   ┌───────────────────────┐
-│   Wry WebView         │   │  Qt WebEngine         │
-│  (WebView2/WebKit)    │   │  (QWebEngineView)     │
-└───────────────────────┘   └───────────────────────┘
+                └───────────┬───────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│              系统 WebView 引擎                               │
+│   Windows: WebView2  │  macOS: WKWebView  │  Linux: WebKitGTK │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ## 核心组件
@@ -110,7 +111,7 @@ pub trait WebViewBackend {
     fn window(&self) -> Option<&tao::window::Window>;
     fn process_events(&self) -> bool;
     fn run_event_loop_blocking(&mut self);
-    
+
     // 通用操作的默认实现
     fn load_url(&mut self, url: &str) -> Result<(), Box<dyn std::error::Error>>;
     fn load_html(&mut self, html: &str) -> Result<(), Box<dyn std::error::Error>>;
@@ -132,6 +133,10 @@ pub trait WebViewBackend {
 **Windows 模式**:
 - `Child`: WS_CHILD 样式（需要同线程父窗口）
 - `Owner`: GWLP_HWNDPARENT（跨线程安全）
+
+### Qt 宿主层
+
+Qt 集成层将系统 WebView 作为子窗口嵌入到 Qt QWidget 容器中。Qt 负责事件循环和窗口外壳，实际渲染委托给平台原生 WebView 引擎（Windows 上为 WebView2，macOS 上为 WKWebView，Linux 上为 WebKitGTK）。
 
 ## 集成模式
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,646 @@
+# AuroraView
+
+> A lightweight WebView framework for DCC (Digital Content Creation) software, built with Rust and Python bindings. Perfect for Maya, 3ds Max, Houdini, Blender, and more.
+
+AuroraView provides a modern web-based UI solution for professional DCC applications like Maya, 3ds Max, Houdini, Blender, Photoshop, and Unreal Engine. On Windows it prioritizes a WebView2 backend (Rust + webview2-com) embedded into Qt hosts, with PyO3 bindings and maturin packaging.
+
+- **Package**: `pip install auroraview`
+- **Python**: 3.7+
+- **Platforms**: Windows, macOS, Linux
+- **License**: MIT
+- **Repository**: https://github.com/loonghao/auroraview
+- **PyPI**: https://pypi.org/project/auroraview/
+
+## Agent Quick Start
+
+All commands go through `vx`. The task runner is `just`.
+
+```bash
+vx just build          # Build the project
+vx just test           # Run tests (Rust + Python)
+vx just lint           # Run linting (clippy + ruff)
+vx just format         # Format code
+```
+
+Local development and CI use the same `just` tasks to avoid drift.
+
+## Key Constraints
+
+- Python code must be compatible with **Python 3.7+** (DCC environments).
+- The Python package ships as a **single `.pyd`** (PyO3 + maturin, abi3) with **zero third-party Python dependencies**.
+- Rust integration tests live in each crate's `tests/` directory and use **`rstest`**.
+- Do not use bare commands; always use `vx just <task>`.
+- Avoid words like `optimized` or `fixed` in code and function names.
+- Do not invent custom wheels; prefer mature, standard crates.
+
+## Tech Stack
+
+- **Windows**: WebView2 (Chromium Edge) + Rust (windows-rs, webview2-com), embedded as child HWND into Qt containers; UI operations run on STA/UI thread.
+- **Cross-DCC**: Maya/3ds Max/Houdini/Nuke use Qt hosts; Blender uses floating tool windows.
+- **Python**: PyO3 + maturin, ABI3 wheel (CPython 3.7–3.13). Zero third-party Python deps.
+- **Concurrency**: Qt owns the event loop; Rust marshals UI work to the creation thread via task queues. Rust does not take over the message pump.
+- **Standalone**: Retains wry/tao mode for development; may migrate to Win32 + WebView2 top-level window later.
+- **Tools**: `uv` for Python deps, `just` for task running, `vx` as the unified tool wrapper.
+- **Core versions**: Rust 1.90+, PyO3 0.27 (abi3), Wry 0.54, Tao 0.34.
+
+## Project Structure
+
+```
+crates/
+  auroraview-core/      Core protocols, RPC, event bus, session management
+  auroraview-cli/       CLI tools and embedded Skills
+  auroraview-plugins/   Plugin system
+python/auroraview/      Python package (AuroraView base class, DCC host layer)
+packages/auroraview-sdk/  TypeScript frontend SDK
+gallery/                Gallery demo app (E2E validation baseline)
+examples/               Code examples
+docs/                   VitePress documentation
+submodules/             Git submodules (pack, protect, signals, extensions)
+.codebuddy/rules/       AI agent execution conventions (source of truth)
+```
+
+## Quick Start
+
+### Installation
+
+```bash
+pip install auroraview
+```
+
+With Qt support (for Maya, Houdini, Nuke):
+
+```bash
+pip install auroraview[qt]
+```
+
+### Recommended API: create_webview
+
+```python
+from auroraview import create_webview
+
+# 1. Standalone window
+webview = create_webview(url="http://localhost:3000")
+webview.show()
+
+# 2. Qt integration (Maya, Houdini, Nuke)
+webview = create_webview(parent=maya_main_window(), url="http://localhost:3000")
+webview.show()
+
+# 3. HWND integration (Unreal Engine)
+webview = create_webview(parent=unreal_hwnd, url="http://localhost:3000")
+webview.show()
+```
+
+### Legacy APIs (still supported)
+
+```python
+from auroraview import AuroraView
+
+webview = AuroraView(url="http://localhost:3000")
+webview.show()
+```
+
+```python
+from auroraview import QtWebView
+
+webview = QtWebView(parent=maya_main_window(), url="http://localhost:3000")
+webview.show()
+```
+
+## Core API Reference
+
+### create_webview Parameters
+
+All WebView types share these common parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| parent | QWidget/int/None | None | Parent widget or HWND |
+| title | str | "AuroraView" | Window title |
+| width | int | 800 | Window width |
+| height | int | 600 | Window height |
+| url | str | None | URL to load |
+| html | str | None | HTML content to load |
+| debug | bool | True | Enable DevTools (F12) |
+| context_menu | bool | True | Enable right-click menu |
+| frame | bool | True | Show window frame |
+| transparent | bool | False | Transparent background |
+| background_color | str | None | Background color |
+| asset_root | str | None | Custom protocol root |
+| allow_file_protocol | bool | False | Enable file:// |
+| mode | str | "auto" | Embedding mode ("auto", "child", "owner") |
+
+### WebView Class Methods
+
+#### Content Loading
+
+```python
+webview.load_url("http://localhost:3000")
+webview.load_html("<h1>Hello World</h1>")
+webview.load_file("path/to/index.html")
+```
+
+#### JavaScript Execution
+
+```python
+webview.eval_js("console.log('Hello from Python')")
+webview.eval_js_async(
+    "document.title",
+    callback=lambda result: print(f"Title: {result}"),
+    timeout_ms=5000
+)
+```
+
+#### Window Control
+
+```python
+webview.show()
+webview.hide()
+webview.close()
+webview.move(100, 100)
+webview.resize(1024, 768)
+webview.minimize()
+webview.maximize()
+webview.restore()
+webview.toggle_fullscreen()
+webview.focus()
+webview.set_always_on_top(True)
+```
+
+## Bidirectional Communication
+
+### Python → JavaScript (Events)
+
+```python
+webview.emit("update_data", {"frame": 120, "objects": ["cube", "sphere"]})
+```
+
+JavaScript side:
+
+```javascript
+window.auroraview.on('update_data', (data) => {
+    console.log('Frame:', data.frame);
+});
+```
+
+Rust/Python events are delivered via `window.auroraview.trigger(event, data)`.
+Do not use `window.dispatchEvent(new CustomEvent(...))`.
+
+### JavaScript → Python (Events)
+
+JavaScript:
+
+```javascript
+window.auroraview.send_event('export_scene', {
+    path: '/path/to/export.fbx',
+    format: 'fbx'
+});
+```
+
+Python:
+
+```python
+@webview.on("export_scene")
+def handle_export(data):
+    print(f"Exporting to: {data['path']}")
+```
+
+### JavaScript → Python (RPC with Return Value)
+
+JavaScript:
+
+```javascript
+const result = await auroraview.api.get_hierarchy({ root: 'scene' });
+console.log(result);
+```
+
+Python:
+
+```python
+@webview.bind_call("api.get_hierarchy")
+def get_hierarchy(root=None):
+    return {"children": ["group1", "mesh_cube"], "count": 2}
+```
+
+### API Binding
+
+```python
+# Bind single method
+@webview.bind_call("api.echo")
+def echo(message: str = "") -> dict:
+    return {"message": message}
+
+# Bind all methods of an object
+class API:
+    def get_data(self) -> dict:
+        return {"items": [1, 2, 3]}
+
+    def save_item(self, name: str = "", value: int = 0) -> dict:
+        return {"ok": True, "name": name}
+
+webview.bind_api(API(), namespace="api")
+```
+
+### auroraview.call Request/Response Protocol
+
+JS → Backend message:
+- `type: "call"`
+- `id: string` — unique ID for Promise correlation
+- `method: string` — e.g., `"api.export_scene"`, `"tool.apply"`
+- `params: any` — object (kwargs), array (positional args), or single value
+
+Backend → JS response:
+- `type: "call_result"`
+- `id: string` — must match request
+- `ok: bool`
+- `result: any` on success
+- `error: { name, message, code?, data? }` on failure
+
+JS Promise semantics:
+- `ok == true` → `resolve(result)`
+- `ok == false` → `reject(error)`
+
+## JavaScript API Reference
+
+### window.auroraview
+
+```javascript
+// Call Python method (returns Promise)
+const result = await auroraview.call('api.method_name', { param: value });
+
+// Proxy shorthand
+const result = await auroraview.api.method_name({ param: value });
+
+// Invoke plugin command (returns Promise)
+const content = await auroraview.invoke('plugin:fs|read_file', { path: '/path/to/file.txt' });
+
+// Send event to Python (fire-and-forget)
+auroraview.send_event('event_name', { data: value });
+
+// Listen for Python events
+const unsubscribe = auroraview.on('event_name', (data) => {
+    console.log('Received:', data);
+});
+
+// Unsubscribe
+auroraview.off('event_name', handler);
+
+// Local JS event (does NOT reach Python)
+auroraview.trigger('local_event', data);
+```
+
+### Ready Event
+
+```javascript
+window.addEventListener('auroraviewready', () => {
+    auroraview.api.init();
+});
+```
+
+### Event Utilities
+
+```javascript
+const debouncedResize = auroraview.utils.debounce(function() {
+    console.log('Resized!');
+}, 250);
+window.addEventListener('resize', debouncedResize);
+
+const throttledScroll = auroraview.utils.throttle(function() {
+    console.log('Scrolled!');
+}, 100);
+window.addEventListener('scroll', throttledScroll);
+
+auroraview.onDebounced('resize', handler, 250);
+auroraview.onThrottled('scroll', handler, 100);
+```
+
+## DCC Integration Matrix
+
+| Software | Python | Mode | Docking |
+|---|---|---|---|
+| Maya 2025+ (Qt6/PySide6) | 3.7+ | Qt Native (QtWebView) | QDockWidget |
+| 3ds Max (Qt) | 3.7+ | Qt Native (QtWebView) | QDockWidget |
+| Houdini (PySide2/Qt5) | 3.7+ | Qt Native (QtWebView) | QDockWidget |
+| Nuke (PySide2/Qt) | 3.7+ | Qt Native (QtWebView) | Custom Panel |
+| Blender | 3.7+ | Standalone / Floating | N/A |
+| Unreal Engine | 3.7+ | HWND (AuroraView) | via HWND API |
+| Photoshop | 3.7+ | Planned | - |
+
+## Qt Integration (QtWebView)
+
+```python
+from auroraview import QtWebView
+from qtpy.QtWidgets import QDialog, QVBoxLayout
+
+dialog = QDialog(maya_main_window())
+layout = QVBoxLayout(dialog)
+
+webview = QtWebView(parent=dialog, width=800, height=600)
+layout.addWidget(webview)
+
+webview.load_url("http://localhost:3000")
+
+dialog.show()
+webview.show()
+```
+
+### WebView2 Pre-warming
+
+```python
+from auroraview.integration.qt import WebViewPool
+
+WebViewPool.prewarm()
+
+if WebViewPool.has_prewarmed():
+    print(f"Pre-warm took {WebViewPool.get_prewarm_time():.2f}s")
+```
+
+## HTML / Static Resource Loading
+
+- Inline HTML: `WebView.load_html(html)` — for simple prototypes without local assets.
+- Local site: `WebView.load_url("file:///.../index.html")` — relative paths resolved by browser from the file location.
+- DCC + Qt: `QtWebView.load_html(html)` and `QtWebView.load_url(url)` delegate to core `WebView`.
+- Custom relative paths: use `<base href="file:///.../">` in HTML; do not add `base_url` params to Python APIs.
+
+## Signals (Qt-like Pattern)
+
+```python
+from auroraview import WebView, Signal
+
+class MyTool(WebView):
+    selection_changed = Signal(list)
+    progress_updated = Signal(int, str)
+
+    def __init__(self):
+        super().__init__(title="My Tool")
+        self.selection_changed.connect(self._on_selection)
+
+    def _on_selection(self, items):
+        print(f"Selection: {items}")
+
+    def update_selection(self, items):
+        self.selection_changed.emit(items)
+```
+
+## Window Events
+
+```python
+@webview.on_shown
+def on_shown(data):
+    print("Window is now visible")
+
+@webview.on_focused
+def on_focused(data):
+    print("Window gained focus")
+
+@webview.on_resized
+def on_resized(data):
+    print(f"Window resized to {data.width}x{data.height}")
+
+@webview.on_closing
+def on_closing(data):
+    return True  # Return True to allow close, False to cancel
+```
+
+## File Drop Events
+
+```python
+from auroraview.core.events import WindowEvent
+
+@webview.on(WindowEvent.FILE_DROP)
+def on_file_drop(data):
+    for path in data['paths']:
+        print(f"Dropped: {path}")
+
+@webview.on(WindowEvent.FILE_DROP_HOVER)
+def on_file_hover(data):
+    if data['hovering']:
+        print(f"Dragging {len(data['paths'])} files over window")
+```
+
+## Custom Protocol Handler
+
+```python
+webview = WebView(title="My App", asset_root="./assets")
+
+def handle_maya_protocol(uri: str) -> dict:
+    path = uri.replace("maya://", "")
+    try:
+        with open(f"C:/maya_projects/{path}", "rb") as f:
+            return {
+                "data": f.read(),
+                "mime_type": "image/png",
+                "status": 200
+            }
+    except FileNotFoundError:
+        return {"data": b"Not Found", "mime_type": "text/plain", "status": 404}
+
+webview.register_protocol("maya", handle_maya_protocol)
+```
+
+## System Tray Support
+
+```python
+from auroraview import run_app
+
+run_app(
+    title="Background App",
+    html=my_html,
+    width=400,
+    height=300,
+    system_tray=True,
+    hide_on_close=True,
+)
+```
+
+## Floating Tool Windows
+
+```python
+from auroraview import create_webview
+
+webview = create_webview(
+    title="AI Assistant",
+    html=panel_html,
+    width=320,
+    height=400,
+    frame=False,
+    transparent=True,
+    always_on_top=True,
+    tool_window=True,
+    parent=parent_hwnd,
+    mode="owner",
+)
+webview.show()
+```
+
+## Application Packaging
+
+```bash
+# Pack a URL-based application
+auroraview-cli pack --url https://example.com --output myapp
+
+# Pack a frontend project
+auroraview-cli pack --frontend ./dist --output myapp
+
+# Pack with configuration
+auroraview-cli pack --config auroraview.pack.toml
+```
+
+Configuration example (`auroraview.pack.toml`):
+
+```toml
+[package]
+name = "my-app"
+version = "1.0.0"
+
+[app]
+title = "My Application"
+frontend_path = "./dist"
+
+[window]
+width = 1200
+height = 800
+resizable = true
+
+[bundle]
+icon = "./assets/my-app-icon.png"
+
+[bundle.platform.windows]
+console = false
+
+[python]
+entry_point = "main:main"
+include_paths = ["./backend"]
+strategy = "standalone"
+```
+
+## Command Line Interface
+
+```bash
+auroraview --url https://example.com
+auroraview --html /path/to/file.html
+auroraview --url https://example.com --title "My App" --width 1024 --height 768
+uvx auroraview --url https://example.com
+```
+
+## Testing Framework
+
+### HeadlessWebView
+
+```python
+from auroraview.testing import HeadlessWebView
+
+with HeadlessWebView.auto() as webview:
+    webview.goto("https://example.com")
+    webview.click("#button")
+    assert webview.text("#result") == "Success"
+
+with HeadlessWebView.playwright() as webview:
+    webview.load_html("<h1>Test</h1>")
+    assert webview.text("h1") == "Test"
+    webview.screenshot("test.png")
+```
+
+### Available Backends
+
+| Backend | Method | Platform | Use Case |
+|---------|--------|----------|----------|
+| Playwright | `HeadlessWebView.playwright()` | All | CI/CD |
+| Xvfb | `HeadlessWebView.virtual_display()` | Linux | Real WebView |
+| WebView2 CDP | `HeadlessWebView.webview2_cdp(url)` | Windows | Real WebView2 |
+
+### Rust Integration Tests
+
+```bash
+cargo test --test '*' --features "test-helpers"
+```
+
+Performance targets: first visible < 300ms, FPS >= 60, idle CPU <= 5%, memory increment <= 200MB.
+
+## Plugin System
+
+- **Process Plugin**: Run external processes with stdout/stderr streaming
+- **File System Plugin**: Native file operations (read, write, copy, move)
+- **Dialog Plugin**: Native file/folder dialogs and message boxes
+- **Shell Plugin**: Execute commands, open URLs, reveal in file manager
+- **Clipboard Plugin**: System clipboard read/write access
+
+## Chrome Extension API Compatibility
+
+- Storage API: `chrome.storage.local/sync/session`
+- Bookmarks API: Create, search, update, delete bookmarks
+- History API: Search and manage browsing history
+- Downloads API: Download files with progress tracking
+- Cookies API: Get, set, remove cookies
+- Notifications API: System notifications with actions
+- TTS API: Text-to-speech synthesis
+- Idle/Power API: User activity detection and power management
+
+## E2E Testing with ProofShot
+
+```bash
+vx just e2e-install        # Install toolchain
+vx just e2e-proofshot      # Quick validation
+vx just e2e-iterate        # Self-improvement loop
+vx just e2e-pr             # Upload evidence to PR
+vx just e2e-snapshot       # Manual exploration
+```
+
+Self-improvement loop:
+1. Build: `vx just gallery-pack-debug`
+2. Start: `vx just e2e-start`
+3. Verify: `vx just e2e-snapshot` / `vx just e2e-screenshot`
+4. Analyze: Review screenshots, console errors, SUMMARY.md
+5. Fix: Modify code based on findings
+6. Repeat until all checks pass
+
+## Skills Distribution
+
+Official skills are embedded in `auroraview-cli` binary:
+
+```bash
+auroraview-cli skills list
+auroraview-cli skills install --target claude
+auroraview-cli skills install --target cursor
+```
+
+Source of truth: `crates/auroraview-cli/skills/<skill-name>/SKILL.md`
+Mirror directories (`.cursor/skills/`, `.claude/skills/`) are generated locally and gitignored.
+
+## Submodules
+
+```bash
+git clone --recurse-submodules https://github.com/loonghao/auroraview.git
+git submodule update --init --recursive
+```
+
+| Submodule | Purpose |
+|-----------|---------|
+| auroraview-pack | Application packaging (overlay, compression, icons) |
+| auroraview-protect | Python bytecode encryption (X25519/AES-256-GCM) |
+| auroraview-signals | Signal/slot system for async event distribution |
+| auroraview-extensions | Chrome-style extension architecture |
+
+## Key Imports
+
+```python
+from auroraview import (
+    create_webview,
+    AuroraView,
+    QtWebView,
+    WebView,
+    Signal,
+    run_app,
+    EventTimer,
+    path_to_file_url,
+)
+```
+
+## Documentation
+
+- [AGENTS.md](https://github.com/loonghao/auroraview/blob/main/AGENTS.md): Progressive-disclosure navigation map for AI agents.
+- [llms.txt](https://github.com/loonghao/auroraview/blob/main/llms.txt): Core AI-friendly usage index.
+- [.codebuddy/rules/](https://github.com/loonghao/auroraview/tree/main/.codebuddy/rules): Execution conventions (tech stack, testing, coding guidelines, frontend API, Python API, event system, architecture).
+- [docs/guide/getting-started.md](https://github.com/loonghao/auroraview/blob/main/docs/guide/getting-started.md): Human-facing quick start.
+- [docs/guide/architecture.md](https://github.com/loonghao/auroraview/blob/main/docs/guide/architecture.md): System architecture.
+- [docs/dcc/](https://github.com/loonghao/auroraview/tree/main/docs/dcc): DCC integration guides.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,160 @@
+# AuroraView
+
+> A lightweight WebView framework for DCC (Digital Content Creation) software, built with Rust and Python bindings. Perfect for Maya, 3ds Max, Houdini, Blender, and more.
+
+AuroraView provides a modern web-based UI solution for professional DCC applications. On Windows it prioritizes a WebView2 backend (Rust + webview2-com) embedded into Qt hosts, with PyO3 bindings and maturin packaging.
+
+- **Package**: `pip install auroraview`
+- **Python**: 3.7+
+- **Platforms**: Windows, macOS, Linux
+- **License**: MIT
+- **Repository**: https://github.com/loonghao/auroraview
+
+## Agent Quick Start
+
+All commands go through `vx`. The task runner is `just`.
+
+```bash
+vx just build          # Build the project
+vx just test           # Run tests (Rust + Python)
+vx just lint           # Run linting (clippy + ruff)
+vx just format         # Format code
+```
+
+Local development and CI use the same `just` tasks to avoid drift.
+
+## Key Constraints
+
+- Python code must be compatible with **Python 3.7+** (DCC environments).
+- The Python package ships as a **single `.pyd`** (PyO3 + maturin, abi3) with **zero third-party Python dependencies**.
+- Rust integration tests live in each crate's `tests/` directory and use **`rstest`**.
+- Do not use bare commands; always use `vx just <task>`.
+- Avoid words like `optimized` or `fixed` in code and function names.
+- Do not invent custom wheels; prefer mature, standard crates.
+
+## Tech Stack
+
+- **Windows**: WebView2 (Chromium Edge) + Rust (windows-rs, webview2-com), embedded as child HWND into Qt containers; UI operations run on STA/UI thread.
+- **Cross-DCC**: Maya/3ds Max/Houdini/Nuke use Qt hosts; Blender uses floating tool windows.
+- **Python**: PyO3 + maturin, ABI3 wheel (CPython 3.7–3.13).
+- **Concurrency**: Qt owns the event loop; Rust marshals UI work to the creation thread via task queues.
+- **Standalone**: Retains wry/tao mode for development; may migrate to Win32 + WebView2 top-level window later.
+- **Tools**: `uv` for Python deps, `just` for task running, `vx` as the unified tool wrapper.
+
+## Project Structure
+
+```
+crates/
+  auroraview-core/      Core protocols, RPC, event bus, session management
+  auroraview-cli/       CLI tools and embedded Skills
+  auroraview-plugins/   Plugin system
+python/auroraview/      Python package (AuroraView base class, DCC host layer)
+packages/auroraview-sdk/  TypeScript frontend SDK
+gallery/                Gallery demo app (E2E validation baseline)
+examples/               Code examples
+docs/                   VitePress documentation
+submodules/             Git submodules (pack, protect, signals, extensions)
+.codebuddy/rules/       AI agent execution conventions (source of truth)
+```
+
+## Core API
+
+### Python: AuroraView Base Class
+
+```python
+from auroraview import AuroraView
+
+class MyTool(AuroraView):
+    def __init__(self, **kwargs):
+        super().__init__(api=self, **kwargs)
+
+    # JS calls: auroraview.api.echo({ message: "..." })
+    def echo(self, message: str) -> None:
+        self.emit("echo_result", {"message": message})
+```
+
+Constructor params:
+- `parent`: `None` for Standalone; Qt object for DCC mode.
+- `url` / `html`: Content to load.
+- `title`, `width`, `height`, `fullscreen`, `debug`.
+- `api`: Object exposed to `auroraview.api.*`.
+
+Lifecycle hooks: `on_show`, `on_hide`, `on_close`, `on_ready`.
+
+Event push: `self.emit(event_name, payload)` → triggers `auroraview.on(event_name, handler)` in JS.
+
+### JS → Python Mapping
+
+1. **`auroraview.api.*` style**
+   - Python passes `api=self` to constructor.
+   - JS: `auroraview.api.export_scene(...)` → Python `api.export_scene(...)`.
+   - `params` as list → `func(*params)`; dict → `func(**params)`.
+
+2. **Generic `auroraview.call(method, params)`**
+   - Python registers: `bind_call("tool.apply", self.apply_tool)`.
+   - JS: `auroraview.call("tool.apply", {"strength": 0.8})`.
+
+### JavaScript: window.auroraview
+
+```javascript
+// Call Python method (Promise)
+const result = await auroraview.call('api.method_name', { param: value });
+
+// Proxy shorthand
+const result = await auroraview.api.method_name({ param: value });
+
+// Subscribe to Python events
+const unsubscribe = auroraview.on('event_name', (data) => { ... });
+
+// Unsubscribe
+auroraview.off('event_name', handler);
+```
+
+Ready event: `window.addEventListener('auroraviewready', () => { ... })`.
+
+### Event Distribution (Python → JS)
+
+Rust/Python events are delivered via `window.auroraview.trigger(event, data)`.
+Do **not** use `window.dispatchEvent(new CustomEvent(...))`.
+
+```javascript
+// Standard pattern injected from Rust
+window.auroraview.trigger('event_name', data);
+```
+
+## DCC Integration Matrix
+
+| Software | Mode | Docking |
+|---|---|---|
+| Maya 2025+ (Qt6/PySide6) | Qt Native (QtWebView) | QDockWidget |
+| 3ds Max (Qt) | Qt Native (QtWebView) | QDockWidget |
+| Houdini (PySide2/Qt5) | Qt Native (QtWebView) | QDockWidget |
+| Nuke (PySide2/Qt) | Qt Native (QtWebView) | Custom Panel |
+| Blender | Standalone / Floating tool window | N/A |
+| Unreal Engine | HWND (AuroraView) | via HWND API |
+
+## HTML / Static Resource Loading
+
+- Inline HTML: `WebView.load_html(html)`.
+- Local site: `WebView.load_url("file:///.../index.html")`.
+- For custom relative paths, use `<base href="file:///.../">` in HTML; do not add `base_url` params to Python APIs.
+
+## Testing
+
+```bash
+# Rust integration tests
+cargo test --test '*' --features "test-helpers"
+
+# Python tests
+pytest tests/
+```
+
+Performance targets: first visible < 300ms, FPS ≥ 60, idle CPU ≤ 5%, memory increment ≤ 200MB.
+
+## Documentation
+
+- [AGENTS.md](https://github.com/loonghao/auroraview/blob/main/AGENTS.md): Progressive-disclosure navigation map for AI agents.
+- [.codebuddy/rules/](https://github.com/loonghao/auroraview/tree/main/.codebuddy/rules): Execution conventions (tech stack, testing, coding guidelines, frontend API, Python API, event system, architecture).
+- [docs/guide/getting-started.md](https://github.com/loonghao/auroraview/blob/main/docs/guide/getting-started.md): Human-facing quick start.
+- [docs/guide/architecture.md](https://github.com/loonghao/auroraview/blob/main/docs/guide/architecture.md): System architecture.
+- [docs/dcc/](https://github.com/loonghao/auroraview/tree/main/docs/dcc): DCC integration guides.


### PR DESCRIPTION
## Summary

Refactors the project's AI-facing documentation to improve agent discoverability and reduce duplication:

1. **AGENTS.md** — Rewritten as a progressive-disclosure navigation map. Instead of duplicating rules, it now points to `.codebuddy/rules/`, `llms.txt`, `llms-full.txt`, and `docs/` based on task type.

2. **GEMINI.md & CLAUDE.md** — Added as lightweight agent entry points that reference AGENTS.md.

3. **llms.txt** — New core AI-friendly usage index following llmstxt.org conventions. Covers tech stack (WebView2 priority, vx/just workflow), project structure, core APIs, and key constraints.

4. **llms-full.txt** — New comprehensive usage index with full API reference, DCC matrix, plugin system, packaging, testing, and E2E details.

5. **docs/guide/architecture.md & zh version** — Fixed the architecture diagram which incorrectly showed Qt WebEngine as a separate rendering backend. Qt is now correctly shown as a host/container layer that delegates to the system WebView engine (WebView2/WKWebView/WebKitGTK).

## Validation

- [x] Files render correctly in Markdown preview
- [x] Architecture diagrams display properly
- [x] All internal links use relative paths or absolute GitHub URLs

## Risk

Low — documentation-only changes. No code or build logic modified.