### PR TITLE
fix: skip docs preview comments for fork PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -101,10 +101,14 @@ jobs:
 
   # PR Preview comment
   preview-comment:
-    if: github.event_name == 'pull_request'
+    # Fork PRs receive a read-only GITHUB_TOKEN, so the optional preview comment
+    # must not fail an otherwise successful docs build for external contributors.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: build
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Find Comment


### PR DESCRIPTION
## Summary

- skip the optional docs preview comment job for fork PRs, where `GITHUB_TOKEN` is read-only
- grant `issues: write` for same-repository PR preview comments because the action uses the issue comments API

## Validation

- `git diff --check`
- `vx actionlint .github/workflows/docs.yml`
- `vx just ci-docs-build`