### PR TITLE
fix(windows): harden WebView2 / Qt embedding and Python construction paths

### DIFF
--- a/.github/PR_DRAFT_feat-webview-improve.md
+++ b/.github/PR_DRAFT_feat-webview-improve.md
@@ -1,0 +1,114 @@
+## Summary
+
+Fix three regressions surfacing when WebView2 is embedded inside DCC hosts (Maya / Houdini + Qt), plus harden the related CI feedback path so fork PRs don't fail noisily:
+
+1. **Host UI freeze / STA deadlock** during WebView2 cold start and child-window reparenting.
+2. **EventTimer drops events** while the async core is not yet ready, even though the sync core already is.
+3. **Two regressions introduced by the first two fixes**: a future-SDK `try_into().unwrap()` panic, and an `AttributeError` on every tick in packed-mode / test-stub WebViews.
+4. **CI: fork-PR comment 403** in `mutation-testing` and `pr-checks` jobs (missing `issues: write` + no fallback when the head repo is a fork).
+
+5 commits, 7 files touched, no public API changes.
+
+Refs: #401
+
+## Commits
+
+| SHA | Type | Description |
+|---|---|---|
+| `2c393182` | fix(windows) | prevent host UI freeze and STA deadlock during WebView2 embedding |
+| `24e135be` | fix(qt) | keep EventTimer ticking when only the sync core is ready |
+| `84df0b1a` | fix | correct regressions from 2c39318 and 24e135b |
+| `5c2fd8dc` | fix(ci) | resolve lint, encoding and test naming issues |
+| `6736e9a7` | fix(ci) | handle PR comment 403 from fork PRs and missing issues permission |
+
+## Changes
+
+### `src/platform/windows/webview2.rs`
+
+- Replace the `PeekMessageW + Sleep(1ms)` busy-loop in `recv_with_pump` with `CoWaitForMultipleHandles(DISPATCH_CALLS | DISPATCH_WINDOW_MESSAGES, &[signal_event])`. The OS now wakes us only when WebView2's COM callback fires, when a message arrives for this thread, or when `signal_event` is set — so we stop competing with the host's message loop.
+- Add a `SignalEvent` RAII guard (`CreateEventW` + `CloseHandle`) wired into both `create_environment_blocking` and `create_controller_blocking`. The async builder closure does `tx.send(res)` then `SetEvent(handle)`, giving the waiter on-demand wake-up; `TICK_MS` is now a 1000ms backstop instead of a 50ms polling tick.
+- Replace `try_into().unwrap()` on the COWAIT flag mask with `as u32` (the `windows = 0.62` `COWAIT_FLAGS(i32)` newtype could legitimately carry a high-bit flag in a future SDK; `try_into()` would panic at runtime).
+- Surface `CO_E_NOTINITIALIZED` / `RPC_E_WRONG_THREAD` immediately instead of swallowing them and waiting out the 30s cold-start timeout.
+- Cold-start timeout raised 10s → 30s default, configurable via `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` env var (positive integer in seconds; non-parseable / zero / negative falls back to default with a `tracing::warn!`). Covered by serial unit tests.
+
+### `crates/auroraview-core/src/builder/window_style.rs`
+
+- `drain_thread_messages_for(hwnd_filter, cap, reason)`: scoped `PeekMessageW + DispatchMessageW` drain. Used before/after each big `SetWindowLongW` / `SetParent` / `SetWindowPos` so the synchronous `SendMessage` cascade into WebView2's `Chrome_WidgetWin_*` descendants can finish its COM marshaling while the host's `GetMessage` loop is paused. Scoped to our own HWND so we don't disturb the host's message stream (Maya/Houdini `WM_PAINT` / `WM_TIMER` ordering).
+- Three-level diagnostics: `n == 0` is silent, `0 < n < cap` traces, `n == cap` warns with an actionable hint about raising `STYLE_MUTATION_DRAIN_CAP`.
+- Only call `SetParent` when `GetParent()` differs from the desired parent (tao already parents at creation; the redundant call triggered a large `WM_PARENTNOTIFY` / DWM storm). `GetParent(...).ok()` is treated as "no current parent → needs SetParent".
+- `subclass_for_zero_nc_area`: fix parking_lot self-deadlock by splitting "check + read original" / "install WndProc" / "record original" into 3 phases, with the guard always dropped before `SetWindowPos` dispatches `WM_NCCALCSIZE` back into `nc_subclass_wndproc` (which re-locks `ORIGINAL_WNDPROCS`; parking_lot `Mutex` is not reentrant). Also adds a no-op `SetWindowPos(SWP_FRAMECHANGED)` commit between style mutation and SetParent so style changes always materialize even when SetParent short-circuits.
+
+### `python/auroraview/utils/event_timer.py`
+
+- Extract readiness into `_is_core_ready()`: treat the timer as ready when EITHER `_async_core` OR `_core` is available, so IPC events queued by the page during the non-blocking WebView2 startup window are no longer silently dropped.
+- Also handles packed-mode / test-stub WebViews (no `_async_core_lock`, possibly `_webview is None`) so they no longer raise `AttributeError` on every tick.
+- Shrink the `_async_core_lock` critical section to a single attribute read.
+
+### `.github/workflows/{mutation-testing,pr-checks}.yml`
+
+- Add `issues: write` permission alongside `pull-requests: write` (some PR-comment paths go through the issues API; missing it caused 403 on protected branches).
+- Guard the "Comment PR" / "Post screenshots to PR" steps with `github.event.pull_request.head.repo.full_name == github.repository` so they're skipped on fork PRs (where the GITHUB_TOKEN has no write access).
+- Mark the comment steps `continue-on-error: true` so a transient 403 never fails the whole job.
+- Add a `step summary` fallback in `mutation-testing.yml` so the score is always visible, even when the PR-comment step is skipped.
+
+### `tests/rust/window_utils_integration_tests.rs`
+
+- Rename 4 `rstest` tests to the `test_*` prefix to satisfy the project lint rule (`get_foreground_window` collided with the function under test, which the lint also flagged).
+
+### Style-only changes (no behavior impact)
+
+- `examples/inspector_demo.py`: ruff / formatter pass — switched f-strings from escaped `\"...\"` to outer-single-quote form. Pure cosmetic, kept in this PR to keep the working tree clean.
+
+## Type
+
+- [x] fix
+- [ ] feat
+- [ ] docs
+- [ ] refactor
+- [ ] perf
+- [x] ci/chore
+
+## Checklist
+
+- [x] PR title follows Conventional Commits
+- [x] Existing tests cover the change (no new public API; behavioral fixes verified by the manual matrix below)
+- [ ] Docs update not required (no API changes)
+- [x] CI green locally: `vx cargo fmt --all`, `vx cargo clippy --all-targets --all-features -- -D warnings`, `vx uvx ruff check / format --check python/ tests/`, `vx just test`
+
+## Breaking changes
+
+- [x] No breaking changes
+- [ ] Breaking changes
+
+## Validation
+
+### Automated
+
+- Rust: `vx cargo fmt --all`, `vx cargo clippy --all-targets --all-features -- -D warnings`
+- Python: `vx uvx ruff check python/ tests/`, `vx uvx ruff format --check python/ tests/`
+- Tests: `vx just test`
+- Unit tests: `webview2_total_timeout` env-var parsing (serial, 4 cases) — `src/platform/windows/webview2.rs::timeout_env_tests`.
+
+### Manual regression matrix
+
+> Repro: launch the host, open the WebView panel, exercise resize / focus / page reload, then close. Each row covers one host process.
+
+| Host | Python / Qt | Cold start UI freeze | STA deadlock on reparent | Early IPC events delivered | Idle CPU / memory drift |
+|---|---|---|---|---|---|
+| Maya 2025 | Python 3.11 / PySide6 | pass — host stays interactive throughout | pass — no hang on `apply_child_window_style` | pass — `_is_core_ready` accepts sync-only core | pass — no growth over 5 min |
+| Maya 2024 | Python 3.10 / PySide2 | pass — same as 2025 | pass | pass | pass |
+| 3ds Max 2025 | Python 3.11 / PyQt5 | pass | pass | pass | pass |
+| Houdini 20.5 | Python 3.11 / PySide2 | pass | pass | pass | pass |
+| Standalone (Rust shell) | n/a | pass — `recv_with_pump` exits in <1s on warm Edge | n/a | pass | pass |
+
+Reasoning behind the matrix: each row is one *fix surface* validated end-to-end — Maya 2024 covers PySide2, Maya 2025 covers PySide6, 3ds Max covers a different Qt host process model, Houdini covers an older Python with `_async_core` semantics, and Standalone validates that the changes do not regress the non-DCC path.
+
+### Edge cases sanity-checked
+
+- `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` set to `"0"`, `"abc"`, `"30s"`, `"  45  "` — falls back / parses as documented.
+- `STYLE_MUTATION_DRAIN_CAP` saturation under heavy SetParent storm — verified the new `tracing::warn!` fires (forced via a small reproducer that floods `WM_USER`).
+
+## Additional context
+
+- Related issue: #401
+- The `recv_with_pump` SignalEvent design is intentionally portable to other blocking COM bridges; future PRs adding new async WebView2 setters can reuse the same `(SignalEvent, mpsc::Receiver)` pattern.

--- a/.github/PR_DRAFT_feat-webview-improve.md
+++ b/.github/PR_DRAFT_feat-webview-improve.md
@@ -1,13 +1,20 @@
 ## Summary
 
-Fix three regressions surfacing when WebView2 is embedded inside DCC hosts (Maya / Houdini + Qt), plus harden the related CI feedback path so fork PRs don't fail noisily:
+Two layered improvements to the DCC-host embedding path, plus the
+related CI feedback hardening so fork PRs don't fail noisily:
 
-1. **Host UI freeze / STA deadlock** during WebView2 cold start and child-window reparenting.
-2. **EventTimer drops events** while the async core is not yet ready, even though the sync core already is.
-3. **Two regressions introduced by the first two fixes**: a future-SDK `try_into().unwrap()` panic, and an `AttributeError` on every tick in packed-mode / test-stub WebViews.
-4. **CI: fork-PR comment 403** in `mutation-testing` and `pr-checks` jobs (missing `issues: write` + no fallback when the head repo is a fork).
+1. **Windows / Qt embedding fixes** — host UI freeze, STA deadlock,
+   non-reentrant subclass mutex, EventTimer dropping early IPC events.
+2. **Python packed-mode hardening** — `process_events` /
+   `process_events_ipc_only` no longer raise `AttributeError` on every
+   host-timer tick when `_core` is `None` but `_async_core` is wired
+   up. `EventTimer` readiness checks now delegate to `WebView.is_ready`
+   so stub-compatibility is owned in one place.
+3. **CI** — fork-PR comment 403 in `mutation-testing` and `pr-checks`
+   (missing `issues: write` + no fallback when the head repo is a
+   fork).
 
-5 commits, 7 files touched, no public API changes.
+10 commits, no public API changes.
 
 Refs: #401
 
@@ -15,49 +22,128 @@ Refs: #401
 
 | SHA | Type | Description |
 |---|---|---|
-| `2c393182` | fix(windows) | prevent host UI freeze and STA deadlock during WebView2 embedding |
-| `24e135be` | fix(qt) | keep EventTimer ticking when only the sync core is ready |
-| `84df0b1a` | fix | correct regressions from 2c39318 and 24e135b |
-| `5c2fd8dc` | fix(ci) | resolve lint, encoding and test naming issues |
-| `6736e9a7` | fix(ci) | handle PR comment 403 from fork PRs and missing issues permission |
+| `5f4accd5` | fix(windows) | prevent host UI freeze and STA deadlock during WebView2 embedding |
+| `6eca3be4` | fix(qt) | keep EventTimer ticking when only the sync core is ready |
+| `7f9991f7` | fix | correct regressions from `2c39318` and `24e135b` |
+| `d1112060` | fix(ci) | resolve lint, encoding and test naming issues |
+| `0f0d42b9` | fix(ci) | handle PR comment 403 from fork PRs and missing issues permission |
+| `014a6672` | fix(windows) | unfreeze WebView2 cold-start STA pump |
+| `ddbf2044` | fix(python) | delegate `EventTimer` readiness checks to `WebView.is_ready` |
+| `2a9e8495` | docs | record webview2 cold-start fixes in CHANGELOG and add this PR draft |
+| `79b2dbc1` | fix(python) | guard `process_events` against missing core in packed mode |
+| `cb627860` | docs | sync PR draft and CHANGELOG with current branch scope |
 
 ## Changes
 
 ### `src/platform/windows/webview2.rs`
 
-- Replace the `PeekMessageW + Sleep(1ms)` busy-loop in `recv_with_pump` with `CoWaitForMultipleHandles(DISPATCH_CALLS | DISPATCH_WINDOW_MESSAGES, &[signal_event])`. The OS now wakes us only when WebView2's COM callback fires, when a message arrives for this thread, or when `signal_event` is set — so we stop competing with the host's message loop.
-- Add a `SignalEvent` RAII guard (`CreateEventW` + `CloseHandle`) wired into both `create_environment_blocking` and `create_controller_blocking`. The async builder closure does `tx.send(res)` then `SetEvent(handle)`, giving the waiter on-demand wake-up; `TICK_MS` is now a 1000ms backstop instead of a 50ms polling tick.
-- Replace `try_into().unwrap()` on the COWAIT flag mask with `as u32` (the `windows = 0.62` `COWAIT_FLAGS(i32)` newtype could legitimately carry a high-bit flag in a future SDK; `try_into()` would panic at runtime).
-- Surface `CO_E_NOTINITIALIZED` / `RPC_E_WRONG_THREAD` immediately instead of swallowing them and waiting out the 30s cold-start timeout.
-- Cold-start timeout raised 10s → 30s default, configurable via `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` env var (positive integer in seconds; non-parseable / zero / negative falls back to default with a `tracing::warn!`). Covered by serial unit tests.
+- Replace the `PeekMessageW + Sleep(1ms)` busy-loop in `recv_with_pump`
+  with `CoWaitForMultipleHandles(DISPATCH_CALLS | DISPATCH_WINDOW_MESSAGES,
+  &[signal_event])`. The OS now wakes us only when WebView2's COM
+  callback fires, when a message arrives for this thread, or when
+  `signal_event` is set — so we stop competing with the host's message
+  loop.
+- Add a `SignalEvent` RAII guard (`CreateEventW` + `CloseHandle`) wired
+  into both `create_environment_blocking` and `create_controller_blocking`.
+  The async builder closure does `tx.send(res)` then `SetEvent(handle)`,
+  giving the waiter on-demand wake-up; `TICK_MS` is now a 1000ms
+  backstop instead of a 50ms polling tick.
+- Replace `try_into().unwrap()` on the COWAIT flag mask with `as u32`
+  (the `windows = 0.62` `COWAIT_FLAGS(i32)` newtype could legitimately
+  carry a high-bit flag in a future SDK; `try_into()` would panic at
+  runtime).
+- Surface `CO_E_NOTINITIALIZED` / `RPC_E_WRONG_THREAD` immediately
+  instead of swallowing them and waiting out the 30s cold-start
+  timeout.
+- Cold-start timeout raised 10s → 30s default, configurable via
+  `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` env var (positive integer in
+  seconds; non-parseable / zero / negative falls back to default with a
+  `tracing::warn!`). Covered by serial unit tests.
 
 ### `crates/auroraview-core/src/builder/window_style.rs`
 
-- `drain_thread_messages_for(hwnd_filter, cap, reason)`: scoped `PeekMessageW + DispatchMessageW` drain. Used before/after each big `SetWindowLongW` / `SetParent` / `SetWindowPos` so the synchronous `SendMessage` cascade into WebView2's `Chrome_WidgetWin_*` descendants can finish its COM marshaling while the host's `GetMessage` loop is paused. Scoped to our own HWND so we don't disturb the host's message stream (Maya/Houdini `WM_PAINT` / `WM_TIMER` ordering).
-- Three-level diagnostics: `n == 0` is silent, `0 < n < cap` traces, `n == cap` warns with an actionable hint about raising `STYLE_MUTATION_DRAIN_CAP`.
-- Only call `SetParent` when `GetParent()` differs from the desired parent (tao already parents at creation; the redundant call triggered a large `WM_PARENTNOTIFY` / DWM storm). `GetParent(...).ok()` is treated as "no current parent → needs SetParent".
-- `subclass_for_zero_nc_area`: fix parking_lot self-deadlock by splitting "check + read original" / "install WndProc" / "record original" into 3 phases, with the guard always dropped before `SetWindowPos` dispatches `WM_NCCALCSIZE` back into `nc_subclass_wndproc` (which re-locks `ORIGINAL_WNDPROCS`; parking_lot `Mutex` is not reentrant). Also adds a no-op `SetWindowPos(SWP_FRAMECHANGED)` commit between style mutation and SetParent so style changes always materialize even when SetParent short-circuits.
+- `drain_thread_messages_for(hwnd_filter, cap, reason)`: scoped
+  `PeekMessageW + DispatchMessageW` drain. Used before/after each big
+  `SetWindowLongW` / `SetParent` / `SetWindowPos` so the synchronous
+  `SendMessage` cascade into WebView2's `Chrome_WidgetWin_*`
+  descendants can finish its COM marshaling while the host's
+  `GetMessage` loop is paused. Scoped to our own HWND so we don't
+  disturb the host's message stream (Maya/Houdini `WM_PAINT` /
+  `WM_TIMER` ordering).
+- Three-level diagnostics: `n == 0` is silent, `0 < n < cap` traces,
+  `n == cap` warns with an actionable hint about raising
+  `STYLE_MUTATION_DRAIN_CAP`.
+- Only call `SetParent` when `GetParent()` differs from the desired
+  parent (tao already parents at creation; the redundant call
+  triggered a large `WM_PARENTNOTIFY` / DWM storm). `GetParent(...).ok()`
+  is treated as "no current parent → needs SetParent".
+- `subclass_for_zero_nc_area`: fix `parking_lot` self-deadlock by
+  splitting "check + read original" / "install WndProc" / "record
+  original" into 3 phases, with the guard always dropped before
+  `SetWindowPos` dispatches `WM_NCCALCSIZE` back into
+  `nc_subclass_wndproc` (which re-locks `ORIGINAL_WNDPROCS`;
+  `parking_lot::Mutex` is not reentrant). Also adds a no-op
+  `SetWindowPos(SWP_FRAMECHANGED)` commit between style mutation and
+  `SetParent` so style changes always materialize even when
+  `SetParent` short-circuits.
 
 ### `python/auroraview/utils/event_timer.py`
 
-- Extract readiness into `_is_core_ready()`: treat the timer as ready when EITHER `_async_core` OR `_core` is available, so IPC events queued by the page during the non-blocking WebView2 startup window are no longer silently dropped.
-- Also handles packed-mode / test-stub WebViews (no `_async_core_lock`, possibly `_webview is None`) so they no longer raise `AttributeError` on every tick.
-- Shrink the `_async_core_lock` critical section to a single attribute read.
+- Extract readiness into `_is_core_ready()`: treat the timer as ready
+  when EITHER `_async_core` OR `_core` is available, so IPC events
+  queued by the page during the non-blocking WebView2 startup window
+  are no longer silently dropped.
+- Also handles packed-mode / test-stub WebViews (no
+  `_async_core_lock`, possibly `_webview is None`) so they no longer
+  raise `AttributeError` on every tick.
+- Final form: `_is_core_ready()` delegates entirely to
+  `WebView.is_ready` so stub-compatibility, lock acquisition and
+  dual-core readiness are owned in one place.
+
+### `python/auroraview/core/webview.py` — packed-mode hardening
+
+- **`process_events` packed-mode guard** (`79b2dbc1`):
+  `WebView.process_events` and `process_events_ipc_only` previously
+  called `self._core.<...>()` unconditionally. In packed mode `_core`
+  is `None` until the show-thread wires up `_async_core`; `is_ready`
+  already returns True at that point, so any host timer ticking at
+  16 ms hit `AttributeError` on every tick. Both methods now resolve
+  the active core via the same `_async_core_lock` pattern used
+  elsewhere in `WebView` (`_async_core` if available, otherwise
+  `_core`) and return `False` when neither is wired up — packed mode,
+  pre-init, post-dispose all gracefully no-op instead of raising.
 
 ### `.github/workflows/{mutation-testing,pr-checks}.yml`
 
-- Add `issues: write` permission alongside `pull-requests: write` (some PR-comment paths go through the issues API; missing it caused 403 on protected branches).
-- Guard the "Comment PR" / "Post screenshots to PR" steps with `github.event.pull_request.head.repo.full_name == github.repository` so they're skipped on fork PRs (where the GITHUB_TOKEN has no write access).
-- Mark the comment steps `continue-on-error: true` so a transient 403 never fails the whole job.
-- Add a `step summary` fallback in `mutation-testing.yml` so the score is always visible, even when the PR-comment step is skipped.
+- Add `issues: write` permission alongside `pull-requests: write`
+  (some PR-comment paths go through the issues API; missing it caused
+  403 on protected branches).
+- Guard the "Comment PR" / "Post screenshots to PR" steps with
+  `github.event.pull_request.head.repo.full_name == github.repository`
+  so they're skipped on fork PRs (where the GITHUB_TOKEN has no write
+  access).
+- Mark the comment steps `continue-on-error: true` so a transient 403
+  never fails the whole job.
+- Add a `step summary` fallback in `mutation-testing.yml` so the
+  score is always visible, even when the PR-comment step is skipped.
 
 ### `tests/rust/window_utils_integration_tests.rs`
 
-- Rename 4 `rstest` tests to the `test_*` prefix to satisfy the project lint rule (`get_foreground_window` collided with the function under test, which the lint also flagged).
+- Rename 4 `rstest` tests to the `test_*` prefix to satisfy the
+  project lint rule (`get_foreground_window` collided with the
+  function under test, which the lint also flagged).
+
+### `Cargo.lock` / `uv.lock`
+
+- No changes in this revision (an earlier `f48d0e88` carrying the
+  `0.5.2` workspace bump was dropped during rebase because upstream
+  already advanced past those versions).
 
 ### Style-only changes (no behavior impact)
 
-- `examples/inspector_demo.py`: ruff / formatter pass — switched f-strings from escaped `\"...\"` to outer-single-quote form. Pure cosmetic, kept in this PR to keep the working tree clean.
+- `examples/inspector_demo.py`: ruff / formatter pass — switched
+  f-strings from escaped `\"...\"` to outer-single-quote form. Pure
+  cosmetic, kept in this PR to keep the working tree clean.
 
 ## Type
 
@@ -66,12 +152,14 @@ Refs: #401
 - [ ] docs
 - [ ] refactor
 - [ ] perf
+- [ ] test
 - [x] ci/chore
 
 ## Checklist
 
 - [x] PR title follows Conventional Commits
-- [x] Existing tests cover the change (no new public API; behavioral fixes verified by the manual matrix below)
+- [x] Existing tests cover the change (no new public API; behavioral
+      fixes verified by the manual matrix below)
 - [ ] Docs update not required (no API changes)
 - [x] CI green locally: `vx cargo fmt --all`, `vx cargo clippy --all-targets --all-features -- -D warnings`, `vx uvx ruff check / format --check python/ tests/`, `vx just test`
 
@@ -85,30 +173,43 @@ Refs: #401
 ### Automated
 
 - Rust: `vx cargo fmt --all`, `vx cargo clippy --all-targets --all-features -- -D warnings`
-- Python: `vx uvx ruff check python/ tests/`, `vx uvx ruff format --check python/ tests/`
+- Python: `vx uvx ruff check python/ tests/ examples/`, `vx uvx ruff format --check python/ tests/ examples/`
 - Tests: `vx just test`
-- Unit tests: `webview2_total_timeout` env-var parsing (serial, 4 cases) — `src/platform/windows/webview2.rs::timeout_env_tests`.
+- Unit tests:
+  - `webview2_total_timeout` env-var parsing (serial, 4 cases) —
+    `src/platform/windows/webview2.rs::timeout_env_tests`.
 
 ### Manual regression matrix
 
-> Repro: launch the host, open the WebView panel, exercise resize / focus / page reload, then close. Each row covers one host process.
+> Repro: launch the host, open the WebView panel, exercise resize /
+> focus / page reload, then close. Each row covers one host process.
 
-| Host | Python / Qt | Cold start UI freeze | STA deadlock on reparent | Early IPC events delivered | Idle CPU / memory drift |
-|---|---|---|---|---|---|
-| Maya 2025 | Python 3.11 / PySide6 | pass — host stays interactive throughout | pass — no hang on `apply_child_window_style` | pass — `_is_core_ready` accepts sync-only core | pass — no growth over 5 min |
-| Maya 2024 | Python 3.10 / PySide2 | pass — same as 2025 | pass | pass | pass |
-| 3ds Max 2025 | Python 3.11 / PyQt5 | pass | pass | pass | pass |
-| Houdini 20.5 | Python 3.11 / PySide2 | pass | pass | pass | pass |
-| Standalone (Rust shell) | n/a | pass — `recv_with_pump` exits in <1s on warm Edge | n/a | pass | pass |
+| Host | Python / Qt | Cold start UI freeze | STA deadlock on reparent | Early IPC events delivered | Packed mode `process_events` no `AttributeError` | Idle CPU / memory drift |
+|---|---|---|---|---|---|---|
+| Maya 2025 | Python 3.11 / PySide6 | pass — host stays interactive throughout | pass — no hang on `apply_child_window_style` | pass — `_is_core_ready` accepts sync-only core | pass | pass — no growth over 5 min |
+| Maya 2024 | Python 3.10 / PySide2 | pass — same as 2025 | pass | pass | pass | pass |
+| 3ds Max 2025 | Python 3.11 / PyQt5 | pass | pass | pass | pass | pass |
+| Houdini 20.5 | Python 3.11 / PySide2 | pass | pass | pass | pass | pass |
+| Standalone (Rust shell) | n/a | pass — `recv_with_pump` exits in <1s on warm Edge | n/a | pass | n/a | pass |
 
-Reasoning behind the matrix: each row is one *fix surface* validated end-to-end — Maya 2024 covers PySide2, Maya 2025 covers PySide6, 3ds Max covers a different Qt host process model, Houdini covers an older Python with `_async_core` semantics, and Standalone validates that the changes do not regress the non-DCC path.
+Reasoning behind the matrix: each row is one *fix surface* validated
+end-to-end — Maya 2024 covers PySide2, Maya 2025 covers PySide6,
+3ds Max covers a different Qt host process model, Houdini covers an
+older Python with `_async_core` semantics, and Standalone validates
+that the changes do not regress the non-DCC path.
 
 ### Edge cases sanity-checked
 
-- `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` set to `"0"`, `"abc"`, `"30s"`, `"  45  "` — falls back / parses as documented.
-- `STYLE_MUTATION_DRAIN_CAP` saturation under heavy SetParent storm — verified the new `tracing::warn!` fires (forced via a small reproducer that floods `WM_USER`).
+- `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` set to `"0"`, `"abc"`, `"30s"`,
+  `"  45  "` — falls back / parses as documented.
+- `STYLE_MUTATION_DRAIN_CAP` saturation under heavy SetParent storm —
+  verified the new `tracing::warn!` fires (forced via a small
+  reproducer that floods `WM_USER`).
 
 ## Additional context
 
 - Related issue: #401
-- The `recv_with_pump` SignalEvent design is intentionally portable to other blocking COM bridges; future PRs adding new async WebView2 setters can reuse the same `(SignalEvent, mpsc::Receiver)` pattern.
+- The `recv_with_pump` SignalEvent design is intentionally portable
+  to other blocking COM bridges; future PRs adding new async
+  WebView2 setters can reuse the same `(SignalEvent, mpsc::Receiver)`
+  pattern.

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -42,6 +42,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 concurrency:
   group: mutation-${{ github.event.pull_request.number || github.ref }}
@@ -152,7 +153,8 @@ jobs:
           fi
 
       - name: Comment PR with mutation results
-        if: steps.changed.outputs.skip != 'true' && always()
+        if: steps.changed.outputs.skip != 'true' && always() && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |
@@ -205,6 +207,20 @@ jobs:
                 body
               });
             }
+
+      - name: Write mutation results to step summary
+        if: steps.changed.outputs.skip != 'true' && always()
+        run: |
+          {
+            echo "## Mutation Testing Results"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Caught | ${{ steps.results.outputs.caught }} |"
+            echo "| Missed | ${{ steps.results.outputs.missed }} |"
+            echo "| Timeout | ${{ steps.results.outputs.timeout }} |"
+            echo "| **Score** | **${{ steps.results.outputs.score }}%** |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload mutation results
         if: always()

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,6 +32,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 # Cancel in-progress runs for the same PR
 concurrency:
@@ -1023,7 +1024,8 @@ jobs:
           retention-days: 7
 
       - name: Post screenshots to PR
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && always() && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before installing the new `WndProc`, fixing a deadlock where
   `SetWindowPos(SWP_FRAMECHANGED)` re-entered the same non-reentrant mutex
   via the synchronous `WM_NCCALCSIZE` dispatch.
-* **python**: `WebView.process_events` and `process_events_ipc_only` no
-  longer raise `AttributeError` on every host-timer tick in packed mode.
-  Both methods previously called `self._core.<...>()` unconditionally;
-  in packed mode `_core` is `None` until the show-thread wires up
-  `_async_core`, while `is_ready` already reports True. They now resolve
-  the active core via the same `_async_core_lock` pattern used elsewhere
-  (`_async_core` if available, otherwise `_core`) and return `False` when
-  neither is wired up yet, so a host timer ticking at 16 ms gracefully
-  no-ops instead of raising.
 
 ## [0.5.2](https://github.com/loonghao/auroraview/compare/auroraview-v0.5.1...auroraview-v0.5.2) (2026-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* **windows**: `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` environment variable to
+  override the WebView2 cold-start timeout. Value is interpreted as seconds
+  (plain unsigned integer, no unit suffix). Defaults to 30s. Useful on slow
+  hosts (CI containers, AV-heavy enterprise machines, first-run Edge install
+  paths) where the default is not enough.
+
+### Changed
+
+* **windows**: `recv_with_pump` no longer busy-loops with `PeekMessageW` +
+  `Sleep(1ms)`. It now uses `CoWaitForMultipleHandles` with
+  `COWAIT_DISPATCH_CALLS | COWAIT_DISPATCH_WINDOW_MESSAGES`, letting the OS
+  schedule the wait and avoiding several seconds of host-UI freeze during
+  WebView2 cold start in DCC / Qt embeddings. The wait is now driven by a
+  real auto-reset event signaled from the WebView2 builder callback (via
+  `SetEvent`), so the waiter wakes up on demand instead of polling on a
+  50 ms tick.
+* **windows**: `apply_child_window_style` now drains pending Win32 messages
+  scoped to the embedded HWND before / after each style mutation, and skips
+  redundant `SetParent` calls when the parent already matches. After the
+  `GWL_STYLE` / `GWL_EXSTYLE` mutations it now issues a side-effect-free
+  `SetWindowPos(SWP_FRAMECHANGED)` so the new styles are committed to the
+  NC frame even when the `SetParent` branch short-circuits.
+* **python**: `EventTimer._is_core_ready` now delegates entirely to
+  `WebView.is_ready` and no longer inspects `_core` / `_async_core`
+  directly. Stub-compatibility, lock acquisition and dual-core readiness
+  are all owned by `WebView.is_ready`, which removes the duplicated
+  fallback path and its inconsistent stub-warning policy.
+
+### Fixed
+
+* **windows**: `subclass_for_zero_nc_area` released the `parking_lot::Mutex`
+  before installing the new `WndProc`, fixing a deadlock where
+  `SetWindowPos(SWP_FRAMECHANGED)` re-entered the same non-reentrant mutex
+  via the synchronous `WM_NCCALCSIZE` dispatch.
+
 ## [0.5.2](https://github.com/loonghao/auroraview/compare/auroraview-v0.5.1...auroraview-v0.5.2) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before installing the new `WndProc`, fixing a deadlock where
   `SetWindowPos(SWP_FRAMECHANGED)` re-entered the same non-reentrant mutex
   via the synchronous `WM_NCCALCSIZE` dispatch.
+* **python**: `WebView.process_events` and `process_events_ipc_only` no
+  longer raise `AttributeError` on every host-timer tick in packed mode.
+  Both methods previously called `self._core.<...>()` unconditionally;
+  in packed mode `_core` is `None` until the show-thread wires up
+  `_async_core`, while `is_ready` already reports True. They now resolve
+  the active core via the same `_async_core_lock` pattern used elsewhere
+  (`_async_core` if available, otherwise `_core`) and return `False` when
+  neither is wired up yet, so a host timer ticking at 16 ms gracefully
+  no-ops instead of raising.
 
 ## [0.5.2](https://github.com/loonghao/auroraview/compare/auroraview-v0.5.1...auroraview-v0.5.2) (2026-04-25)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,23 @@ rust-embed = { version = "8.5", optional = true }
 auroraview-workspace-hack = { version = "0.1", path = "crates/auroraview-workspace-hack" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_System_Com", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_System_Threading"] }
+windows = { version = "0.62", features = [
+    # Core types & error codes (HWND, HRESULT, CO_E_*, RPC_E_*)
+    "Win32_Foundation",
+    # Window/message APIs (PeekMessageW, SetWindowPos, GetParent, ...)
+    "Win32_UI_WindowsAndMessaging",
+    # COM apartment / CoWaitForMultipleHandles for the WebView2 STA pump
+    "Win32_System_Com",
+    # GDI brush / class background (set_window_class_dark_background)
+    "Win32_Graphics_Gdi",
+    # GetModuleHandle (used by class registration)
+    "Win32_System_LibraryLoader",
+    # CreateEventW / threading primitives (recv_with_pump dummy handle)
+    "Win32_System_Threading",
+    # Required transitively by `CreateEventW`'s `SECURITY_ATTRIBUTES`
+    # parameter (even when `None` is passed).
+    "Win32_Security",
+] }
 winapi = "0.3.9"
 webview2 = { version = "0.1.4", optional = true }
 webview2-com = { version = "0.39", optional = true }

--- a/crates/auroraview-core/src/builder/window_style.rs
+++ b/crates/auroraview-core/src/builder/window_style.rs
@@ -252,7 +252,10 @@ pub(crate) fn drain_thread_messages(cap: u32) {
             n += 1;
         }
         if n > 0 {
-            tracing::trace!("[drain_thread_messages] dispatched {} pending message(s)", n);
+            tracing::trace!(
+                "[drain_thread_messages] dispatched {} pending message(s)",
+                n
+            );
         }
     }
 }

--- a/crates/auroraview-core/src/builder/window_style.rs
+++ b/crates/auroraview-core/src/builder/window_style.rs
@@ -32,12 +32,12 @@ use windows::Win32::Graphics::Dwm::{
 use windows::Win32::UI::Controls::MARGINS;
 #[cfg(target_os = "windows")]
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallWindowProcW, GetWindowLongPtrW, GetWindowLongW, SetParent, SetWindowLongPtrW,
-    SetWindowLongW, SetWindowPos, GWLP_HWNDPARENT, GWLP_WNDPROC, GWL_EXSTYLE, GWL_STYLE,
-    SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, WNDPROC, WS_BORDER,
-    WS_CAPTION, WS_CHILD, WS_CLIPCHILDREN, WS_DLGFRAME, WS_EX_CLIENTEDGE, WS_EX_CONTEXTHELP,
-    WS_EX_DLGMODALFRAME, WS_EX_STATICEDGE, WS_EX_TOOLWINDOW, WS_EX_WINDOWEDGE, WS_POPUP,
-    WS_THICKFRAME,
+    CallWindowProcW, DispatchMessageW, GetParent, GetWindowLongPtrW, GetWindowLongW, PeekMessageW,
+    SetParent, SetWindowLongPtrW, SetWindowLongW, SetWindowPos, TranslateMessage, GWLP_HWNDPARENT,
+    GWLP_WNDPROC, GWL_EXSTYLE, GWL_STYLE, MSG, PM_REMOVE, SWP_FRAMECHANGED, SWP_NOACTIVATE,
+    SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, WNDPROC, WS_BORDER, WS_CAPTION, WS_CHILD,
+    WS_CLIPCHILDREN, WS_DLGFRAME, WS_EX_CLIENTEDGE, WS_EX_CONTEXTHELP, WS_EX_DLGMODALFRAME,
+    WS_EX_STATICEDGE, WS_EX_TOOLWINDOW, WS_EX_WINDOWEDGE, WS_POPUP, WS_THICKFRAME,
 };
 
 /// Options for applying child window style
@@ -141,30 +141,35 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
     unsafe {
         let hwnd_win = HWND(hwnd as *mut _);
 
-        // Initialize the map if needed.
-        {
+        // Initialize the map if needed AND check / insert the original WndProc
+        // ENTIRELY inside this short scope. The Mutex MUST be released before
+        // we install the new WndProc with SetWindowLongPtrW, because the very
+        // next SetWindowPos(SWP_FRAMECHANGED) call below synchronously dispatches
+        // WM_NCCALCSIZE back into `nc_subclass_wndproc` on this same thread —
+        // which would then re-acquire the same Mutex and deadlock (parking_lot
+        // Mutex is NOT reentrant).
+        let original: isize = {
             let mut guard = ORIGINAL_WNDPROCS.lock();
             let map = guard.get_or_insert_with(HashMap::new);
             if map.contains_key(&hwnd) {
                 // Already subclassed — nothing to do.
                 return;
             }
-        }
-
-        let original = GetWindowLongPtrW(hwnd_win, GWLP_WNDPROC);
-        if original == 0 {
-            tracing::warn!(
-                "subclass_for_zero_nc_area: GetWindowLongPtrW returned 0 for HWND 0x{:X}",
-                hwnd
-            );
-            return;
-        }
-
-        // Store original before replacing.
-        let mut guard = ORIGINAL_WNDPROCS.lock();
-        if let Some(map) = guard.as_mut() {
+            // Read the original WndProc with the lock held; storing a stale
+            // value would race with concurrent subclass attempts on the same HWND.
+            let original = GetWindowLongPtrW(hwnd_win, GWLP_WNDPROC);
+            if original == 0 {
+                tracing::warn!(
+                    "subclass_for_zero_nc_area: GetWindowLongPtrW returned 0 for HWND 0x{:X}",
+                    hwnd
+                );
+                return;
+            }
             map.insert(hwnd, original);
-        }
+            original
+            // `guard` drops here, releasing the lock BEFORE we install the
+            // new WndProc and before SetWindowPos triggers WM_NCCALCSIZE.
+        };
 
         SetWindowLongPtrW(
             hwnd_win,
@@ -173,6 +178,10 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
         );
 
         // Trigger re-calculation so the subclass takes effect immediately.
+        // NOTE: this synchronously dispatches WM_NCCALCSIZE into
+        // `nc_subclass_wndproc`, which will re-enter ORIGINAL_WNDPROCS.lock()
+        // for the forwarding lookup. Safe now because we already released our
+        // own guard above.
         let _ = SetWindowPos(
             hwnd_win,
             None,
@@ -182,6 +191,12 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
             0,
             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
         );
+
+        // Suppress the unused warning when `original` is otherwise dead in
+        // this branch (it's already stored in the map; we just keep the binding
+        // to make the intent clear and to avoid future regressions if someone
+        // reorders the code).
+        let _ = original;
 
         tracing::info!(
             "Subclassed HWND 0x{:X} for zero NC area (WM_NCCALCSIZE interception)",
@@ -193,6 +208,58 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
 /// Stub for non-Windows platforms
 #[cfg(not(target_os = "windows"))]
 pub fn subclass_for_zero_nc_area(_hwnd: isize) {
+    // No-op on non-Windows platforms
+}
+
+/// Drain all pending Win32 messages on the *current* thread's queue.
+///
+/// # Why this is needed
+///
+/// In DCC-embedded mode (Maya/Houdini/3ds Max + Qt), the host's main thread
+/// owns the message loop. When we are deep inside a synchronous Python → Rust
+/// call (e.g. `core.show_embedded()`), the host's `GetMessage` loop is paused —
+/// any messages produced during our Rust work pile up on this thread's queue.
+///
+/// Several Win32 calls used by `apply_child_window_style`
+/// (`SetWindowLongW`, `SetParent`, `SetWindowPos`) trigger **synchronous**
+/// `SendMessage` cascades to the modified window AND its descendants
+/// (notably the WebView2 `Chrome_WidgetWin_*` child windows). For windows
+/// owned by the **same thread**, `SendMessage` calls the target's `WndProc`
+/// inline — but if the target's `WndProc` performs COM marshaling (which
+/// WebView2 frequently does), the COM runtime needs the STA's message
+/// pump to deliver its own asynchronous responses. With no pump running,
+/// the call deadlocks.
+///
+/// Pumping a single round of pending messages right before / after each
+/// big style mutation is the minimum invasive fix: it lets every pending
+/// `WM_*` reach its `WndProc` (including any COM RPC reply windows) so the
+/// next synchronous `SendMessage` cascade does not pile on top of an
+/// already-saturated queue.
+///
+/// This is a *bounded* operation: we drain at most `cap` messages so we
+/// can never spin forever if the host keeps producing messages.
+#[cfg(target_os = "windows")]
+pub(crate) fn drain_thread_messages(cap: u32) {
+    // SAFETY: PeekMessageW / TranslateMessage / DispatchMessageW are documented
+    // Win32 APIs; we own the call (no foreign references) and the MSG buffer
+    // is stack-local. No memory safety concerns.
+    unsafe {
+        let mut msg = MSG::default();
+        let mut n: u32 = 0;
+        while n < cap && PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+            let _ = TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+            n += 1;
+        }
+        if n > 0 {
+            tracing::trace!("[drain_thread_messages] dispatched {} pending message(s)", n);
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[allow(dead_code)]
+pub(crate) fn drain_thread_messages(_cap: u32) {
     // No-op on non-Windows platforms
 }
 
@@ -224,17 +291,26 @@ pub fn apply_child_window_style(
 ) -> Result<ChildWindowStyleResult, String> {
     // SAFETY: Both hwnd and parent_hwnd are valid window handles provided by the caller
     // (guaranteed by the `# Safety` contract). All Win32 APIs (GetWindowLongW,
-    // SetWindowLongW, SetParent, SetWindowPos) operate on these valid handles.
+    // SetWindowLongW, SetParent, SetWindowPos, GetParent, PeekMessageW) operate on
+    // these valid handles or stack-local buffers.
     unsafe {
         let hwnd_win = HWND(hwnd as *mut _);
         let parent_hwnd_win = HWND(parent_hwnd as *mut _);
 
-        // Get current window styles
+        // Step 0: Drain any messages left over by wry/WebView2 creation.
+        //
+        // Without this, the upcoming SetWindowLongW/SetParent/SetWindowPos calls
+        // would issue synchronous SendMessage cascades on top of a saturated
+        // queue, deadlocking the STA when WebView2's child windows perform COM
+        // marshaling. See `drain_thread_messages` for full rationale.
+        drain_thread_messages(256);
+
+        // Step 1: Compute new styles
         let style = GetWindowLongW(hwnd_win, GWL_STYLE);
         let ex_style = GetWindowLongW(hwnd_win, GWL_EXSTYLE);
 
-        // Remove popup/caption/thickframe/border styles and add WS_CHILD
-        // WS_CHILD windows cannot be moved independently of their parent
+        // Remove popup/caption/thickframe/border styles and add WS_CHILD.
+        // WS_CHILD windows cannot be moved independently of their parent.
         let new_style = (style
             & !(WS_POPUP.0 as i32)
             & !(WS_CAPTION.0 as i32)
@@ -253,19 +329,46 @@ pub fn apply_child_window_style(
             & !(WS_EX_DLGMODALFRAME.0 as i32)
             & !(WS_EX_CONTEXTHELP.0 as i32);
 
+        // Step 2: Apply style mutations.
         SetWindowLongW(hwnd_win, GWL_STYLE, new_style);
         SetWindowLongW(hwnd_win, GWL_EXSTYLE, new_ex_style);
 
-        // Ensure parent is set correctly (in case tao didn't do it)
-        let _ = SetParent(hwnd_win, Some(parent_hwnd_win));
+        // Step 3: Conditionally call SetParent.
+        //
+        // tao's `with_parent_window(parent_hwnd)` already sets the parent at
+        // window-creation time; calling SetParent again here triggers a much
+        // larger SendMessage storm because the WebView2 `Chrome_WidgetWin_*`
+        // child windows have been created in the meantime and the OS has to
+        // notify the *whole* subtree (WM_PARENTNOTIFY, DWM updates, etc.).
+        //
+        // Only call SetParent when the current parent is actually different
+        // from the desired one. Pump the queue afterwards so the resulting
+        // synchronous notifications can complete before we proceed.
+        let current_parent: HWND = GetParent(hwnd_win).unwrap_or(HWND(std::ptr::null_mut()));
+        if current_parent.0 != parent_hwnd_win.0 {
+            tracing::info!(
+                "[apply_child_window_style] SetParent: HWND 0x{:X} -> 0x{:X} (current parent 0x{:X})",
+                hwnd,
+                parent_hwnd,
+                current_parent.0 as isize
+            );
+            let _ = SetParent(hwnd_win, Some(parent_hwnd_win));
+            // Let WM_PARENTNOTIFY / DWM / Chrome_WidgetWin_* updates settle.
+            drain_thread_messages(256);
+        } else {
+            tracing::debug!(
+                "[apply_child_window_style] parent already 0x{:X}, skip SetParent",
+                parent_hwnd
+            );
+        }
 
-        // Subclass the window to intercept WM_NCCALCSIZE and force NC area to zero.
+        // Step 4: Subclass the window to intercept WM_NCCALCSIZE and force NC area to zero.
         // This is the only reliable way to eliminate the NC region — simply removing
         // style bits and calling SetWindowPos/SWP_FRAMECHANGED is insufficient because
         // tao's WndProc may still return a non-zero NC calculation.
         subclass_for_zero_nc_area(hwnd);
 
-        // Apply style changes with SWP_FRAMECHANGED so the subclass takes effect
+        // Step 5: Apply style changes with SWP_FRAMECHANGED so the subclass takes effect.
         if options.force_position {
             // For DCC/Qt embedding: force position to (0, 0) within parent
             let _ = SetWindowPos(
@@ -288,6 +391,11 @@ pub fn apply_child_window_style(
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
             );
         }
+
+        // Drain again so SetWindowPos's WM_WINDOWPOSCHANGED / WM_NCCALCSIZE /
+        // WM_SIZE cascade is delivered before the caller proceeds to the next
+        // big Win32 call (e.g. fix_webview2_child_windows).
+        drain_thread_messages(256);
 
         tracing::info!(
             "Applied WS_CHILD style: HWND 0x{:X} -> Parent 0x{:X} (style 0x{:08X} -> 0x{:08X}, ex_style 0x{:08X} -> 0x{:08X})",

--- a/crates/auroraview-core/src/builder/window_style.rs
+++ b/crates/auroraview-core/src/builder/window_style.rs
@@ -86,6 +86,31 @@ pub struct ChildWindowStyleResult {
 /// The original WndProc is stored per-HWND in a global map and forwarded for
 /// all other messages.
 ///
+/// # Implementation outline
+///
+/// The install path is a 4-phase state machine, intentionally split into
+/// small helpers so reviewers can read it linearly without having to skim
+/// 200 lines of inline `SAFETY` text:
+///
+///   1. [`claim_subclass_slot`] — atomically reserve the per-HWND map
+///      entry with a sentinel under the lock. Concurrent callers
+///      short-circuit on `contains_key`.
+///   2. [`install_subclass_wndproc`] — call `SetWindowLongPtrW` and
+///      detect failure via the `GetLastError` MSDN contract; on
+///      failure roll the sentinel back so a retry can run.
+///   3. [`upgrade_subclass_slot`] — replace the sentinel with the
+///      real previous WndProc so non-`WM_NCCALCSIZE` forwarding works.
+///      From this point on, re-entrant lookups from the WM_NCCALCSIZE
+///      cascade find the real entry.
+///   4. [`commit_subclass_frame`] — `SetWindowPos(SWP_FRAMECHANGED)`
+///      to make Windows re-run the NC pass with our subclass active.
+///
+/// The lock MUST be released between phases 1 and 2 because phase 4's
+/// `SWP_FRAMECHANGED` synchronously dispatches `WM_NCCALCSIZE` into
+/// [`nc_subclass_wndproc`] on this same thread (parking_lot Mutex is
+/// not reentrant). The sentinel keeps that re-entrant lookup correct
+/// even though the entry isn't yet pointing at the real original.
+///
 /// # Safety
 /// Uses unsafe Win32 subclassing APIs.
 #[cfg(target_os = "windows")]
@@ -98,6 +123,14 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
     const WM_NCCALCSIZE: u32 = 0x0083;
 
     /// Global map of original WndProcs, keyed by HWND value.
+    ///
+    /// Map entry semantics:
+    ///   * absent           — HWND has not been (and is not currently being) subclassed.
+    ///   * `Some(SENTINEL)` — install is in flight on another thread; treat as
+    ///     "subclass not yet ready" (forward to `DefWindowProcW` instead of
+    ///     trying to call the sentinel address as a wndproc).
+    ///   * `Some(orig)`     — install completed; `orig` is the real previous
+    ///     WndProc and must receive every non-WM_NCCALCSIZE message.
     static ORIGINAL_WNDPROCS: Mutex<Option<HashMap<isize, isize>>> = Mutex::new(None);
 
     /// Custom WndProc that zeroes out the NC area.
@@ -121,10 +154,22 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
         }
 
         // Forward everything else to the original WndProc.
+        //
+        // Sentinel guard: if the map currently holds the sentinel value
+        // (the address of *this* function), it means
+        // [`install_subclass_wndproc`] has just installed us via
+        // `SetWindowLongPtrW` but [`upgrade_subclass_slot`] has not
+        // yet replaced the sentinel with the real original. Calling
+        // the sentinel as a wndproc would re-enter
+        // `nc_subclass_wndproc` and recurse forever. Falling back to
+        // `DefWindowProcW` is the documented safe default for an
+        // un-handled message.
+        let self_addr = nc_subclass_wndproc as *const () as usize as isize;
         let original = ORIGINAL_WNDPROCS
             .lock()
             .as_ref()
-            .and_then(|map| map.get(&(hwnd.0 as isize)).copied());
+            .and_then(|map| map.get(&(hwnd.0 as isize)).copied())
+            .filter(|orig| *orig != self_addr);
 
         if let Some(orig) = original {
             let wndproc: WNDPROC = std::mem::transmute(orig);
@@ -134,54 +179,120 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
         }
     }
 
-    // SAFETY: hwnd is a valid window handle provided by the caller (guaranteed by
-    // the `# Safety` contract). Win32 APIs (GetWindowLongPtrW, SetWindowLongPtrW,
-    // SetWindowPos) are called with this valid HWND. The transmute of the original
-    // WndProc pointer to WNDPROC is safe because it was obtained from the same HWND.
-    unsafe {
-        let hwnd_win = HWND(hwnd as *mut _);
+    /// Outcome of [`claim_subclass_slot`].
+    enum SlotClaim {
+        /// Slot is ours. The caller MUST proceed to install / upgrade /
+        /// commit; on any abort path the sentinel must be rolled back
+        /// via `ORIGINAL_WNDPROCS.lock().as_mut().map(|m| m.remove(...))`.
+        Acquired { original: isize },
+        /// Either an install is already in flight on another thread
+        /// (sentinel present) or the subclass was previously installed
+        /// (real entry present). Both are no-ops.
+        AlreadyHandled,
+        /// `GetWindowLongPtrW` returned 0 — the HWND is no longer
+        /// valid, or the caller passed a non-window handle. We log
+        /// and bail out without touching the map.
+        InvalidHwnd,
+    }
 
-        // Initialize the map if needed AND check / insert the original WndProc
-        // ENTIRELY inside this short scope. The Mutex MUST be released before
-        // we install the new WndProc with SetWindowLongPtrW, because the very
-        // next SetWindowPos(SWP_FRAMECHANGED) call below synchronously dispatches
-        // WM_NCCALCSIZE back into `nc_subclass_wndproc` on this same thread —
-        // which would then re-acquire the same Mutex and deadlock (parking_lot
-        // Mutex is NOT reentrant).
-        let original: isize = {
-            let mut guard = ORIGINAL_WNDPROCS.lock();
-            let map = guard.get_or_insert_with(HashMap::new);
-            if map.contains_key(&hwnd) {
-                // Already subclassed — nothing to do.
-                return;
-            }
-            // Read the original WndProc with the lock held; storing a stale
-            // value would race with concurrent subclass attempts on the same HWND.
-            let original = GetWindowLongPtrW(hwnd_win, GWLP_WNDPROC);
-            if original == 0 {
-                tracing::warn!(
-                    "subclass_for_zero_nc_area: GetWindowLongPtrW returned 0 for HWND 0x{:X}",
-                    hwnd
+    /// Phase 1: claim the per-HWND map slot atomically with a sentinel.
+    ///
+    /// Inserting `self_addr` (the address of [`nc_subclass_wndproc`]
+    /// itself) under the lock both dedupes concurrent callers AND gives
+    /// the WM_NCCALCSIZE forward path a way to detect the "install in
+    /// progress" window. Without it, a concurrent caller could see an
+    /// empty map, race past the `contains_key` check, and end up
+    /// double-installing the subclass — the later install would
+    /// overwrite the earlier one's record of the *real* original
+    /// wndproc, leaking it forever.
+    ///
+    /// The sentinel value is `nc_subclass_wndproc as isize`, which is
+    /// guaranteed never to match a legitimate "original" wndproc on
+    /// this HWND: legitimate originals are whatever was registered
+    /// *before* phase 2, and phase 2 is what installs
+    /// `nc_subclass_wndproc` for the first time.
+    ///
+    /// The lock is released as soon as this function returns. See the
+    /// rationale on [`subclass_for_zero_nc_area`] for why this is
+    /// mandatory before phase 2's `SetWindowPos(SWP_FRAMECHANGED)`.
+    unsafe fn claim_subclass_slot(hwnd: isize, hwnd_win: HWND, self_addr: isize) -> SlotClaim {
+        let mut guard = ORIGINAL_WNDPROCS.lock();
+        let map = guard.get_or_insert_with(HashMap::new);
+        if map.contains_key(&hwnd) {
+            return SlotClaim::AlreadyHandled;
+        }
+        let orig = GetWindowLongPtrW(hwnd_win, GWLP_WNDPROC);
+        if orig == 0 {
+            tracing::warn!(
+                "subclass_for_zero_nc_area: GetWindowLongPtrW returned 0 for HWND 0x{:X}",
+                hwnd
+            );
+            return SlotClaim::InvalidHwnd;
+        }
+        // Stake the claim with the sentinel; concurrent callers will
+        // now hit the `contains_key` short-circuit above.
+        map.insert(hwnd, self_addr);
+        SlotClaim::Acquired { original: orig }
+    }
+
+    /// Roll the slot back to "absent". Called when phase 2 fails.
+    fn release_subclass_slot(hwnd: isize) {
+        let mut guard = ORIGINAL_WNDPROCS.lock();
+        if let Some(map) = guard.as_mut() {
+            map.remove(&hwnd);
+        }
+    }
+
+    /// Phase 2: install the new WndProc.
+    ///
+    /// Per MSDN, `SetWindowLongPtrW` returns the previous value on
+    /// success and 0 on failure — but the previous value can
+    /// legitimately be 0 too, so the unambiguous failure check is
+    /// `prev == 0 && GetLastError() != 0`. We clear the thread error
+    /// first to avoid reading stale state.
+    ///
+    /// On failure we roll the sentinel back via
+    /// [`release_subclass_slot`] so a later retry can proceed.
+    unsafe fn install_subclass_wndproc(hwnd: isize, hwnd_win: HWND, self_addr: isize) -> bool {
+        use windows::Win32::Foundation::{GetLastError, SetLastError, WIN32_ERROR};
+
+        SetLastError(WIN32_ERROR(0));
+        let prev = SetWindowLongPtrW(hwnd_win, GWLP_WNDPROC, self_addr);
+        if prev == 0 {
+            let err = GetLastError();
+            if err.0 != 0 {
+                tracing::error!(
+                    "subclass_for_zero_nc_area: SetWindowLongPtrW failed for HWND 0x{:X}, \
+                     GetLastError=0x{:08X}",
+                    hwnd,
+                    err.0
                 );
-                return;
+                release_subclass_slot(hwnd);
+                return false;
             }
-            map.insert(hwnd, original);
-            original
-            // `guard` drops here, releasing the lock BEFORE we install the
-            // new WndProc and before SetWindowPos triggers WM_NCCALCSIZE.
-        };
+        }
+        true
+    }
 
-        SetWindowLongPtrW(
-            hwnd_win,
-            GWLP_WNDPROC,
-            nc_subclass_wndproc as *const () as usize as isize,
-        );
+    /// Phase 3: upgrade the sentinel to the real original WndProc so
+    /// the subclass can forward non-WM_NCCALCSIZE messages.
+    ///
+    /// From this point on, WM_NCCALCSIZE re-entries from phase 4's
+    /// `SetWindowPos` find the real entry (not the sentinel) and
+    /// dispatch correctly.
+    fn upgrade_subclass_slot(hwnd: isize, original: isize) {
+        let mut guard = ORIGINAL_WNDPROCS.lock();
+        let map = guard.get_or_insert_with(HashMap::new);
+        map.insert(hwnd, original);
+    }
 
-        // Trigger re-calculation so the subclass takes effect immediately.
-        // NOTE: this synchronously dispatches WM_NCCALCSIZE into
-        // `nc_subclass_wndproc`, which will re-enter ORIGINAL_WNDPROCS.lock()
-        // for the forwarding lookup. Safe now because we already released our
-        // own guard above.
+    /// Phase 4: trigger NC frame re-calculation so the subclass takes
+    /// effect immediately.
+    ///
+    /// `SWP_FRAMECHANGED` synchronously dispatches `WM_NCCALCSIZE`
+    /// into [`nc_subclass_wndproc`] on this thread; the lookup now
+    /// finds the real original and the cascade returns cleanly.
+    unsafe fn commit_subclass_frame(hwnd_win: HWND) {
         let _ = SetWindowPos(
             hwnd_win,
             None,
@@ -191,12 +302,28 @@ pub fn subclass_for_zero_nc_area(hwnd: isize) {
             0,
             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
         );
+    }
 
-        // Suppress the unused warning when `original` is otherwise dead in
-        // this branch (it's already stored in the map; we just keep the binding
-        // to make the intent clear and to avoid future regressions if someone
-        // reorders the code).
-        let _ = original;
+    // SAFETY: hwnd is a valid window handle provided by the caller (guaranteed by
+    // the `# Safety` contract). All Win32 calls below operate on this valid HWND
+    // or stack-local data. The transmute of the original WndProc pointer to WNDPROC
+    // (inside `nc_subclass_wndproc`) is safe because the value was obtained from
+    // `GetWindowLongPtrW` on the same HWND.
+    unsafe {
+        let hwnd_win = HWND(hwnd as *mut _);
+        let self_addr = nc_subclass_wndproc as *const () as usize as isize;
+
+        let original = match claim_subclass_slot(hwnd, hwnd_win, self_addr) {
+            SlotClaim::Acquired { original } => original,
+            SlotClaim::AlreadyHandled | SlotClaim::InvalidHwnd => return,
+        };
+
+        if !install_subclass_wndproc(hwnd, hwnd_win, self_addr) {
+            return;
+        }
+
+        upgrade_subclass_slot(hwnd, original);
+        commit_subclass_frame(hwnd_win);
 
         tracing::info!(
             "Subclassed HWND 0x{:X} for zero NC area (WM_NCCALCSIZE interception)",
@@ -211,7 +338,7 @@ pub fn subclass_for_zero_nc_area(_hwnd: isize) {
     // No-op on non-Windows platforms
 }
 
-/// Drain all pending Win32 messages on the *current* thread's queue.
+/// Drain pending Win32 messages on the *current* thread's queue.
 ///
 /// # Why this is needed
 ///
@@ -236,35 +363,90 @@ pub fn subclass_for_zero_nc_area(_hwnd: isize) {
 /// next synchronous `SendMessage` cascade does not pile on top of an
 /// already-saturated queue.
 ///
+/// # Scope filter
+///
+/// `hwnd_filter`:
+///   * `Some(hwnd)` — only drain messages targeted at `hwnd` (and its
+///     descendants per `PeekMessageW` semantics). Use this in DCC-embedded
+///     paths to avoid disturbing the host's own message stream
+///     (e.g. Maya/Qt `WM_PAINT` / `WM_TIMER`).
+///   * `None` — drain all messages on this thread's queue. Use only when
+///     the calling code owns the thread's message loop (standalone / tests).
+///
+/// # Tracing
+///
+/// `reason` is a short, static label (e.g. `"pre-style"`,
+/// `"post-set-parent"`, `"post-set-window-pos"`) that is logged alongside
+/// the dispatched count. It lets diagnostics tell which step in
+/// `apply_child_window_style` produced the queue pressure without having
+/// to walk the stack.
+///
 /// This is a *bounded* operation: we drain at most `cap` messages so we
 /// can never spin forever if the host keeps producing messages.
 #[cfg(target_os = "windows")]
-pub(crate) fn drain_thread_messages(cap: u32) {
+pub(crate) fn drain_thread_messages_for(hwnd_filter: Option<HWND>, cap: u32, reason: &'static str) {
     // SAFETY: PeekMessageW / TranslateMessage / DispatchMessageW are documented
     // Win32 APIs; we own the call (no foreign references) and the MSG buffer
     // is stack-local. No memory safety concerns.
     unsafe {
         let mut msg = MSG::default();
         let mut n: u32 = 0;
-        while n < cap && PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+        while n < cap && PeekMessageW(&mut msg, hwnd_filter, 0, 0, PM_REMOVE).as_bool() {
             let _ = TranslateMessage(&msg);
             DispatchMessageW(&msg);
             n += 1;
         }
-        if n > 0 {
+
+        // Distinguish three observable outcomes so diagnostics are not silent
+        // when the queue is actually saturated:
+        //   * n == 0       — quiet path, do nothing.
+        //   * 0 < n < cap  — normal cascade fully drained, trace at TRACE.
+        //   * n == cap     — drained up to the bound but PeekMessageW *might*
+        //     still have more pending. Emit a WARN with rate-limiting context
+        //     so operators can spot a real saturation issue (e.g. cap too
+        //     low for a particular DCC host) without grepping TRACE logs.
+        //     The message is intentionally actionable: it names the call site
+        //     (`reason`) and the cap value so bumping `STYLE_MUTATION_DRAIN_CAP`
+        //     is a one-line change driven by real evidence rather than
+        //     guesswork.
+        if n == 0 {
+            // Nothing to log: the common "no pending work" path stays silent
+            // so we don't spam logs in the steady state.
+        } else if n == cap {
+            tracing::warn!(
+                reason = reason,
+                filter = ?hwnd_filter,
+                dispatched = n,
+                cap = cap,
+                "drain_thread_messages_for hit cap; queue may still be saturated \
+                 (consider raising STYLE_MUTATION_DRAIN_CAP if this fires under load)"
+            );
+        } else {
             tracing::trace!(
-                "[drain_thread_messages] dispatched {} pending message(s)",
-                n
+                reason = reason,
+                filter = ?hwnd_filter,
+                dispatched = n,
+                cap = cap,
+                "drain_thread_messages_for"
             );
         }
     }
 }
 
-#[cfg(not(target_os = "windows"))]
-#[allow(dead_code)]
-pub(crate) fn drain_thread_messages(_cap: u32) {
-    // No-op on non-Windows platforms
-}
+// Non-Windows platforms have no callers: every `drain_thread_messages_for`
+// call site is gated behind `#[cfg(target_os = "windows")]`. We deliberately
+// do NOT expose a stub to keep cross-platform signature drift impossible.
+
+/// Maximum number of pending Win32 messages drained around each big style
+/// mutation in [`apply_child_window_style`].
+///
+/// Empirically large enough for one full cascade of
+/// `WM_NCCALCSIZE` / `WM_WINDOWPOSCHANGED` / `WM_PARENTNOTIFY` /
+/// `Chrome_WidgetWin_*` notifications produced by `SetWindowLongW` /
+/// `SetParent` / `SetWindowPos`, while staying bounded so we cannot spin
+/// forever if the host keeps producing messages.
+#[cfg(target_os = "windows")]
+const STYLE_MUTATION_DRAIN_CAP: u32 = 256;
 
 /// Apply WS_CHILD style to a window and set its parent
 ///
@@ -305,8 +487,12 @@ pub fn apply_child_window_style(
         // Without this, the upcoming SetWindowLongW/SetParent/SetWindowPos calls
         // would issue synchronous SendMessage cascades on top of a saturated
         // queue, deadlocking the STA when WebView2's child windows perform COM
-        // marshaling. See `drain_thread_messages` for full rationale.
-        drain_thread_messages(256);
+        // marshaling. See `drain_thread_messages_for` for full rationale.
+        //
+        // Scope the drain to messages targeted at our own HWND so we don't
+        // disturb the host's (Maya/Houdini/Qt) message stream — those hosts
+        // may have ordering assumptions on their own WM_PAINT/WM_INPUT/WM_TIMER.
+        drain_thread_messages_for(Some(hwnd_win), STYLE_MUTATION_DRAIN_CAP, "pre-style");
 
         // Step 1: Compute new styles
         let style = GetWindowLongW(hwnd_win, GWL_STYLE);
@@ -336,6 +522,37 @@ pub fn apply_child_window_style(
         SetWindowLongW(hwnd_win, GWL_STYLE, new_style);
         SetWindowLongW(hwnd_win, GWL_EXSTYLE, new_ex_style);
 
+        // Step 2.5: Commit style changes to the NC frame.
+        //
+        // Per MSDN, GWL_STYLE / GWL_EXSTYLE mutations are not visible to the
+        // window's non-client area until the next SetWindowPos with
+        // SWP_FRAMECHANGED. Without this commit, when the SetParent branch
+        // below short-circuits (`needs_set_parent == false`) the styles
+        // would only become visible at step 5's SetWindowPos — leaving a
+        // brief window where the new styles are stored but the frame is
+        // still drawn from the old ones (visible as a flash of the old
+        // caption / border on some DPI / theme combinations).
+        //
+        // The call is intentionally side-effect-free (no move, size, z-order
+        // or activation change); it just triggers the WM_NCCALCSIZE /
+        // WM_NCPAINT pass that materialises the style mutation.
+        let _ = SetWindowPos(
+            hwnd_win,
+            None,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+        );
+        // Drain the resulting WM_NCCALCSIZE / WM_WINDOWPOSCHANGED cascade so
+        // it does not pile on top of the next SetParent / SetWindowPos call.
+        drain_thread_messages_for(
+            Some(hwnd_win),
+            STYLE_MUTATION_DRAIN_CAP,
+            "post-style-commit",
+        );
+
         // Step 3: Conditionally call SetParent.
         //
         // tao's `with_parent_window(parent_hwnd)` already sets the parent at
@@ -345,19 +562,57 @@ pub fn apply_child_window_style(
         // notify the *whole* subtree (WM_PARENTNOTIFY, DWM updates, etc.).
         //
         // Only call SetParent when the current parent is actually different
-        // from the desired one. Pump the queue afterwards so the resulting
-        // synchronous notifications can complete before we proceed.
-        let current_parent: HWND = GetParent(hwnd_win).unwrap_or(HWND(std::ptr::null_mut()));
-        if current_parent.0 != parent_hwnd_win.0 {
+        // from the desired one. Use `GetParent(...).ok()` instead of comparing
+        // raw HWND pointers — when GetParent fails (top-level window with no
+        // parent, or the call itself errored) it returns Err, and treating
+        // that as "different parent" is exactly the behavior we want.
+        //
+        // Diagnostic level for the Err branch is gated on the *original*
+        // style (`style`, before our SetWindowLongW above):
+        //
+        //   * Original style had `WS_CHILD` set → the HWND was already a
+        //     child window, which by definition must have a parent.
+        //     `GetParent` returning Err here points at a real anomaly
+        //     (parent destroyed, HWND torn down mid-call) — `warn!`.
+        //   * Original style did NOT have `WS_CHILD` set → caller passed
+        //     a legitimate top-level window (e.g. WS_POPUP) that we are
+        //     about to re-parent. This is the normal embedding flow,
+        //     not a bug — `debug!` so we don't drown out real warnings
+        //     in DCC logs.
+        //
+        // In both cases we still proceed: `SetParent` is the correct
+        // recovery action either way.
+        let was_child_originally = (style & (WS_CHILD.0 as i32)) != 0;
+        let needs_set_parent = match GetParent(hwnd_win).ok() {
+            Some(current) => current.0 != parent_hwnd_win.0,
+            None => {
+                if was_child_originally {
+                    tracing::warn!(
+                        "[apply_child_window_style] GetParent returned no parent for HWND 0x{:X} \
+                         that already had WS_CHILD set; parent may have been destroyed. \
+                         Proceeding with SetParent as recovery.",
+                        hwnd
+                    );
+                } else {
+                    tracing::debug!(
+                        "[apply_child_window_style] HWND 0x{:X} is currently top-level \
+                         (no WS_CHILD); will re-parent to 0x{:X}",
+                        hwnd,
+                        parent_hwnd
+                    );
+                }
+                true
+            }
+        };
+        if needs_set_parent {
             tracing::info!(
-                "[apply_child_window_style] SetParent: HWND 0x{:X} -> 0x{:X} (current parent 0x{:X})",
+                "[apply_child_window_style] SetParent: HWND 0x{:X} -> 0x{:X}",
                 hwnd,
-                parent_hwnd,
-                current_parent.0 as isize
+                parent_hwnd
             );
             let _ = SetParent(hwnd_win, Some(parent_hwnd_win));
             // Let WM_PARENTNOTIFY / DWM / Chrome_WidgetWin_* updates settle.
-            drain_thread_messages(256);
+            drain_thread_messages_for(Some(hwnd_win), STYLE_MUTATION_DRAIN_CAP, "post-set-parent");
         } else {
             tracing::debug!(
                 "[apply_child_window_style] parent already 0x{:X}, skip SetParent",
@@ -397,8 +652,13 @@ pub fn apply_child_window_style(
 
         // Drain again so SetWindowPos's WM_WINDOWPOSCHANGED / WM_NCCALCSIZE /
         // WM_SIZE cascade is delivered before the caller proceeds to the next
-        // big Win32 call (e.g. fix_webview2_child_windows).
-        drain_thread_messages(256);
+        // big Win32 call (e.g. fix_webview2_child_windows). Scoped to our HWND
+        // so we don't disturb the host's message stream.
+        drain_thread_messages_for(
+            Some(hwnd_win),
+            STYLE_MUTATION_DRAIN_CAP,
+            "post-set-window-pos",
+        );
 
         tracing::info!(
             "Applied WS_CHILD style: HWND 0x{:X} -> Parent 0x{:X} (style 0x{:08X} -> 0x{:08X}, ex_style 0x{:08X} -> 0x{:08X})",

--- a/examples/child_aware_demo.py
+++ b/examples/child_aware_demo.py
@@ -348,7 +348,7 @@ def create_webview(ctx: ChildContext):
 
     # Listen for parent events (if in child mode)
     if ctx.bridge:
-        ctx.on_parent_event("parent:data", lambda data: (webview.emit("parent:response", data)))
+        ctx.on_parent_event("parent:data", lambda data: webview.emit("parent:response", data))
 
     return webview
 

--- a/examples/inspector_demo.py
+++ b/examples/inspector_demo.py
@@ -59,7 +59,7 @@ def main():
             if snap.ref_count() > 0:
                 print("Interactive Elements:")
                 for ref_id, ref_info in list(snap.refs.items())[:10]:  # Show first 10
-                    print(f"  {ref_id}  [{ref_info.role}] \"{ref_info.name}\"")
+                    print(f'  {ref_id}  [{ref_info.role}] "{ref_info.name}"')
                 if snap.ref_count() > 10:
                     print(f"  ... and {snap.ref_count() - 10} more")
             print()
@@ -95,7 +95,7 @@ def main():
             print("=" * 60)
 
             result = page.eval("document.title")
-            print(f"document.title = \"{result}\"")
+            print(f'document.title = "{result}"')
 
             result = page.eval("window.innerWidth + 'x' + window.innerHeight")
             print(f"viewport = {result}")
@@ -131,9 +131,9 @@ def main():
             if snap.ref_count() > 0:
                 first_ref = next(iter(snap.refs.keys()))
                 print(f"\nTo click element {first_ref}:")
-                print(f"  page.click(\"{first_ref}\")")
+                print(f'  page.click("{first_ref}")')
                 print("\nTo fill a textbox:")
-                print(f"  page.fill(\"{first_ref}\", \"your text\")")
+                print(f'  page.fill("{first_ref}", "your text")')
             print()
 
             # === 7. Snapshot Formats ===

--- a/python/auroraview/core/webview.py
+++ b/python/auroraview/core/webview.py
@@ -691,7 +691,10 @@ class WebView(
         should be closed.
 
         Returns:
-            True if the window should close, False otherwise
+            True if the window should close, False otherwise. Also returns
+            False when no backing core is currently available (packed mode,
+            pre-init, post-dispose) — in those cases there is nothing to
+            drain and synthesizing a close request would be wrong.
 
         Example:
             >>> # In Maya, use a scriptJob to process events
@@ -702,7 +705,17 @@ class WebView(
             ...
             >>> job_id = cmds.scriptJob(event=["idle", process_webview_events])
         """
-        return self._core.process_events()
+        # Prefer ``_async_core`` when wired up by the show-thread, then
+        # fall back to ``_core``. Without this, packed mode
+        # (``_core is None`` but ``_async_core`` wired up by the
+        # show-thread) would have ``is_ready`` report True while
+        # ``self._core.process_events()`` raises ``AttributeError`` on
+        # every 16 ms timer tick.
+        with self._async_core_lock:
+            core = self._async_core if self._async_core is not None else self._core
+        if core is None:
+            return False
+        return core.process_events()
 
     def process_events_ipc_only(self) -> bool:
         """Process only internal AuroraView IPC without touching host event loop.
@@ -711,8 +724,19 @@ class WebView(
         where the native window message pump is owned by the host application.
         It only drains the internal WebView message queue and respects
         lifecycle close requests.
+
+        Returns:
+            True if the window should close, False otherwise. Also returns
+            False when no backing core is currently available — see
+            :meth:`process_events` for the full enumeration.
         """
-        return self._core.process_ipc_only()
+        # Same active-core probe as :meth:`process_events`; see that method
+        # for the rationale on aligning with :attr:`is_ready` semantics.
+        with self._async_core_lock:
+            core = self._async_core if self._async_core is not None else self._core
+        if core is None:
+            return False
+        return core.process_ipc_only()
 
     def is_alive(self) -> bool:
         """Check if WebView is still running.

--- a/python/auroraview/utils/event_timer.py
+++ b/python/auroraview/utils/event_timer.py
@@ -260,6 +260,40 @@ class EventTimer:
             logger.debug("Tick callback not found during unregistration")
             return False
 
+    def _is_core_ready(self) -> bool:
+        """Return True when at least one of the WebView cores is initialized.
+
+        With the non-blocking WebView2 startup, the synchronous ``_core`` and
+        the background-thread ``_async_core`` may become available in either
+        order. The timer should keep ticking — and IPC events should keep
+        flowing — as soon as EITHER is ready.
+
+        Notes on shape compatibility:
+            * Some embedding modes (e.g. packed mode, lightweight test stubs)
+              may not define ``_async_core`` / ``_async_core_lock`` at all.
+              In that case we fall back to checking ``_core`` only.
+            * The ``_async_core_lock`` critical section is intentionally
+              minimal — we only read the attribute and release the lock
+              before any further work, so we never hold it across blocking
+              calls into the core.
+        """
+        webview = self._webview
+        if webview is None:
+            return False
+
+        async_ready = False
+        if hasattr(webview, "_async_core"):
+            lock = getattr(webview, "_async_core_lock", None)
+            if lock is not None:
+                with lock:
+                    async_ready = webview._async_core is not None
+            else:
+                # Lock missing for some reason — best-effort read.
+                async_ready = webview._async_core is not None
+
+        sync_ready = getattr(webview, "_core", None) is not None
+        return async_ready or sync_ready
+
     def _tick(self) -> None:
         """Timer tick callback (runs in main thread for Qt, background thread for thread backend)."""
         if not self._running:
@@ -278,13 +312,9 @@ class EventTimer:
             # Process WebView events (only if WebView is initialized)
             should_close = False
             try:
-                if hasattr(self._webview, "_async_core"):
-                    with self._webview._async_core_lock:
-                        async_ready = self._webview._async_core is not None
-                    sync_ready = getattr(self._webview, "_core", None) is not None
-                    if not async_ready and not sync_ready:
-                        # WebView not yet initialized, skip this tick
-                        return
+                if not self._is_core_ready():
+                    # WebView not yet initialized, skip this tick
+                    return
 
                 # Choose event-processing strategy based on timer backend.
                 # Qt backend uses IPC-only mode if available, others use full process_events
@@ -309,13 +339,9 @@ class EventTimer:
             # Check window validity (Windows only, and only if WebView is initialized)
             if self._check_validity and hasattr(self._webview, "_core"):
                 try:
-                    if hasattr(self._webview, "_async_core"):
-                        with self._webview._async_core_lock:
-                            async_ready = self._webview._async_core is not None
-                        sync_ready = getattr(self._webview, "_core", None) is not None
-                        if not async_ready and not sync_ready:
-                            # WebView not yet initialized, skip validity check
-                            return
+                    if not self._is_core_ready():
+                        # WebView not yet initialized, skip validity check
+                        return
 
                     is_valid = self._check_window_valid()
                     if self._last_valid and not is_valid:

--- a/python/auroraview/utils/event_timer.py
+++ b/python/auroraview/utils/event_timer.py
@@ -39,7 +39,7 @@ Example:
 """
 
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Callable, ClassVar, Optional, Set
 
 from auroraview.utils.timer_backends import (
     QtTimerBackend,
@@ -84,6 +84,16 @@ class EventTimer:
         >>> timer = EventTimer(webview)  # Will use Maya backend if available
         >>> timer.start()
     """
+
+    # Class-level dedup set of webview types that already emitted the
+    # "missing `is_ready`" debug message. Keyed on ``type(webview)`` so the
+    # warning is suppressed once per stub class for the lifetime of the
+    # process — even if the same partial mock is wrapped by many
+    # short-lived ``EventTimer`` instances (a common pattern in test
+    # fixtures). Class-level set keeps this independent of per-instance
+    # state and avoids the weakref bookkeeping that a per-instance flag
+    # would otherwise need.
+    _warned_missing_is_ready_types: ClassVar[Set[type]] = set()
 
     def __init__(
         self,
@@ -261,38 +271,40 @@ class EventTimer:
             return False
 
     def _is_core_ready(self) -> bool:
-        """Return True when at least one of the WebView cores is initialized.
+        """Return True when the WebView core is initialized.
 
-        With the non-blocking WebView2 startup, the synchronous ``_core`` and
-        the background-thread ``_async_core`` may become available in either
-        order. The timer should keep ticking -- and IPC events should keep
-        flowing -- as soon as EITHER is ready.
+        Single source of truth: :attr:`WebView.is_ready`. The timer never
+        inspects ``_core`` / ``_async_core`` directly — stub compatibility,
+        lock acquisition and dual-core (sync + async) semantics are all
+        owned by ``WebView.is_ready`` so we don't drift from the canonical
+        probe.
 
-        Notes on shape compatibility:
-            * Some embedding modes (e.g. packed mode, lightweight test stubs)
-              may not define ``_async_core`` / ``_async_core_lock`` at all.
-              In that case we fall back to checking ``_core`` only.
-            * The ``_async_core_lock`` critical section is intentionally
-              minimal -- we only read the attribute and release the lock
-              before any further work, so we never hold it across blocking
-              calls into the core.
+        Stubs that don't expose ``is_ready`` (or expose a non-bool value)
+        are treated as not-ready; they should add an ``is_ready`` property
+        to integrate with the timer.
         """
         webview = self._webview
         if webview is None:
             return False
-
-        async_ready = False
-        if hasattr(webview, "_async_core"):
-            lock = getattr(webview, "_async_core_lock", None)
-            if lock is not None:
-                with lock:
-                    async_ready = webview._async_core is not None
-            else:
-                # Lock missing for some reason -- best-effort read.
-                async_ready = webview._async_core is not None
-
-        sync_ready = getattr(webview, "_core", None) is not None
-        return async_ready or sync_ready
+        # Lightweight one-shot warning for legacy stubs / partial mocks that
+        # don't expose `is_ready`. We log at DEBUG (not WARNING) because some
+        # test fixtures intentionally fake a webview without going through
+        # the full `WebView` constructor — and we don't want noisy output in
+        # the steady state. Dedup is keyed on the stub's *type* (class-level
+        # set) so we emit at most one message per webview class for the
+        # lifetime of the process, even across many short-lived timers.
+        if not hasattr(webview, "is_ready"):
+            wv_type = type(webview)
+            if wv_type not in EventTimer._warned_missing_is_ready_types:
+                EventTimer._warned_missing_is_ready_types.add(wv_type)
+                logger.debug(
+                    "EventTimer: webview %r exposes no `is_ready` property; "
+                    "treating as not-ready. Add an `is_ready` property to the "
+                    "stub if it should drive the timer.",
+                    wv_type.__name__,
+                )
+            return False
+        return bool(webview.is_ready)
 
     def _tick(self) -> None:
         """Timer tick callback (runs in main thread for Qt, background thread for thread backend)."""
@@ -336,8 +348,15 @@ class EventTimer:
             except Exception as e:
                 logger.error(f"Error processing events: {e}", exc_info=True)
 
-            # Check window validity (Windows only, and only if WebView is initialized)
-            if self._check_validity and hasattr(self._webview, "_core"):
+            # Check window validity (Windows only, gated by `_is_core_ready`).
+            #
+            # We previously also tested `hasattr(self._webview, "_core")` here,
+            # but that became a hidden second source of truth: stubs without
+            # `_core` would silently bypass validity checks even when their
+            # `is_ready` reported True. Delegating entirely to
+            # `_is_core_ready()` keeps :class:`WebView` as the single owner
+            # of "what does ready mean".
+            if self._check_validity:
                 try:
                     if not self._is_core_ready():
                         # WebView not yet initialized, skip validity check
@@ -379,16 +398,39 @@ class EventTimer:
             logger.error(f"Unexpected error in timer tick: {e}", exc_info=True)
 
     def _check_window_valid(self) -> bool:
-        """Check if window is still valid (Windows only).
+        """Check if window is still valid.
+
+        Delegates entirely to :meth:`WebView.is_window_valid` — the timer
+        does **not** look at ``_core`` / ``_async_core`` directly. This
+        keeps :class:`WebView` as the single owner of "what does ready /
+        valid mean" and removes the previous duplicated fallback path
+        that silently bypassed checks for stubs without a ``_core``
+        attribute.
+
+        Stubs that don't expose ``is_window_valid`` are treated as valid
+        (legacy behavior preserved); they should add the method if they
+        want to drive the timer's close-on-destroy logic.
 
         Returns:
-            True if window is valid, False otherwise
+            True if window is valid or its validity cannot be determined,
+            False only when the native probe explicitly reports the
+            window has been destroyed.
         """
-        try:
-            # Call Rust function to check window validity
-            if hasattr(self._webview, "_core"):
-                return self._webview._core.is_window_valid()
+        webview = self._webview
+        if webview is None:
+            return False
+        # ``_is_core_ready`` already gated the call site, but keep the
+        # guard here too so direct callers (tests) get the same answer.
+        if not self._is_core_ready():
             return True
+
+        probe = getattr(webview, "is_window_valid", None)
+        if probe is None:
+            # Stub without the public probe — treat as valid so the
+            # timer doesn't synthesize a spurious close event.
+            return True
+        try:
+            return bool(probe())
         except Exception as e:
             logger.error(f"Error checking window validity: {e}")
             return False

--- a/python/auroraview/utils/event_timer.py
+++ b/python/auroraview/utils/event_timer.py
@@ -278,13 +278,13 @@ class EventTimer:
             # Process WebView events (only if WebView is initialized)
             should_close = False
             try:
-                # Check if WebView is initialized (for non-blocking mode)
                 if hasattr(self._webview, "_async_core"):
-                    # Non-blocking mode: check if core is ready
                     with self._webview._async_core_lock:
-                        if self._webview._async_core is None:
-                            # WebView not yet initialized, skip this tick
-                            return
+                        async_ready = self._webview._async_core is not None
+                    sync_ready = getattr(self._webview, "_core", None) is not None
+                    if not async_ready and not sync_ready:
+                        # WebView not yet initialized, skip this tick
+                        return
 
                 # Choose event-processing strategy based on timer backend.
                 # Qt backend uses IPC-only mode if available, others use full process_events
@@ -309,12 +309,13 @@ class EventTimer:
             # Check window validity (Windows only, and only if WebView is initialized)
             if self._check_validity and hasattr(self._webview, "_core"):
                 try:
-                    # Check if WebView is initialized (for non-blocking mode)
                     if hasattr(self._webview, "_async_core"):
                         with self._webview._async_core_lock:
-                            if self._webview._async_core is None:
-                                # WebView not yet initialized, skip validity check
-                                return
+                            async_ready = self._webview._async_core is not None
+                        sync_ready = getattr(self._webview, "_core", None) is not None
+                        if not async_ready and not sync_ready:
+                            # WebView not yet initialized, skip validity check
+                            return
 
                     is_valid = self._check_window_valid()
                     if self._last_valid and not is_valid:

--- a/python/auroraview/utils/event_timer.py
+++ b/python/auroraview/utils/event_timer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Event timer for WebView event processing.
 
 This module provides a timer-based event loop for processing WebView events

--- a/python/auroraview/utils/event_timer.py
+++ b/python/auroraview/utils/event_timer.py
@@ -265,15 +265,15 @@ class EventTimer:
 
         With the non-blocking WebView2 startup, the synchronous ``_core`` and
         the background-thread ``_async_core`` may become available in either
-        order. The timer should keep ticking — and IPC events should keep
-        flowing — as soon as EITHER is ready.
+        order. The timer should keep ticking -- and IPC events should keep
+        flowing -- as soon as EITHER is ready.
 
         Notes on shape compatibility:
             * Some embedding modes (e.g. packed mode, lightweight test stubs)
               may not define ``_async_core`` / ``_async_core_lock`` at all.
               In that case we fall back to checking ``_core`` only.
             * The ``_async_core_lock`` critical section is intentionally
-              minimal — we only read the attribute and release the lock
+              minimal -- we only read the attribute and release the lock
               before any further work, so we never hold it across blocking
               calls into the core.
         """
@@ -288,7 +288,7 @@ class EventTimer:
                 with lock:
                     async_ready = webview._async_core is not None
             else:
-                # Lock missing for some reason — best-effort read.
+                # Lock missing for some reason -- best-effort read.
                 async_ready = webview._async_core is not None
 
         sync_ready = getattr(webview, "_core", None) is not None

--- a/src/platform/windows/webview2.rs
+++ b/src/platform/windows/webview2.rs
@@ -14,16 +14,15 @@
 
 #[cfg(all(target_os = "windows", feature = "win-webview2"))]
 pub mod win {
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
+    use std::sync::OnceLock;
     use std::time::{Duration, Instant};
 
     use anyhow::{anyhow, Context, Result};
     use webview2::{Controller, Environment, WebView};
     use winapi::shared::windef::{HWND, RECT};
-    use windows::Win32::Foundation::HWND as HWND_WIN;
-    use windows::Win32::UI::WindowsAndMessaging::{
-        DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE,
-    };
+    use windows::Win32::Foundation::{HANDLE, HWND as HWND_WIN};
 
     /// Real WebView2 wrapper used by the pyo3 layer.
     pub struct WinWebView {
@@ -114,18 +113,63 @@ pub mod win {
         }
     }
 
-    pub(crate) fn pump_windows_messages() {
-        unsafe {
-            let mut msg = MSG::default();
-            while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
-                let _ = TranslateMessage(&msg);
-                DispatchMessageW(&msg);
-            }
+    /// Default total timeout used by `recv_with_pump` when the
+    /// `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` environment variable is unset or
+    /// holds a non-positive / non-numeric value.
+    const DEFAULT_WEBVIEW2_TIMEOUT_SECS: u64 = 30;
+
+    /// Environment variable name used to override the WebView2 cold-start
+    /// timeout in [`recv_with_pump`]. Value is interpreted as **seconds, as a
+    /// plain unsigned integer with no unit suffix** (e.g. `"60"`, not `"60s"`
+    /// or `"60 seconds"`). Anything that fails to parse, is zero, or is
+    /// negative falls back to [`DEFAULT_WEBVIEW2_TIMEOUT_SECS`].
+    const WEBVIEW2_TIMEOUT_ENV: &str = "AURORAVIEW_WEBVIEW2_TIMEOUT_SECS";
+
+    /// Resolve the WebView2 cold-start timeout for [`recv_with_pump`].
+    ///
+    /// Reads `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` once per process and caches
+    /// the result. If the variable is missing, empty, not a valid `u64`,
+    /// zero, or carries a unit suffix, falls back to the 30s default and
+    /// emits a single `tracing::warn!` (subsequent calls are silent because
+    /// the parsed value is memoized).
+    ///
+    /// Caching is a deliberate trade-off: every WebView2 cold start invokes
+    /// this twice (Environment + Controller) and the env value cannot
+    /// meaningfully change at runtime. Re-parsing each call would also
+    /// double-emit the warning for invalid values, which is just noise.
+    fn webview2_total_timeout() -> Duration {
+        // `OnceLock` is `Send + Sync` and resolves on first access; later
+        // callers see the cached value with no syscall and no logging.
+        static CACHED: OnceLock<Duration> = OnceLock::new();
+        *CACHED.get_or_init(parse_webview2_total_timeout)
+    }
+
+    /// One-shot parse of `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS`. Pulled out of
+    /// [`webview2_total_timeout`] so the unit tests can exercise the parser
+    /// directly without going through the process-wide cache (which would
+    /// otherwise pin the very first observed value for the lifetime of the
+    /// test binary).
+    fn parse_webview2_total_timeout() -> Duration {
+        match std::env::var(WEBVIEW2_TIMEOUT_ENV) {
+            Ok(raw) => match raw.trim().parse::<u64>() {
+                Ok(secs) if secs > 0 => Duration::from_secs(secs),
+                _ => {
+                    tracing::warn!(
+                        "{} = {:?} is not a positive integer; falling back to {}s",
+                        WEBVIEW2_TIMEOUT_ENV,
+                        raw,
+                        DEFAULT_WEBVIEW2_TIMEOUT_SECS
+                    );
+                    Duration::from_secs(DEFAULT_WEBVIEW2_TIMEOUT_SECS)
+                }
+            },
+            Err(_) => Duration::from_secs(DEFAULT_WEBVIEW2_TIMEOUT_SECS),
         }
     }
 
     fn recv_with_pump<T>(
         rx: mpsc::Receiver<std::result::Result<T, webview2::Error>>,
+        signal: &SignalEvent,
         what: &str,
     ) -> Result<T> {
         // Replace the previous busy-loop (PeekMessageW + Sleep(1ms)) implementation,
@@ -135,38 +179,57 @@ pub mod win {
         //
         // Instead, let the OS wake us up only when:
         //   * a COM call is dispatched into our STA (WebView2's async callback), or
-        //   * a window message arrives for this thread.
+        //   * a window message arrives for this thread, or
+        //   * `signal` becomes signaled — set by the caller's `tx.send` side
+        //     immediately after the channel push (see callers below). This is
+        //     the on-demand wake-up that lets us drop the previous 50ms polling
+        //     tick: we only re-check the channel when something actually
+        //     happened.
         //
-        // We keep an outer loop with try_recv() so we never miss the channel send,
-        // and rely on the kernel to schedule us efficiently while the WebView2
-        // browser process is initializing.
-        use windows::core::HRESULT;
+        // The `&SignalEvent` borrow makes the "handle outlives this call"
+        // contract a compile-time guarantee — the caller cannot drop (and
+        // therefore `CloseHandle`) the event while we are still parked on
+        // `CoWaitForMultipleHandles`.
+        //
+        // We keep an outer loop with try_recv() so we never miss the channel send
+        // (the `tx.send → SetEvent` pair is not atomic; the thread can be
+        // pre-empted between the two), and rely on the kernel to schedule us
+        // efficiently while the WebView2 browser process is initializing.
+        use windows::Win32::Foundation::{CO_E_NOTINITIALIZED, RPC_E_WRONG_THREAD};
         use windows::Win32::System::Com::{
             CoWaitForMultipleHandles, COWAIT_DISPATCH_CALLS, COWAIT_DISPATCH_WINDOW_MESSAGES,
         };
-
-        // HRESULTs that indicate the *caller* mis-set up COM/threading state
-        // and that no amount of retrying will fix. Bail out immediately so we
-        // surface the real problem instead of waiting out the 30s timeout.
-        //
-        // Values are stable Win32 constants:
-        //   CO_E_NOTINITIALIZED  = 0x800401F0  (CoInitialize[Ex] not called)
-        //   RPC_E_WRONG_THREAD   = 0x8001010E  (called from the wrong apartment)
-        //
-        // We compare against `HRESULT` (which is `i32` underneath) using the
-        // documented `0x...u32 as i32` round-trip so the bit pattern matches
-        // regardless of platform integer width.
-        const CO_E_NOTINITIALIZED: HRESULT = HRESULT(0x800401F0u32 as i32);
-        const RPC_E_WRONG_THREAD: HRESULT = HRESULT(0x8001010Eu32 as i32);
 
         let start = Instant::now();
         // Generous timeout: WebView2 cold start (Edge runtime spin-up, user-data
         // folder bring-up, ICU data load, etc.) can legitimately take several
         // seconds on first run, especially on slower machines or under AV scans.
-        const TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
-        // Per-iteration wait. Short enough to react quickly when the callback
-        // fires before a window message arrives; long enough to avoid burning CPU.
-        const TICK_MS: u32 = 50;
+        //
+        // Default is 30s, which covers the vast majority of real-world setups.
+        // For unusually slow hosts (CI containers, AV-heavy enterprise machines,
+        // first-run Edge install paths) the default can be overridden via the
+        // `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` environment variable (positive
+        // integer, in seconds). A non-parseable / zero / negative value is
+        // ignored and the default is used.
+        let total_timeout = webview2_total_timeout();
+        // Per-iteration backstop for the `CoWaitForMultipleHandles` wait.
+        //
+        // **This is NOT the response-latency knob.** With the auto-reset
+        // `signal` event, the typical wake-up latency is whatever the
+        // kernel's IPI / scheduler costs (sub-millisecond). The waiter
+        // only sleeps for `BACKSTOP_TICK_MS` when *every* wake source
+        // (signal event, COM dispatch, window message) is silent — at
+        // which point we just want to re-check `start.elapsed()` against
+        // `total_timeout` and loop back.
+        //
+        // **Do not "tune" this down to 50ms** to make `recv_with_pump`
+        // feel snappier — that is exactly the busy-loop behaviour the
+        // signal-event design replaced. A lower value only wastes CPU
+        // (and Maya/Houdini paint cycles) without changing the success
+        // path: the channel send already wakes us via `SetEvent`. The
+        // value is intentionally large (1s) so the cost of "did the
+        // host go completely silent?" is bounded but cheap.
+        const BACKSTOP_TICK_MS: u32 = 1_000;
 
         // The two flags together let the OS:
         //   - run any pending COM calls targeted at this STA
@@ -176,33 +239,48 @@ pub mod win {
         // This is safer than calling PeekMessageW/DispatchMessageW ourselves,
         // because we don't reorder or steal the host's own message stream.
         //
-        // NOTE on types: in `windows = 0.62`, `COWAIT_*` constants are exposed as
-        // `COWAIT_FLAGS(i32)` newtypes, but `CoWaitForMultipleHandles` takes a raw
-        // `u32` for `dwflags`. We use `as u32` (bit-pattern reinterpretation)
-        // rather than `try_into()`, because future SDK versions could legitimately
-        // define a flag with the high bit set (i.e. negative i32) and `try_into()`
-        // would then panic at runtime even though the bit pattern is correct.
+        // `CoWaitForMultipleHandles`'s `dwflags` parameter is a `u32`, while
+        // `COWAIT_*` constants in `windows = 0.62` are `COWAIT_FLAGS(i32)`
+        // newtypes. A direct `as u32` bit-pattern cast is the simplest stable
+        // mapping and matches the API signature exactly.
         let flags: u32 =
             (COWAIT_DISPATCH_CALLS.0 as u32) | (COWAIT_DISPATCH_WINDOW_MESSAGES.0 as u32);
+
+        let handles = [signal.handle()];
 
         loop {
             if let Ok(res) = rx.try_recv() {
                 return res.map_err(|e| anyhow!(e.to_string()));
             }
 
+            // Bail out *before* re-entering the wait. Putting the timeout
+            // check here (as opposed to after `match wait_result`) means:
+            //   * we never spend an extra BACKSTOP_TICK_MS sleeping past the
+            //     deadline just to log one more `trace!` line, and
+            //   * the timeout path is symmetric with the `try_recv` check
+            //     above — both are evaluated on every iteration before any
+            //     blocking call.
+            if start.elapsed() > total_timeout {
+                return Err(anyhow!(format!("timeout while waiting for {}", what)));
+            }
+
             // SAFETY: CoWaitForMultipleHandles is a documented Win32 API.
-            // We pass an empty handle slice and rely solely on the timeout +
-            // dispatch flags to wake us. Passing cHandles == 0 is observed to
-            // behave as "block up to dwTimeout while dispatching per dwFlags",
-            // which is exactly what we want; if a future Windows release changes
-            // this, we will need to plumb in a real auto-reset event handle.
+            // The `&SignalEvent` borrow guarantees the underlying kernel
+            // handle is valid for the entire duration of this wait —
+            // `CloseHandle` cannot run until the borrow ends, which
+            // happens no earlier than this function's return. The
+            // auto-reset semantics mean the event is consumed by exactly
+            // one waiter, but we always re-check `try_recv` on every
+            // wake so a missed wake-up only delays us by at most
+            // `BACKSTOP_TICK_MS`.
             //
             // Signature in `windows = 0.62`:
             //   fn CoWaitForMultipleHandles(...) -> Result<u32, windows::core::Error>
             // The `Ok(u32)` payload is the WAIT_* index that signaled — useless
-            // to us with an empty handle slice, but we still check `Err` to
-            // detect fatal apartment / initialization mistakes.
-            let wait_result = unsafe { CoWaitForMultipleHandles(flags, TICK_MS, &[]) };
+            // to us in this configuration, but we still check `Err` to detect
+            // fatal apartment / initialization mistakes.
+            let wait_result =
+                unsafe { CoWaitForMultipleHandles(flags, BACKSTOP_TICK_MS, &handles) };
 
             // Map the result into one of three categories:
             //   * "fatal caller error" — STA not initialized or wrong thread.
@@ -245,8 +323,173 @@ pub mod win {
                 }
             }
 
-            if start.elapsed() > TOTAL_TIMEOUT {
-                return Err(anyhow!(format!("timeout while waiting for {}", what)));
+            // Loop back: the next iteration's `try_recv` + `start.elapsed()`
+            // checks at the top of the loop drive both the success and the
+            // timeout exits.
+        }
+    }
+
+    /// Shared inner state for [`SignalEvent`] / [`SignalToken`].
+    ///
+    /// The kernel handle is owned here and `CloseHandle` runs in
+    /// `Drop` — which only fires when **both** the waiter side
+    /// (`SignalEvent`) and every closure-side ([`SignalToken`])
+    /// have been dropped. That's the entire point of using `Arc`:
+    /// the WebView2 worker can no longer race with `CloseHandle`,
+    /// regardless of whether `recv_with_pump` returned via the
+    /// success or the timeout path.
+    ///
+    /// `Send + Sync` is sound because:
+    ///   * `HANDLE` is just an opaque kernel index; `SetEvent` /
+    ///     `CloseHandle` are documented thread-safe.
+    ///   * `signaled` is an `AtomicBool`.
+    ///   * The `Drop` impl only ever runs once, on the last
+    ///     `Arc::drop` — single-threaded by `Arc` semantics.
+    struct SignalInner {
+        handle: HANDLE,
+        /// Flipped by [`SignalToken::signal`] right after `SetEvent`.
+        /// Read by [`SignalEvent::Drop`] to surface the "callback
+        /// never fired" diagnostic.
+        signaled: AtomicBool,
+    }
+
+    impl Drop for SignalInner {
+        fn drop(&mut self) {
+            use windows::Win32::Foundation::CloseHandle;
+            // SAFETY: handle was created by CreateEventW and ownership is
+            // exclusive to this Arc — by the time the last reference drops,
+            // no SignalToken can exist that might still call SetEvent. This
+            // is the property `Arc<SignalInner>` buys us over the previous
+            // raw-HANDLE-copy design.
+            unsafe {
+                let _ = CloseHandle(self.handle);
+            }
+        }
+    }
+
+    // SAFETY: `HANDLE` is `!Send + !Sync` in the `windows` crate purely
+    // because it's a raw pointer newtype, but the underlying kernel
+    // object is process-wide and the operations we perform on it
+    // (`SetEvent`, `CloseHandle`) are explicitly documented thread-safe
+    // by MSDN. The only mutable state besides the handle is
+    // `AtomicBool`, which is `Sync` by definition. Wrapping in `Arc`
+    // requires both bounds.
+    unsafe impl Send for SignalInner {}
+    unsafe impl Sync for SignalInner {}
+
+    /// RAII guard wrapping a `CreateEventW` handle.
+    ///
+    /// Used by `recv_with_pump` callers to signal channel completion.
+    ///
+    /// # Ownership model
+    ///
+    /// Both the waiter (`SignalEvent`, on the STA stack) and every
+    /// closure-side wake-up token (`SignalToken`, captured into the
+    /// WebView2 builder callback) hold an `Arc<SignalInner>`. The
+    /// kernel `HANDLE` is closed exactly once — when the last `Arc`
+    /// reference drops. This is what eliminates the closed-handle
+    /// race the previous raw-`HANDLE`-copy design accepted: a
+    /// pre-empted closure can no longer invoke `SetEvent` on a
+    /// recycled kernel handle, because the handle simply cannot be
+    /// closed while the closure (and therefore its `SignalToken`)
+    /// is still alive.
+    ///
+    /// # Drop-time diagnostics
+    ///
+    /// `Drop` emits a `tracing::warn!` if the channel was never
+    /// signaled before *the waiter side* released its `Arc`. That
+    /// still flags real problems (timeout while the WebView2
+    /// callback never fired) without depending on the closure
+    /// having outlived the waiter.
+    struct SignalEvent {
+        inner: std::sync::Arc<SignalInner>,
+    }
+
+    /// Wake-up token captured by the WebView2 callback closure.
+    ///
+    /// Holds an `Arc<SignalInner>` so the kernel handle stays alive
+    /// for as long as any closure copy exists. Cheap to clone.
+    #[derive(Clone)]
+    struct SignalToken {
+        inner: std::sync::Arc<SignalInner>,
+    }
+
+    impl SignalToken {
+        /// Signal the event so any `recv_with_pump` waiter wakes up.
+        ///
+        /// Safe to call from any thread; `SetEvent` on a kernel
+        /// `HANDLE` is documented thread-safe and the `Arc` keeps
+        /// the handle alive for the entire call.
+        fn signal(&self) {
+            use windows::Win32::System::Threading::SetEvent;
+            // Mark *before* `SetEvent` so the `Drop` warning path
+            // never fires when the closure has clearly run, even
+            // if `SetEvent` itself happens to fail.
+            self.inner.signaled.store(true, Ordering::Release);
+            // SAFETY: handle is kept alive by `self.inner`; cannot be
+            // closed until every Arc ref (including this one) is dropped.
+            if let Err(e) = unsafe { SetEvent(self.inner.handle) } {
+                tracing::trace!("SetEvent on recv_with_pump signal failed: {}", e);
+            }
+        }
+    }
+
+    impl SignalEvent {
+        fn new() -> Result<Self> {
+            use windows::Win32::System::Threading::CreateEventW;
+            // Auto-reset, initially non-signaled. Anonymous (no name) so we
+            // don't pollute the global namespace.
+            // SAFETY: CreateEventW with all defaults is documented to either
+            // return a valid kernel handle or an Err; we propagate the Err.
+            let h = unsafe { CreateEventW(None, false, false, None) }
+                .context("CreateEventW for recv_with_pump signal handle failed")?;
+            Ok(SignalEvent {
+                inner: std::sync::Arc::new(SignalInner {
+                    handle: h,
+                    signaled: AtomicBool::new(false),
+                }),
+            })
+        }
+
+        fn handle(&self) -> HANDLE {
+            self.inner.handle
+        }
+
+        /// Build a wake-up token for the WebView2 callback closure.
+        ///
+        /// The token shares the same kernel `HANDLE` and the same
+        /// `signaled` flag as the owning `SignalEvent`. Because both
+        /// hold an `Arc<SignalInner>`, the underlying handle is
+        /// closed exactly once, after every reference is dropped —
+        /// the WebView2 worker can never observe a closed handle.
+        fn token(&self) -> SignalToken {
+            SignalToken {
+                inner: std::sync::Arc::clone(&self.inner),
+            }
+        }
+    }
+
+    impl Drop for SignalEvent {
+        fn drop(&mut self) {
+            // Surface the "callback never ran" path. We hit this when
+            // `recv_with_pump` returns via the timeout branch *and* the
+            // WebView2 callback never managed to push a result before
+            // we tore the channel down. That's an actual diagnostic
+            // signal — operators want to see it instead of having
+            // to instrument the call site.
+            //
+            // The actual `CloseHandle` happens in `SignalInner::drop`,
+            // which only fires once the WebView2 closure has also
+            // released its Arc — eliminating the previous design's
+            // closed-handle race entirely.
+            if !self.inner.signaled.load(Ordering::Acquire) {
+                tracing::warn!(
+                    "SignalEvent dropped without the WebView2 callback ever firing. \
+                     This usually means: \
+                     (a) WebView2 cold start exceeded AURORAVIEW_WEBVIEW2_TIMEOUT_SECS, or \
+                     (b) the COM apartment was torn down while a callback was queued. \
+                     If this fires repeatedly, raise the timeout and check Edge runtime health."
+                );
             }
         }
     }
@@ -262,32 +505,114 @@ pub mod win {
             }
         }
 
+        let signal = SignalEvent::new()?;
+        // Closures captured by the WebView2 builder run on a worker thread
+        // and require `'static`, so they cannot borrow `signal`. Capture a
+        // `SignalToken` (Copy of the raw `HANDLE` plus a clone of the
+        // shared `signaled` flag) instead — the owning `SignalEvent`
+        // outlives `recv_with_pump` (we pass it by reference), which in
+        // turn outlives every closure invocation.
+        let token = signal.token();
         let (tx, rx) = mpsc::channel();
         let builder = Environment::builder();
         builder
             .build(move |res| {
+                // Push the result first so a wake-up always observes a ready
+                // channel. Then signal — even if the waiter is pre-empted
+                // between try_recv and CoWaitForMultipleHandles, the auto-reset
+                // event keeps the wake-up pending until the next wait.
                 let _ = tx.send(res);
+                token.signal();
                 Ok(())
             })
             .context("Environment::builder().build failed")?;
-        recv_with_pump(rx, "WebView2 Environment")
+        recv_with_pump(rx, &signal, "WebView2 Environment")
     }
 
     fn create_controller_blocking(
         env: &Environment,
         parent_hwnd: isize,
     ) -> Result<(Controller, WebView)> {
+        let signal = SignalEvent::new()?;
+        // See `create_environment_blocking` for why we capture a token
+        // instead of borrowing `signal` directly.
+        let token = signal.token();
         let (tx, rx) = mpsc::channel();
         let hwnd: HWND = parent_hwnd as *mut winapi::shared::windef::HWND__;
         env.create_controller(hwnd, move |res| {
             let res =
                 res.and_then(|controller| controller.get_webview().map(|wv| (controller, wv)));
             let _ = tx.send(res);
+            token.signal();
             Ok(())
         })
         .context("Environment::create_controller failed")?;
 
-        recv_with_pump(rx, "WebView2 Controller")
+        recv_with_pump(rx, &signal, "WebView2 Controller")
+    }
+
+    #[cfg(test)]
+    mod timeout_env_tests {
+        //! Unit tests for the timeout env var parsing.
+        //!
+        //! These tests intentionally exercise [`parse_webview2_total_timeout`]
+        //! rather than [`webview2_total_timeout`], because the latter caches
+        //! its result in a process-wide `OnceLock` — once any test resolves
+        //! it, every later test would observe the same pinned value
+        //! regardless of how the env var is mutated.
+        //!
+        //! Tests still mutate the process-wide
+        //! `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` environment variable and must
+        //! therefore run serially — `serial_test::serial` is required.
+        use super::{
+            parse_webview2_total_timeout, DEFAULT_WEBVIEW2_TIMEOUT_SECS, WEBVIEW2_TIMEOUT_ENV,
+        };
+        use serial_test::serial;
+        use std::time::Duration;
+
+        fn default_duration() -> Duration {
+            Duration::from_secs(DEFAULT_WEBVIEW2_TIMEOUT_SECS)
+        }
+
+        #[test]
+        #[serial]
+        fn falls_back_to_default_when_env_unset() {
+            std::env::remove_var(WEBVIEW2_TIMEOUT_ENV);
+            assert_eq!(parse_webview2_total_timeout(), default_duration());
+        }
+
+        #[test]
+        #[serial]
+        fn parses_positive_integer() {
+            std::env::set_var(WEBVIEW2_TIMEOUT_ENV, "60");
+            assert_eq!(parse_webview2_total_timeout(), Duration::from_secs(60));
+            std::env::remove_var(WEBVIEW2_TIMEOUT_ENV);
+        }
+
+        #[test]
+        #[serial]
+        fn trims_surrounding_whitespace() {
+            std::env::set_var(WEBVIEW2_TIMEOUT_ENV, "  45  ");
+            assert_eq!(parse_webview2_total_timeout(), Duration::from_secs(45));
+            std::env::remove_var(WEBVIEW2_TIMEOUT_ENV);
+        }
+
+        #[test]
+        #[serial]
+        fn falls_back_on_zero_or_non_numeric() {
+            // Each invalid input must fall back to the default and emit a
+            // `tracing::warn!` (we only assert the value here).
+            for raw in ["0", "-5", "abc", "", " ", "30s", "30 seconds"] {
+                std::env::set_var(WEBVIEW2_TIMEOUT_ENV, raw);
+                assert_eq!(
+                    parse_webview2_total_timeout(),
+                    default_duration(),
+                    "input {:?} should fall back to default",
+                    raw
+                );
+            }
+            std::env::remove_var(WEBVIEW2_TIMEOUT_ENV);
+        }
     }
 }
 
@@ -397,12 +722,5 @@ mod tests {
         assert_eq!(bounds.1, 20);
         assert_eq!(bounds.2, 800);
         assert_eq!(bounds.3, 600);
-    }
-
-    #[test]
-    #[cfg(all(target_os = "windows", feature = "win-webview2"))]
-    fn test_pump_windows_messages_does_not_panic() {
-        // Test that message pump doesn't panic when called
-        win::pump_windows_messages();
     }
 }

--- a/src/platform/windows/webview2.rs
+++ b/src/platform/windows/webview2.rs
@@ -128,14 +128,61 @@ pub mod win {
         rx: mpsc::Receiver<std::result::Result<T, webview2::Error>>,
         what: &str,
     ) -> Result<T> {
+        // Replace the previous busy-loop (PeekMessageW + Sleep(1ms)) implementation,
+        // which would aggressively dispatch ALL host (e.g. Maya/Qt) window messages
+        // on the calling thread and could cause the host UI to appear frozen for
+        // several seconds during WebView2 cold start.
+        //
+        // Instead, let the OS wake us up only when:
+        //   * a COM call is dispatched into our STA (WebView2's async callback), or
+        //   * a window message arrives for this thread.
+        //
+        // We keep an outer loop with try_recv() so we never miss the channel send,
+        // and rely on the kernel to schedule us efficiently while the WebView2
+        // browser process is initializing.
+        use windows::Win32::System::Com::{
+            CoWaitForMultipleHandles, COWAIT_DISPATCH_CALLS, COWAIT_DISPATCH_WINDOW_MESSAGES,
+        };
+
         let start = Instant::now();
+        // Generous timeout: WebView2 cold start (Edge runtime spin-up, user-data
+        // folder bring-up, ICU data load, etc.) can legitimately take several
+        // seconds on first run, especially on slower machines or under AV scans.
+        const TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
+        // Per-iteration wait. Short enough to react quickly when the callback
+        // fires before a window message arrives; long enough to avoid burning CPU.
+        const TICK_MS: u32 = 50;
+
+        // The two flags together let the OS:
+        //   - run any pending COM calls targeted at this STA
+        //     (this is how WebView2's async build callback gets delivered)
+        //   - dispatch any window messages waiting on this thread
+        //     (so the host UI stays responsive)
+        // This is safer than calling PeekMessageW/DispatchMessageW ourselves,
+        // because we don't reorder or steal the host's own message stream.
+        //
+        // NOTE on types: in `windows = 0.62`, `COWAIT_*` constants are exposed as
+        // `COWAIT_FLAGS(i32)` newtypes, but `CoWaitForMultipleHandles` takes a raw
+        // `u32` for `dwflags`. We unwrap with `.0`, OR the bits together, then
+        // reinterpret the bit pattern as u32.
+        let flags: u32 =
+            (COWAIT_DISPATCH_CALLS.0 | COWAIT_DISPATCH_WINDOW_MESSAGES.0).try_into().unwrap();
+
         loop {
             if let Ok(res) = rx.try_recv() {
                 return res.map_err(|e| anyhow!(e.to_string()));
             }
-            pump_windows_messages();
-            std::thread::sleep(Duration::from_millis(1));
-            if start.elapsed() > Duration::from_secs(10) {
+
+            // SAFETY: CoWaitForMultipleHandles is a documented Win32 API.
+            // We pass an empty handle slice and rely solely on the timeout +
+            // dispatch flags to wake us.
+            unsafe {
+                // Ignore the result: RPC_S_CALLPENDING / timeout / dispatched
+                // are all expected and we re-check the channel on the next iter.
+                let _ = CoWaitForMultipleHandles(flags, TICK_MS, &[]);
+            }
+
+            if start.elapsed() > TOTAL_TIMEOUT {
                 return Err(anyhow!(format!("timeout while waiting for {}", what)));
             }
         }

--- a/src/platform/windows/webview2.rs
+++ b/src/platform/windows/webview2.rs
@@ -140,9 +140,24 @@ pub mod win {
         // We keep an outer loop with try_recv() so we never miss the channel send,
         // and rely on the kernel to schedule us efficiently while the WebView2
         // browser process is initializing.
+        use windows::core::HRESULT;
         use windows::Win32::System::Com::{
             CoWaitForMultipleHandles, COWAIT_DISPATCH_CALLS, COWAIT_DISPATCH_WINDOW_MESSAGES,
         };
+
+        // HRESULTs that indicate the *caller* mis-set up COM/threading state
+        // and that no amount of retrying will fix. Bail out immediately so we
+        // surface the real problem instead of waiting out the 30s timeout.
+        //
+        // Values are stable Win32 constants:
+        //   CO_E_NOTINITIALIZED  = 0x800401F0  (CoInitialize[Ex] not called)
+        //   RPC_E_WRONG_THREAD   = 0x8001010E  (called from the wrong apartment)
+        //
+        // We compare against `HRESULT` (which is `i32` underneath) using the
+        // documented `0x...u32 as i32` round-trip so the bit pattern matches
+        // regardless of platform integer width.
+        const CO_E_NOTINITIALIZED: HRESULT = HRESULT(0x800401F0u32 as i32);
+        const RPC_E_WRONG_THREAD: HRESULT = HRESULT(0x8001010Eu32 as i32);
 
         let start = Instant::now();
         // Generous timeout: WebView2 cold start (Edge runtime spin-up, user-data
@@ -163,10 +178,12 @@ pub mod win {
         //
         // NOTE on types: in `windows = 0.62`, `COWAIT_*` constants are exposed as
         // `COWAIT_FLAGS(i32)` newtypes, but `CoWaitForMultipleHandles` takes a raw
-        // `u32` for `dwflags`. We unwrap with `.0`, OR the bits together, then
-        // reinterpret the bit pattern as u32.
+        // `u32` for `dwflags`. We use `as u32` (bit-pattern reinterpretation)
+        // rather than `try_into()`, because future SDK versions could legitimately
+        // define a flag with the high bit set (i.e. negative i32) and `try_into()`
+        // would then panic at runtime even though the bit pattern is correct.
         let flags: u32 =
-            (COWAIT_DISPATCH_CALLS.0 | COWAIT_DISPATCH_WINDOW_MESSAGES.0).try_into().unwrap();
+            (COWAIT_DISPATCH_CALLS.0 as u32) | (COWAIT_DISPATCH_WINDOW_MESSAGES.0 as u32);
 
         loop {
             if let Ok(res) = rx.try_recv() {
@@ -175,11 +192,57 @@ pub mod win {
 
             // SAFETY: CoWaitForMultipleHandles is a documented Win32 API.
             // We pass an empty handle slice and rely solely on the timeout +
-            // dispatch flags to wake us.
-            unsafe {
-                // Ignore the result: RPC_S_CALLPENDING / timeout / dispatched
-                // are all expected and we re-check the channel on the next iter.
-                let _ = CoWaitForMultipleHandles(flags, TICK_MS, &[]);
+            // dispatch flags to wake us. Passing cHandles == 0 is observed to
+            // behave as "block up to dwTimeout while dispatching per dwFlags",
+            // which is exactly what we want; if a future Windows release changes
+            // this, we will need to plumb in a real auto-reset event handle.
+            //
+            // Signature in `windows = 0.62`:
+            //   fn CoWaitForMultipleHandles(...) -> Result<u32, windows::core::Error>
+            // The `Ok(u32)` payload is the WAIT_* index that signaled — useless
+            // to us with an empty handle slice, but we still check `Err` to
+            // detect fatal apartment / initialization mistakes.
+            let wait_result = unsafe { CoWaitForMultipleHandles(flags, TICK_MS, &[]) };
+
+            // Map the result into one of three categories:
+            //   * "fatal caller error" — STA not initialized or wrong thread.
+            //     Return immediately so the caller sees the real cause instead
+            //     of a 30s timeout.
+            //   * other Err  — RPC_S_CALLPENDING / RPC_S_TIMEOUT / etc. Expected
+            //     during normal operation; trace and keep looping.
+            //   * Ok(_)      — a wait was satisfied; just loop and re-check
+            //     the channel.
+            match wait_result {
+                Err(ref e) if e.code() == CO_E_NOTINITIALIZED => {
+                    return Err(anyhow!(
+                        "{}: COM not initialized on this thread (CO_E_NOTINITIALIZED). \
+                         CoInitializeEx(COINIT_APARTMENTTHREADED) must be called first.",
+                        what
+                    ));
+                }
+                Err(ref e) if e.code() == RPC_E_WRONG_THREAD => {
+                    return Err(anyhow!(
+                        "{}: called from the wrong COM apartment (RPC_E_WRONG_THREAD). \
+                         This function must run on the STA that owns the WebView2 controller.",
+                        what
+                    ));
+                }
+                Err(e) => {
+                    tracing::trace!(
+                        "[recv_with_pump:{}] CoWaitForMultipleHandles hr=0x{:08X}, elapsed={:?}",
+                        what,
+                        e.code().0 as u32,
+                        start.elapsed()
+                    );
+                }
+                Ok(idx) => {
+                    tracing::trace!(
+                        "[recv_with_pump:{}] CoWaitForMultipleHandles signaled idx={}, elapsed={:?}",
+                        what,
+                        idx,
+                        start.elapsed()
+                    );
+                }
             }
 
             if start.elapsed() > TOTAL_TIMEOUT {

--- a/tests/rust/window_utils_integration_tests.rs
+++ b/tests/rust/window_utils_integration_tests.rs
@@ -9,7 +9,7 @@ use rstest::rstest;
 
 #[rstest]
 #[cfg(target_os = "windows")]
-fn get_foreground_window() {
+fn test_get_foreground_window() {
     let result = get_foreground_window();
     assert!(result.is_ok(), "get_foreground_window should succeed");
     // May or may not have a foreground window depending on test environment
@@ -17,7 +17,7 @@ fn get_foreground_window() {
 
 #[rstest]
 #[cfg(target_os = "windows")]
-fn get_all_windows() {
+fn test_get_all_windows() {
     let result = get_all_windows();
     assert!(result.is_ok(), "get_all_windows should succeed");
 
@@ -28,7 +28,7 @@ fn get_all_windows() {
 
 #[rstest]
 #[cfg(target_os = "windows")]
-fn find_windows_by_title() {
+fn test_find_windows_by_title() {
     let result = find_windows_by_title("test");
     assert!(result.is_ok(), "find_windows_by_title should succeed");
     // May or may not find windows depending on test environment
@@ -36,7 +36,7 @@ fn find_windows_by_title() {
 
 #[rstest]
 #[cfg(target_os = "windows")]
-fn find_windows_by_empty_title() {
+fn test_find_windows_by_empty_title() {
     let result = find_windows_by_title("");
     assert!(
         result.is_ok(),


### PR DESCRIPTION
## Summary

Stabilize WebView2 / Qt embedding in DCC hosts and harden the Python `WebView` construction paths.

1. **Windows / Qt embedding** — host UI freeze, STA deadlock, non-reentrant `parking_lot` subclass mutex, EventTimer dropping early IPC events.
2. **Python construction-path hardening** — collapse the long-standing `WebView.__init__` / `WebView.create_embedded` drift surface behind a single `_WebViewInitState` dataclass funnel; fix a `process_events` `AttributeError` in packed mode that was masked by `is_ready`.
3. **CI** — fork-PR comment 403 in `mutation-testing` / `pr-checks` (missing `issues: write` + no fork fallback).

13 commits · 17 files · no public API changes. Refs #401.

## Key changes

### `src/platform/windows/webview2.rs` — cold start

- Replace the `PeekMessageW + Sleep(1ms)` busy-loop in `recv_with_pump` with `CoWaitForMultipleHandles(DISPATCH_CALLS | DISPATCH_WINDOW_MESSAGES, &[signal_event])`. A new `SignalEvent` RAII handle is signaled by the WebView2 builder callback (`SetEvent` after `tx.send`), so the waiter wakes on demand instead of polling. `TICK_MS` is now a 1000ms backstop.
- Surface `CO_E_NOTINITIALIZED` / `RPC_E_WRONG_THREAD` immediately instead of waiting out the cold-start timeout.
- Cold-start timeout 10s → 30s, configurable via `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS`.
- `try_into().unwrap()` on the COWAIT flag mask → `as u32` (future-SDK panic guard).

### `crates/auroraview-core/src/builder/window_style.rs` — reparent

- New `drain_thread_messages_for(hwnd_filter, cap, reason)` scoped to our own HWND. Used before/after each big `SetWindowLongW` / `SetParent` / `SetWindowPos` so the synchronous `SendMessage` cascade into WebView2's `Chrome_WidgetWin_*` descendants can finish its COM marshaling while the host's `GetMessage` loop is paused.
- Skip `SetParent` when `GetParent()` already matches (tao parents at creation; the redundant call triggered a `WM_PARENTNOTIFY` / DWM storm).
- Fix `parking_lot` self-deadlock in `subclass_for_zero_nc_area` by dropping the guard before `SetWindowPos` dispatches `WM_NCCALCSIZE` back into `nc_subclass_wndproc` (which re-locks `ORIGINAL_WNDPROCS`; `parking_lot::Mutex` is not reentrant). Adds a `SetWindowPos(SWP_FRAMECHANGED)` commit so styles materialize even when `SetParent` short-circuits.

### `python/auroraview/utils/event_timer.py` — readiness

- `_is_core_ready()` now delegates entirely to `WebView.is_ready` and treats the timer as ready when EITHER `_async_core` OR `_core` is available. Stops dropping IPC events queued during the non-blocking startup window. Also handles packed-mode / test-stub WebViews so they no longer raise `AttributeError` on every tick.

### `python/auroraview/core/webview.py` — construction-path hardening

- Inline the previous `WebViewLifecycleMixin` / `WebViewFactoryMixin` indirection back into `WebView`; remove `factory.py`. Adding a new field used to require touching four files.
- Route `__init__` and `create_embedded` through a single `_WebViewInitState` dataclass with a `from_init_kwargs` classmethod:
  - `forward_asset_root_to_core` makes the `core.set_asset_root` ownership explicit (non-packed `__init__` already passes via the Rust core constructor; packed mode and `create_embedded` need post-hoc `set_asset_root`).
  - `strict=True` (default) raises on typos like `parent_hwnd=` instead of silently leaving fields at their defaults.
  - `None` on a field-with-default falls through to the dataclass default; `None` on required `Optional[X]` fields stays as a real value. Pinned by regression tests.
- `process_events` / `process_events_ipc_only` now route through `_peek_active_core` so they share readiness semantics with `is_ready` / `is_window_valid`. Returns `False` when no backing core is available (packed mode pre-init, post-dispose, transient lock contention) instead of raising `AttributeError` on every host-timer tick.

### `tests/python/unit/test_webview_init_state.py` (new)

- 13 cases pinning every branch of the `_WebViewInitState.from_init_kwargs` state machine.
- `TestRequiredFieldInvariant` fails loudly if any of the four `Optional[X]` required fields (`url` / `html` / `parent` / `mode`) ever gain a dataclass default — which would silently change what `<field>=None` means for every caller.

### `.github/workflows/{mutation-testing,pr-checks}.yml`

- Add `issues: write` permission; gate "Comment PR" steps on `head.repo.full_name == github.repository` so they're skipped on fork PRs; mark them `continue-on-error: true`. `mutation-testing` also writes the score to the step summary as a fallback.

## Type

- [x] fix · [x] refactor · [x] test · [x] ci/chore

## Breaking changes

None.

## Validation

### Automated

- `vx cargo fmt --all`
- `vx cargo clippy --all-targets --all-features -- -D warnings`
- `vx uvx ruff check / format --check python/ tests/ examples/`
- `vx just test`
- New unit tests:
  - `webview2_total_timeout` env-var parsing (4 cases) — `src/platform/windows/webview2.rs::timeout_env_tests`.
  - `_WebViewInitState.from_init_kwargs` (13 cases) — `tests/python/unit/test_webview_init_state.py`.

### Manual regression matrix

> Repro: open the WebView panel, exercise resize / focus / page reload, close.

| Host | Python / Qt | Cold-start freeze | Reparent STA deadlock | Early IPC delivered | Packed `process_events` |
|---|---|---|---|---|---|
| Maya 2025 | 3.11 / PySide6 | pass | pass | pass | pass |
| Maya 2024 | 3.10 / PySide2 | pass | pass | pass | pass |
| 3ds Max 2025 | 3.11 / PyQt5 | pass | pass | pass | pass |
| Houdini 20.5 | 3.11 / PySide2 | pass | pass | pass | pass |
| Standalone (Rust shell) | n/a | pass | n/a | pass | n/a |

### Edge cases

- `AURORAVIEW_WEBVIEW2_TIMEOUT_SECS` = `"0"` / `"abc"` / `"30s"` / `"  45  "` → falls back / parses as documented.
- `_WebViewInitState.from_init_kwargs(parent_hwnd=...)` with a typo → `TypeError` listing the offending key.
- `WebView(bridge=False)` survives the None-sentinel filter as a legal user choice.

## Additional context

- Related issue: #401
- The `SignalEvent` design is portable to other blocking COM bridges; future async WebView2 setters can reuse the `(SignalEvent, mpsc::Receiver)` pattern.
- The `_WebViewInitState` funnel makes adding a new construction-time field a one-liner: drop a `@dataclass` attribute, assign it in `_init_runtime_state`, done. Both `__init__` and `create_embedded` pick it up automatically.
