### PR TITLE
fix: repair ci wheel and release publishing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,15 +29,6 @@ coverage:
         only_pulls: false
         informational: true  # Don't block PR for patch coverage
 
-    # Changes coverage (lines changed in PR)
-    changes:
-      default:
-        target: 80%
-        threshold: 5%
-        if_ci_failed: success
-        if_not_found: success
-        informational: true  # Don't block PR, just inform
-
 # Comment configuration
 comment:
   layout: "header, diff, flags, components, footer"
@@ -177,8 +168,3 @@ ignore:
 # GitHub checks
 github_checks:
   annotations: true  # Add annotations to PR
-
-# Codecov AI (if enabled)
-codecov_ai:
-  enabled: true
-

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -175,6 +175,34 @@ runs:
         wheel_file=$(ls dist/*.whl | head -1)
         echo "wheel-path=$wheel_file" >> $GITHUB_OUTPUT
 
+    - name: Verify wheel Python tag
+      shell: bash
+      run: |
+        wheel_file=$(ls -t dist/*.whl | head -1)
+        echo "Verifying wheel tag: $wheel_file"
+
+        if [[ "${{ inputs.python-version }}" == "3.7" ]]; then
+          if [[ "$wheel_file" == *"abi3"* ]]; then
+            echo "[ERROR] Python 3.7 wheels must be non-abi3: $wheel_file"
+            exit 1
+          fi
+          if [[ "$wheel_file" != *"cp37"* ]]; then
+            echo "[ERROR] Python 3.7 wheel should carry a cp37 tag: $wheel_file"
+            exit 1
+          fi
+          echo "[OK] Python 3.7 wheel uses a dedicated cp37 tag"
+        else
+          if [[ "$wheel_file" != *"abi3"* ]]; then
+            echo "[ERROR] Python ${{ inputs.python-version }} wheels must use abi3: $wheel_file"
+            exit 1
+          fi
+          if [[ "$wheel_file" == *"cp37"* ]]; then
+            echo "[ERROR] ABI3 wheel must not be tagged as cp37: $wheel_file"
+            exit 1
+          fi
+          echo "[OK] Python ${{ inputs.python-version }} wheel uses abi3"
+        fi
+
     - name: Test wheel installation
       if: inputs.test-wheel == 'true'
       shell: bash

--- a/.github/workflows/build-gallery.yml
+++ b/.github/workflows/build-gallery.yml
@@ -353,7 +353,11 @@ jobs:
           exit 1
 
       - name: Run CDP E2E tests
-        run: vx uv run pytest tests/test_gallery_cdp.py -v --tb=short
+        run: vx uv run --with pytest --with playwright pytest tests/test_gallery_cdp.py -v --tb=short -o addopts=
+        env:
+          # This CDP smoke test does not use Qt. Keep pytest-qt from requiring
+          # PySide/PyQt in the lean Gallery E2E environment.
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,14 +131,18 @@ jobs:
               const hasLinux = artifacts.artifacts.some(a => a.name === 'wheels-linux-x86_64');
               const hasWindows = artifacts.artifacts.some(a => a.name === 'wheels-windows-x64');
               const hasMacos = artifacts.artifacts.some(a => a.name === 'wheels-macos-universal2-apple-darwin');
+              const hasLinuxPy37 = artifacts.artifacts.some(a => a.name === 'wheels-linux-x86_64-py37');
+              const hasWindowsPy37 = artifacts.artifacts.some(a => a.name === 'wheels-windows-x64-py37');
 
-              // Check for essential platforms (x86_64 + macOS universal2)
+              // Check for essential platforms (x86_64 + macOS universal2) and CPython 3.7 baseline wheels.
               // Note: ARM64 wheels are not built (webkit2gtk/wry cross-compilation is not feasible)
-              if (hasLinux && hasWindows && hasMacos) {
+              if (hasLinux && hasWindows && hasMacos && hasLinuxPy37 && hasWindowsPy37) {
                 console.log(`Found matching artifacts from run ${run.id} (commit: ${targetSha})`);
-                console.log(`  Linux x86_64: ${hasLinux}`);
-                console.log(`  Windows x64: ${hasWindows}`);
-                console.log(`  macOS universal2: ${hasMacos}`);
+                console.log(`  Linux x86_64 abi3: ${hasLinux}`);
+                console.log(`  Windows x64 abi3: ${hasWindows}`);
+                console.log(`  macOS universal2 abi3: ${hasMacos}`);
+                console.log(`  Linux x86_64 py37: ${hasLinuxPy37}`);
+                console.log(`  Windows x64 py37: ${hasWindowsPy37}`);
                 core.setOutput('available', 'true');
                 core.setOutput('run_id', run.id.toString());
                 core.setOutput('source_sha', targetSha);
@@ -418,8 +422,10 @@ jobs:
             return ${PIPESTATUS[0]}
           }
 
+          set +e
           publish_trusted "$trusted_log"
           trusted_status=$?
+          set -e
           if [ "$trusted_status" -eq 0 ]; then
             echo "publish_result=success" >> "$GITHUB_OUTPUT"
             echo "publish_method=trusted" >> "$GITHUB_OUTPUT"
@@ -431,8 +437,10 @@ jobs:
           if [ -n "${NPM_TOKEN:-}" ] && grep -Eiq 'ENEEDAUTH|E401|E404|authentication|must be logged in|trusted publishing|trusted publisher|not authorized|not linked' "$trusted_log"; then
             publish_method="token"
             final_log="$token_log"
+            set +e
             publish_with_token "$token_log"
             token_status=$?
+            set -e
             final_status="$token_status"
             if [ "$token_status" -eq 0 ]; then
               echo "publish_result=success" >> "$GITHUB_OUTPUT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "askama",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-ai-agent"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "auroraview-workspace-hack",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-assets"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "mime_guess",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-bookmarks"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-browser"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-bookmarks",
  "auroraview-core",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "auroraview-assets",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "active-win-pos-rs",
  "askama",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-dcc"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-core",
  "auroraview-workspace-hack",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-desktop"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-core",
  "auroraview-plugins",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-devtools"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "rstest 0.18.2",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-downloads"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-extensions"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-history"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-mcp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "auroraview-workspace-hack",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-notifications"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-pack"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-extensions",
  "auroraview-protect",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "dunce",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-fs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-plugin-core",
  "auroraview-workspace-hack",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugins"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "auroraview-extensions",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-protect"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-settings"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "parking_lot",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-signals"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "crossbeam-channel",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-tabs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "dashmap",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-telemetry"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "auroraview-workspace-hack",
  "opentelemetry",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-testing"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-ue"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "auroraview-core",

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ server.stop()
 
 - Core stack: Rust 1.90+, PyO3 0.27 (abi3), Wry 0.54, Tao 0.34
 - Web engines: Windows (WebView2), macOS (WKWebView), Linux (WebKitGTK)
-- Packaging: maturin with abi3 → one wheel works for CPython 3.7-3.13
+- Packaging: maturin wheels; CPython 3.8+ uses abi3 per platform, CPython 3.7 uses dedicated cp37 wheels on Linux/Windows and source builds on macOS
 - Event loop: blocking show() by default; nonblocking mode planned for host loops
 - Deferred loading: URL/HTML set before show() are stored then applied at creation
 - IPC: bidirectional event bus (Python ↔ JavaScript via CustomEvent)
@@ -231,7 +231,8 @@ sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev  # Debian/Ubuntu
 # sudo pacman -S webkit2gtk                          # Arch Linux
 
 # Download and install wheel from GitHub Releases
-pip install https://github.com/loonghao/auroraview/releases/latest/download/auroraview-{version}-cp37-abi3-linux_x86_64.whl
+# Python 3.8+: cp38-abi3, Python 3.7: cp37-cp37m
+pip install https://github.com/loonghao/auroraview/releases/latest/download/auroraview-{version}-cp38-abi3-linux_x86_64.whl
 ```
 
 Or build from source:

--- a/docs/contributing/ci-pipeline-zh.md
+++ b/docs/contributing/ci-pipeline-zh.md
@@ -178,7 +178,7 @@ Python 包作为 `auroraview` 发布到 PyPI。关键注意事项：
 
 1. **文件大小限制**: PyPI 对每个文件有 100MB 限制。源代码分发包（sdist）通常由于捆绑的资源而超过此限制，因此它们仅单独构建用于 GitHub 发布。
 2. **平台标签**: 只有 Windows 和 macOS 的 wheel 会上传到 PyPI。Linux wheel 使用非标准标签并被排除。
-3. **ABI3 支持**: Python 3.8+ 使用 abi3（稳定 ABI），每个平台只需一个 wheel。Python 3.7 需要单独的非 abi3 构建。
+3. **ABI3 支持**: Python 3.8+ 使用 abi3（稳定 ABI），每个平台只需一个 wheel。Python 3.7 需要单独的非 abi3 构建；CI 为 Linux/Windows 发布专用 `cp37` wheel，macOS 3.7 用户应从源码构建。
 
 ## 故障排除
 
@@ -202,10 +202,11 @@ Python 包作为 `auroraview` 发布到 PyPI。关键注意事项：
 错误：`404 Not Found - PUT https://registry.npmjs.org/@auroraview%2fsdk`
 
 **解决方案**：
-1. 验证 GitHub 仓库 secrets 中已设置 `NPM_TOKEN`
-2. 在 https://www.npmjs.com/settings/loonghao/tokens 生成新令牌
-3. 使用 "Automation" 令牌类型（不是 "Publish"）
-4. 确保令牌未过期
+1. 验证 npm trusted publishing 已绑定此 GitHub 仓库/包，或使用 `NPM_TOKEN`
+2. 验证 GitHub 仓库 secrets 中已设置 `NPM_TOKEN`
+3. 在 https://www.npmjs.com/settings/loonghao/tokens 生成新令牌
+4. 使用具有发布权限的 "Automation" 令牌类型
+5. 确保令牌未过期
 
 ### PyPI 发布失败，提示"文件太大"
 

--- a/docs/contributing/ci-pipeline.md
+++ b/docs/contributing/ci-pipeline.md
@@ -178,7 +178,7 @@ The Python package is published to PyPI as `auroraview`. Key considerations:
 
 1. **File Size Limit**: PyPI has a 100MB limit per file. Source distributions (sdist) often exceed this due to bundled assets, so they are built separately for GitHub Releases only.
 2. **Platform Tags**: Only Windows and macOS wheels are uploaded to PyPI. Linux wheels use non-standard tags and are excluded.
-3. **ABI3 Support**: Python 3.8+ uses abi3 (stable ABI) for a single wheel per platform. Python 3.7 requires separate non-abi3 builds.
+3. **ABI3 Support**: Python 3.8+ uses abi3 (stable ABI) for a single wheel per platform. Python 3.7 requires separate non-abi3 builds; CI publishes dedicated `cp37` wheels for Linux/Windows, while macOS 3.7 users should build from source.
 
 ## Troubleshooting
 
@@ -202,10 +202,11 @@ The Python package is published to PyPI as `auroraview`. Key considerations:
 Error: `404 Not Found - PUT https://registry.npmjs.org/@auroraview%2fsdk`
 
 **Solution**:
-1. Verify `NPM_TOKEN` is set in GitHub repository secrets
-2. Generate a new token at https://www.npmjs.com/settings/loonghao/tokens
-3. Use "Automation" token type (not "Publish")
-4. Ensure the token hasn't expired
+1. Verify npm trusted publishing is linked to this GitHub repository/package, or use `NPM_TOKEN`
+2. Verify `NPM_TOKEN` is set in GitHub repository secrets
+3. Generate a new token at https://www.npmjs.com/settings/loonghao/tokens
+4. Use "Automation" token type with publish permission
+5. Ensure the token hasn't expired
 
 ### PyPI publish fails with "File too large"
 

--- a/justfile
+++ b/justfile
@@ -1254,8 +1254,7 @@ gallery-ci-build: sdk-build gallery-ci-install
 # Install Python Playwright for Gallery CI/E2E flows
 gallery-ci-playwright-install:
     @echo "Installing Python Playwright for Gallery tests..."
-    vx uv sync --group test
-    vx uv run python -m playwright install chromium
+    vx uv run --with playwright python -m playwright install chromium
     @echo "[OK] Gallery Playwright installed!"
 
 
@@ -1288,7 +1287,7 @@ gallery-test-inspector: gallery-build
 # Run Gallery Playwright E2E tests (frontend only, with mock API)
 gallery-test-playwright: gallery-ci-playwright-install
     @echo "Running Gallery Playwright E2E tests..."
-    vx uv run python scripts/test_gallery_e2e.py
+    vx uv run --with playwright python scripts/test_gallery_e2e.py
 
 # Full Gallery verification path aligned with CI frontend checks
 gallery-verify: gallery-ci-build gallery-test-playwright
@@ -1342,14 +1341,26 @@ gallery-e2e-stop:
     @echo "[OK] Gallery stopped"
 
 # Run E2E tests against a running packed Gallery via CDP
+[windows]
 gallery-e2e-test: gallery-ci-playwright-install
     @echo "Running Gallery CDP E2E tests..."
-    vx uv run pytest tests/test_gallery_cdp.py -v --tb=short
+    $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD = '1'; vx uv run --with pytest --with playwright pytest tests/test_gallery_cdp.py -v --tb=short -o addopts=
+
+[unix]
+gallery-e2e-test: gallery-ci-playwright-install
+    @echo "Running Gallery CDP E2E tests..."
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 vx uv run --with pytest --with playwright pytest tests/test_gallery_cdp.py -v --tb=short -o addopts=
 
 # Run E2E tests with more verbose stdout (for debugging)
+[windows]
 gallery-e2e-test-headed: gallery-ci-playwright-install
     @echo "Running Gallery CDP E2E tests with verbose output..."
-    vx uv run pytest tests/test_gallery_cdp.py -v --tb=short -s
+    $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD = '1'; vx uv run --with pytest --with playwright pytest tests/test_gallery_cdp.py -v --tb=short -s -o addopts=
+
+[unix]
+gallery-e2e-test-headed: gallery-ci-playwright-install
+    @echo "Running Gallery CDP E2E tests with verbose output..."
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 vx uv run --with pytest --with playwright pytest tests/test_gallery_cdp.py -v --tb=short -s -o addopts=
 
 # Show where Gallery E2E artifacts are written
 gallery-e2e-report:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,10 @@ auroraview = "auroraview.__main__:main"
 [tool.maturin]
 python-source = "python"
 module-name = "auroraview._core"
-# Note: abi3-py38 for Python 3.8+, Python 3.7 requires separate non-abi3 build
+# Default builds stay non-abi3 so Python 3.7 source builds remain valid.
+# CI passes abi3-py38 explicitly for Python 3.8+ release wheels.
 # Note: runtime-desktop and runtime-dcc are optional features for advanced use cases
-features = ["python-bindings", "pyo3/extension-module", "abi3-py38", "runtime-desktop", "runtime-dcc"]
+features = ["python-bindings", "pyo3/extension-module", "runtime-desktop", "runtime-dcc"]
 bindings = "pyo3"
 
 # Ruff configuration

--- a/uv.lock
+++ b/uv.lock
@@ -11,12 +11,10 @@ resolution-markers = [
 
 [[package]]
 name = "auroraview"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- keep Python 3.7 wheels as dedicated cp37 builds while requiring abi3 tags for Python 3.8+ wheels
- make release artifact reuse require both abi3 and py37 wheel artifacts before skipping rebuilds
- repair npm trusted-publish fallback and isolate Gallery CDP tests from pytest-qt in lean CI environments
- sync Cargo/uv lockfiles with the current 0.5.3 release metadata

## Validation
- vx git diff --check
- vx cargo fetch --locked
- vx uv lock --check
- vx uv run --locked --with pyyaml python -c "import pathlib, yaml; files=['.github/actions/build-wheel/action.yml','.github/workflows/build-gallery.yml','.github/workflows/release.yml']; [yaml.safe_load(pathlib.Path(f).read_text()) for f in files]; print('yaml ok')"
- vx uv run --locked --no-sync python -c "import pathlib, tomllib; features=tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))['tool']['maturin']['features']; print(features); assert 'abi3-py38' not in features"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 vx uv run --locked --with pytest --with playwright pytest tests/test_gallery_cdp.py --collect-only -q -o addopts=
- vx just --list