### PR TITLE
fix: gate unsafe usage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,15 +29,6 @@ coverage:
         only_pulls: false
         informational: true  # Don't block PR for patch coverage
 
-    # Changes coverage (lines changed in PR)
-    changes:
-      default:
-        target: 80%
-        threshold: 5%
-        if_ci_failed: success
-        if_not_found: success
-        informational: true  # Don't block PR, just inform
-
 # Comment configuration
 comment:
   layout: "header, diff, flags, components, footer"
@@ -177,8 +168,3 @@ ignore:
 # GitHub checks
 github_checks:
   annotations: true  # Add annotations to PR
-
-# Codecov AI (if enabled)
-codecov_ai:
-  enabled: true
-

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -138,6 +138,8 @@ jobs:
             ci:
               - '.github/**'
               - 'justfile'
+              - 'scripts/audit_unsafe.py'
+              - 'scripts/unsafe_allowlist.txt'
               - '.pre-commit-config.yaml'
               - '.codecov.yml'
             tests:
@@ -342,6 +344,10 @@ jobs:
       - name: Check Rust formatting
         if: needs.path-filter.outputs.needs_rust_checks == 'true'
         run: cargo fmt --all -- --check
+
+      - name: Audit unsafe usage
+        if: needs.path-filter.outputs.needs_rust_checks == 'true'
+        run: vx just unsafe-audit
 
       - name: Install system dependencies
         if: needs.path-filter.outputs.needs_rust_checks == 'true'

--- a/justfile
+++ b/justfile
@@ -509,8 +509,13 @@ hakari-check:
     vx cargo hakari generate --diff
     vx cargo hakari manage-deps --dry-run
 
+# Verify Rust unsafe usage stays inside reviewed FFI boundaries
+unsafe-audit:
+    @echo "Auditing Rust unsafe usage..."
+    vx python scripts/audit_unsafe.py
+
 # Run linting
-lint:
+lint: unsafe-audit
     @echo "Linting Rust code..."
     vx cargo clippy --all-targets --all-features -- -D warnings
     @echo "Linting Python code..."
@@ -658,6 +663,7 @@ ci-test-basic:
 
 ci-lint:
     @echo "Running CI linting..."
+    vx just unsafe-audit
     vx cargo fmt --all -- --check
     vx cargo clippy --all-targets --all-features -- -D warnings
     vx uvx ruff check python/ tests/

--- a/scripts/audit_unsafe.py
+++ b/scripts/audit_unsafe.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Audit Rust unsafe usage against an explicit allowlist.
+
+AuroraView needs some unsafe code at Win32, COM, and WebView2 FFI boundaries.
+This audit keeps that unsafe surface intentional: new unsafe constructs must be
+added to the allowlist with a count and rationale instead of slipping in silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+UNSAFE_CONSTRUCT_RE = re.compile(r"\bunsafe\s*(?:\{|impl\b|fn\b|extern\b|trait\b)")
+EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    "dist",
+    "gallery/dist",
+    "node_modules",
+    "packages/auroraview-sdk/coverage",
+    "submodules",
+    "target",
+}
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    count: int
+    reason: str
+    line_number: int
+
+
+def repo_relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def is_excluded(path: Path, root: Path) -> bool:
+    rel = repo_relative(path, root)
+    rel_parts = Path(rel).parts
+
+    for excluded in EXCLUDED_DIRS:
+        excluded_parts = Path(excluded).parts
+        if len(excluded_parts) == 1 and excluded_parts[0] in rel_parts:
+            return True
+        if rel_parts[: len(excluded_parts)] == excluded_parts:
+            return True
+
+    return False
+
+
+def load_allowlist(path: Path) -> tuple[dict[str, AllowlistEntry], list[str]]:
+    entries: dict[str, AllowlistEntry] = {}
+    errors: list[str] = []
+
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = [part.strip() for part in line.split("|", 2)]
+        if len(parts) != 3:
+            errors.append(f"{path}:{line_number}: expected 'path | count | reason'")
+            continue
+
+        rel_path, count_text, reason = parts
+        if not rel_path.endswith(".rs"):
+            errors.append(f"{path}:{line_number}: allowlist path must be a Rust source file")
+            continue
+        if not reason:
+            errors.append(f"{path}:{line_number}: unsafe allowlist entry needs a rationale")
+            continue
+        if rel_path in entries:
+            errors.append(f"{path}:{line_number}: duplicate allowlist entry for {rel_path}")
+            continue
+
+        try:
+            count = int(count_text)
+        except ValueError:
+            errors.append(f"{path}:{line_number}: unsafe count must be an integer")
+            continue
+        if count <= 0:
+            errors.append(f"{path}:{line_number}: unsafe count must be positive")
+            continue
+
+        entries[rel_path] = AllowlistEntry(count=count, reason=reason, line_number=line_number)
+
+    return entries, errors
+
+
+def scan_unsafe(root: Path) -> dict[str, int]:
+    counts: dict[str, int] = {}
+
+    for path in root.rglob("*.rs"):
+        if is_excluded(path, root):
+            continue
+
+        count = 0
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue
+            count += len(UNSAFE_CONSTRUCT_RE.findall(line))
+
+        if count:
+            counts[repo_relative(path, root)] = count
+
+    return counts
+
+
+def audit(root: Path, allowlist_path: Path) -> int:
+    allowlist, errors = load_allowlist(allowlist_path)
+    actual = scan_unsafe(root)
+
+    for rel_path, actual_count in sorted(actual.items()):
+        entry = allowlist.get(rel_path)
+        if entry is None:
+            errors.append(
+                f"{rel_path}: found {actual_count} unsafe construct(s), but the file is not allowlisted"
+            )
+            continue
+        if actual_count != entry.count:
+            errors.append(
+                f"{rel_path}: expected {entry.count} unsafe construct(s) from allowlist line "
+                f"{entry.line_number}, found {actual_count}"
+            )
+
+    for rel_path, entry in sorted(allowlist.items()):
+        if rel_path not in actual:
+            errors.append(
+                f"{allowlist_path}:{entry.line_number}: stale allowlist entry for {rel_path}; "
+                "the file has no unsafe constructs"
+            )
+
+    total = sum(actual.values())
+    print(
+        f"Unsafe audit: {total} construct(s) across {len(actual)} Rust file(s); "
+        f"{len(allowlist)} allowlist entr{'y' if len(allowlist) == 1 else 'ies'}."
+    )
+
+    if errors:
+        print("\nUnsafe audit failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "\nIf the unsafe usage is genuinely required, update "
+            f"{repo_relative(allowlist_path, root)} with the new count and rationale.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Unsafe audit passed.")
+    return 0
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=root / "scripts" / "unsafe_allowlist.txt",
+        help="Path to the unsafe allowlist file.",
+    )
+    args = parser.parse_args()
+
+    allowlist_path = args.allowlist
+    if not allowlist_path.is_absolute():
+        allowlist_path = root / allowlist_path
+
+    return audit(root, allowlist_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/unsafe_allowlist.txt
+++ b/scripts/unsafe_allowlist.txt
@@ -1,0 +1,28 @@
+# AuroraView unsafe allowlist.
+#
+# Format:
+#   path | unsafe construct count | rationale
+#
+# This file freezes the current unsafe boundary. Do not raise a count or add a
+# path without explaining why safe Rust cannot express that boundary.
+
+crates/auroraview-browser/src/browser.rs | 3 | Win32 child window enumeration callback and HWND FFI for browser embedding.
+crates/auroraview-cli/src/packed/mod.rs | 1 | Windows handle and process setup for packed executable launch.
+crates/auroraview-cli/src/packed/warmup.rs | 2 | Optional Windows WebView2 DLL warmup through dynamically loaded native symbols.
+crates/auroraview-core/src/builder/click_through.rs | 3 | Win32 window style mutation and subclass procedure for click-through behavior.
+crates/auroraview-core/src/builder/com_init.rs | 1 | COM apartment initialization through the Win32 API.
+crates/auroraview-core/src/builder/vibrancy.rs | 8 | DWM/User32 dynamic symbol calls and window composition attributes.
+crates/auroraview-core/src/builder/window_style.rs | 16 | Win32 subclassing, DWM attributes, owner/parent mutation, and GDI brush lifecycle.
+crates/auroraview-core/src/utils.rs | 1 | Win32 process handle query and handle close.
+crates/auroraview-core/src/window/mod.rs | 2 | Win32 message posting and HWND destruction for native windows.
+crates/auroraview-dcc/src/webview.rs | 18 | WebView2 COM controller, settings, event callbacks, and message pumping in DCC hosts.
+crates/auroraview-desktop/src/window/builder.rs | 1 | COM apartment initialization for desktop window creation.
+crates/auroraview-signals/src/signal.rs | 2 | Manual Send/Sync marker for signal storage guarded by synchronization primitives.
+src/platform/windows/warmup.rs | 2 | Optional Windows WebView2 runtime warmup through dynamically loaded native symbols.
+src/platform/windows/webview2.rs | 7 | Win32 event handles, COM wait integration, and manual Send/Sync marker for signal state.
+src/webview/backend/native.rs | 5 | Win32 HWND validation, subclass callbacks, and child-window enumeration.
+src/webview/message_pump.rs | 4 | Win32 message pump calls and COM apartment setup.
+src/webview/proxy.rs | 2 | Manual Send/Sync marker for proxy state composed of Arc-backed synchronization.
+src/webview/tab_manager.rs | 3 | Win32 child-window enumeration callback and HWND FFI for tab discovery.
+src/webview/timer.rs | 3 | Win32 timer message loop and callback integration.
+src/webview/webview_inner.rs | 5 | WebView2 COM event handlers and Windows-specific WebView interaction.


### PR DESCRIPTION
## Summary
- add an explicit Rust unsafe audit with a reviewed allowlist
- freeze the current baseline at 89 unsafe constructs across 20 Rust files, each with a rationale
- wire `vx just unsafe-audit` into local linting and PR quick checks
- carry the Codecov config cleanup from #409 so this PR is not blocked by the known project-coverage false drop

## Validation
- `vx just unsafe-audit`
- `vx python -m py_compile scripts/audit_unsafe.py`
- `vx git diff --check`