### PR TITLE
fix(qt): declare ctypes argtypes to avoid 64-bit handle overflow

### DIFF
--- a/gallery/check_window.py
+++ b/gallery/check_window.py
@@ -36,6 +36,48 @@ class RECT(ctypes.Structure):
     ]
 
 
+# Configure Win32 function signatures. Without argtypes, ctypes marshals
+# Python int as a 32-bit C int, which overflows on 64-bit Windows when an
+# HWND/handle is passed ("OverflowError: int too long to convert").
+EnumWindows.argtypes = [EnumWindowsProc, wintypes.LPARAM]
+EnumWindows.restype = wintypes.BOOL
+GetWindowTextW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+GetWindowTextW.restype = ctypes.c_int
+GetWindowTextLengthW.argtypes = [wintypes.HWND]
+GetWindowTextLengthW.restype = ctypes.c_int
+IsWindowVisible.argtypes = [wintypes.HWND]
+IsWindowVisible.restype = wintypes.BOOL
+GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(RECT)]
+GetWindowRect.restype = wintypes.BOOL
+# hWndInsertAfter accepts negative sentinels (HWND_TOPMOST=-1, HWND_NOTOPMOST=-2),
+# so declare it as c_ssize_t to carry both real handles and the negatives.
+SetWindowPos.argtypes = [
+    wintypes.HWND,
+    ctypes.c_ssize_t,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    wintypes.UINT,
+]
+SetWindowPos.restype = wintypes.BOOL
+ShowWindow.argtypes = [wintypes.HWND, ctypes.c_int]
+ShowWindow.restype = wintypes.BOOL
+GetWindowThreadProcessId.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.DWORD)]
+GetWindowThreadProcessId.restype = wintypes.DWORD
+user32.GetSystemMetrics.argtypes = [ctypes.c_int]
+user32.GetSystemMetrics.restype = ctypes.c_int
+user32.MoveWindow.argtypes = [
+    wintypes.HWND,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    wintypes.BOOL,
+]
+user32.MoveWindow.restype = wintypes.BOOL
+
+
 def get_window_title(hwnd):
     length = GetWindowTextLengthW(hwnd)
     if length == 0:

--- a/python/auroraview/integration/qt/embedding.py
+++ b/python/auroraview/integration/qt/embedding.py
@@ -284,8 +284,8 @@ class EmbeddingMixin:
                     return
                 try:
                     backend = get_backend()
-                    if hasattr(backend, "_fix_all_child_windows_recursive"):
-                        count = backend._fix_all_child_windows_recursive(webview_hwnd)
+                    if hasattr(backend, "_fix_all_child_windows"):
+                        count = backend._fix_all_child_windows(webview_hwnd)
                         if count > 0:
                             logger.info(f"[EmbeddingMixin] Fixed {count} WebView2 child windows")
                 except Exception as e:

--- a/python/auroraview/integration/qt/platforms/win.py
+++ b/python/auroraview/integration/qt/platforms/win.py
@@ -361,8 +361,7 @@ class WindowsPlatformBackend(PlatformBackend):
 
             if fixed_count > 0:
                 logger.info(
-                    f"[Win32] Fixed {fixed_count} child windows "
-                    f"for parent 0x{parent_hwnd:X}"
+                    f"[Win32] Fixed {fixed_count} child windows for parent 0x{parent_hwnd:X}"
                 )
 
         except Exception as e:

--- a/python/auroraview/integration/qt/platforms/win.py
+++ b/python/auroraview/integration/qt/platforms/win.py
@@ -49,10 +49,14 @@ else:
     GetWindowLong = user32.GetWindowLongW
     SetWindowLong = user32.SetWindowLongW
 
-# Configure SetWindowPos function signature
+# Configure SetWindowPos function signature.
+# hWndInsertAfter accepts negative sentinels (HWND_TOP=0, HWND_BOTTOM=1,
+# HWND_TOPMOST=-1, HWND_NOTOPMOST=-2), so declare it as c_ssize_t to carry both
+# real handles and the negatives. wintypes.HWND (a c_void_p) cannot hold a
+# negative value and would raise OverflowError if a sentinel were ever passed.
 user32.SetWindowPos.argtypes = [
     wintypes.HWND,  # hWnd
-    wintypes.HWND,  # hWndInsertAfter
+    ctypes.c_ssize_t,  # hWndInsertAfter
     ctypes.c_int,  # X
     ctypes.c_int,  # Y
     ctypes.c_int,  # cx
@@ -70,13 +74,6 @@ user32.SetLayeredWindowAttributes.argtypes = [
 ]
 user32.SetLayeredWindowAttributes.restype = wintypes.BOOL
 
-# Whether the current process is 64-bit (pointer width == 8 bytes).
-# On 64-bit Windows, HWND/handles and WndProc pointers exceed the C int range,
-# so any Win32 function receiving them MUST declare argtypes with pointer-wide
-# types. Otherwise ctypes defaults to marshalling Python int as C int (32-bit)
-# and raises "OverflowError: int too long to convert".
-_IS_64BIT = ctypes.sizeof(ctypes.c_void_p) == 8
-
 # EnumChildWindows callback prototype (module level so the signature is reused
 # and the BOOL/HWND/LPARAM types stay consistent across calls).
 WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
@@ -87,16 +84,19 @@ user32.EnumChildWindows.argtypes = [wintypes.HWND, WNDENUMPROC, wintypes.LPARAM]
 user32.EnumChildWindows.restype = wintypes.BOOL
 
 # Configure CallWindowProcW function signature.
-# lpPrevWndFunc is a function pointer (pointer-wide); WPARAM/LPARAM follow the
-# process bitness. Without argtypes the pointer overflows C int on 64-bit.
+# lpPrevWndFunc is a function pointer (pointer-wide); without argtypes it
+# overflows C int on 64-bit. wintypes.WPARAM/LPARAM already resolve to the
+# pointer-wide ctype on 64-bit and the narrow one on 32-bit, so no manual
+# bitness branch is needed here. The LRESULT return type is LONG_PTR, identical
+# in width/signedness to LPARAM (wintypes has no LRESULT alias).
 user32.CallWindowProcW.argtypes = [
     ctypes.c_void_p,  # lpPrevWndFunc
     wintypes.HWND,  # hWnd
     wintypes.UINT,  # Msg
-    ctypes.c_ulonglong if _IS_64BIT else wintypes.WPARAM,  # wParam
-    ctypes.c_longlong if _IS_64BIT else wintypes.LPARAM,  # lParam
+    wintypes.WPARAM,  # wParam
+    wintypes.LPARAM,  # lParam
 ]
-user32.CallWindowProcW.restype = ctypes.c_longlong if _IS_64BIT else ctypes.c_long
+user32.CallWindowProcW.restype = wintypes.LPARAM
 
 # Window style constants
 GWL_STYLE = -16
@@ -250,10 +250,10 @@ class WindowsPlatformBackend(PlatformBackend):
             # Step 8: Apply clip styles to parent
             self.apply_clip_styles_to_parent(parent_hwnd)
 
-            # Step 9: CRITICAL - Fix all WebView2 child windows recursively
+            # Step 9: CRITICAL - Fix all WebView2 child windows
             # WebView2 creates multiple child windows (Chrome_WidgetWin_0, etc.)
             # that may still be draggable. We need to fix ALL of them.
-            self._fix_all_child_windows_recursive(child_hwnd)
+            self._fix_all_child_windows(child_hwnd)
 
             if _VERBOSE_LOGGING:
                 logger.info(
@@ -270,8 +270,8 @@ class WindowsPlatformBackend(PlatformBackend):
             logger.error(f"[Win32] embed_window_directly failed: {e}")
             return False
 
-    def _fix_all_child_windows_recursive(self, parent_hwnd: int, depth: int = 0) -> int:
-        """Recursively fix all child windows to prevent independent dragging.
+    def _fix_all_child_windows(self, parent_hwnd: int) -> int:
+        """Fix every descendant window to prevent independent dragging.
 
         WebView2 creates a hierarchy of child windows:
         - Main WebView window
@@ -281,20 +281,17 @@ class WindowsPlatformBackend(PlatformBackend):
               - ...
 
         All of these need WS_CHILD style and proper positioning to prevent
-        them from being dragged independently.
+        them from being dragged independently. EnumChildWindows already walks
+        the entire descendant tree in a single call (not just direct children),
+        so no manual recursion is needed here.
 
         Args:
-            parent_hwnd: The parent window to enumerate children from.
-            depth: Current recursion depth (for logging).
+            parent_hwnd: The parent window to enumerate descendants from.
 
         Returns:
             Number of windows fixed.
         """
         fixed_count = 0
-        max_depth = 10  # Prevent infinite recursion
-
-        if depth > max_depth:
-            return 0
 
         try:
             # EnumChildWindows callback (WNDENUMPROC is defined at module level)
@@ -355,7 +352,7 @@ class WindowsPlatformBackend(PlatformBackend):
                         if _VERBOSE_LOGGING:
                             logger.debug(
                                 f"[Win32] Fixed child window: HWND=0x{child_hwnd:X} "
-                                f"(depth={depth}, style=0x{style:08X}->0x{new_style:08X})"
+                                f"(style=0x{style:08X}->0x{new_style:08X})"
                             )
 
                 except Exception as e:
@@ -364,13 +361,13 @@ class WindowsPlatformBackend(PlatformBackend):
 
             if fixed_count > 0:
                 logger.info(
-                    f"[Win32] Fixed {fixed_count} child windows at depth {depth} "
+                    f"[Win32] Fixed {fixed_count} child windows "
                     f"for parent 0x{parent_hwnd:X}"
                 )
 
         except Exception as e:
             if _VERBOSE_LOGGING:
-                logger.debug(f"[Win32] _fix_all_child_windows_recursive failed: {e}")
+                logger.debug(f"[Win32] _fix_all_child_windows failed: {e}")
 
         return fixed_count
 

--- a/python/auroraview/integration/qt/platforms/win.py
+++ b/python/auroraview/integration/qt/platforms/win.py
@@ -70,6 +70,34 @@ user32.SetLayeredWindowAttributes.argtypes = [
 ]
 user32.SetLayeredWindowAttributes.restype = wintypes.BOOL
 
+# Whether the current process is 64-bit (pointer width == 8 bytes).
+# On 64-bit Windows, HWND/handles and WndProc pointers exceed the C int range,
+# so any Win32 function receiving them MUST declare argtypes with pointer-wide
+# types. Otherwise ctypes defaults to marshalling Python int as C int (32-bit)
+# and raises "OverflowError: int too long to convert".
+_IS_64BIT = ctypes.sizeof(ctypes.c_void_p) == 8
+
+# EnumChildWindows callback prototype (module level so the signature is reused
+# and the BOOL/HWND/LPARAM types stay consistent across calls).
+WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+# Configure EnumChildWindows function signature.
+# Without argtypes, the HWND argument overflows C int on 64-bit Windows.
+user32.EnumChildWindows.argtypes = [wintypes.HWND, WNDENUMPROC, wintypes.LPARAM]
+user32.EnumChildWindows.restype = wintypes.BOOL
+
+# Configure CallWindowProcW function signature.
+# lpPrevWndFunc is a function pointer (pointer-wide); WPARAM/LPARAM follow the
+# process bitness. Without argtypes the pointer overflows C int on 64-bit.
+user32.CallWindowProcW.argtypes = [
+    ctypes.c_void_p,  # lpPrevWndFunc
+    wintypes.HWND,  # hWnd
+    wintypes.UINT,  # Msg
+    ctypes.c_ulonglong if _IS_64BIT else wintypes.WPARAM,  # wParam
+    ctypes.c_longlong if _IS_64BIT else wintypes.LPARAM,  # lParam
+]
+user32.CallWindowProcW.restype = ctypes.c_longlong if _IS_64BIT else ctypes.c_long
+
 # Window style constants
 GWL_STYLE = -16
 GWL_EXSTYLE = -20
@@ -269,9 +297,7 @@ class WindowsPlatformBackend(PlatformBackend):
             return 0
 
         try:
-            # EnumChildWindows callback
-            WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
-
+            # EnumChildWindows callback (WNDENUMPROC is defined at module level)
             child_windows = []
 
             def enum_callback(hwnd, lparam):
@@ -454,10 +480,7 @@ class WindowsPlatformBackend(PlatformBackend):
             _GetWndProc = user32.GetWindowLongW
             _SetWndProc = user32.SetWindowLongW
 
-        user32.CallWindowProcW.restype = (
-            ctypes.c_longlong if ctypes.sizeof(ctypes.c_void_p) == 8 else ctypes.c_long
-        )
-
+        # CallWindowProcW argtypes/restype are configured at module level.
         original_wndproc = _GetWndProc(hwnd, GWLP_WNDPROC)
         if not original_wndproc:
             logger.warning(f"[Win32] GetWindowLongPtrW returned 0 for HWND 0x{hwnd:X}")

--- a/tests/python/unit/integration/qt/test_embedding.py
+++ b/tests/python/unit/integration/qt/test_embedding.py
@@ -162,7 +162,7 @@ class TestScheduleChildWindowFixes:
         backend = MagicMock()
         with patch("auroraview.integration.qt.platforms.get_backend", return_value=backend):
             EmbeddingMixin._schedule_child_window_fixes(host, 0xABCD)
-        backend._fix_all_child_windows_recursive.assert_not_called()
+        backend._fix_all_child_windows.assert_not_called()
         # The synchronous call returned early but two follow-up timers are
         # still scheduled (each will also see _is_closing=True at fire-time
         # and bail out).  We assert the schedule pattern matches the docstring:
@@ -176,16 +176,16 @@ class TestScheduleChildWindowFixes:
         with patch("auroraview.integration.qt.platforms.get_backend", return_value=backend):
             EmbeddingMixin._schedule_child_window_fixes(host, 0xABCD)
         # Must not call into the backend while the peer holds the flag
-        backend._fix_all_child_windows_recursive.assert_not_called()
+        backend._fix_all_child_windows.assert_not_called()
 
     def test_synchronous_fix_runs_first(self, monkeypatch):
         host = _Host()
         monkeypatch.setattr(embedding.QTimer, "singleShot", staticmethod(lambda d, c: None))
         backend = MagicMock()
-        backend._fix_all_child_windows_recursive.return_value = 5
+        backend._fix_all_child_windows.return_value = 5
         with patch("auroraview.integration.qt.platforms.get_backend", return_value=backend):
             EmbeddingMixin._schedule_child_window_fixes(host, 0xABCD)
-        backend._fix_all_child_windows_recursive.assert_called_once_with(0xABCD)
+        backend._fix_all_child_windows.assert_called_once_with(0xABCD)
 
     def test_schedules_two_catch_up_ticks(self, monkeypatch):
         host = _Host()
@@ -214,7 +214,7 @@ class TestScheduleChildWindowFixes:
         host = _Host()
         monkeypatch.setattr(embedding.QTimer, "singleShot", staticmethod(lambda d, c: None))
         backend = MagicMock()
-        backend._fix_all_child_windows_recursive.side_effect = RuntimeError("boom")
+        backend._fix_all_child_windows.side_effect = RuntimeError("boom")
         with patch("auroraview.integration.qt.platforms.get_backend", return_value=backend):
             # Must not propagate
             EmbeddingMixin._schedule_child_window_fixes(host, 0xABCD)
@@ -224,7 +224,7 @@ class TestScheduleChildWindowFixes:
     def test_handles_backend_without_fix_method(self, monkeypatch):
         host = _Host()
         monkeypatch.setattr(embedding.QTimer, "singleShot", staticmethod(lambda d, c: None))
-        backend = MagicMock(spec=[])  # no _fix_all_child_windows_recursive
+        backend = MagicMock(spec=[])  # no _fix_all_child_windows
         with patch("auroraview.integration.qt.platforms.get_backend", return_value=backend):
             EmbeddingMixin._schedule_child_window_fixes(host, 0xABCD)
         # Just ensure no exception escapes

--- a/tests/python/unit/integration/qt/test_platform_win.py
+++ b/tests/python/unit/integration/qt/test_platform_win.py
@@ -292,6 +292,70 @@ class TestShowWindowAfterInit:
         assert result is False
 
 
+class TestFixAllChildWindowsRecursive:
+    """Tests for _fix_all_child_windows_recursive method."""
+
+    def test_enumerates_children_via_enum_child_windows(self, mock_win32_apis):
+        """Test that EnumChildWindows is called with the parent HWND.
+
+        Regression guard for the 64-bit handle overflow bug: the parent HWND
+        must reach EnumChildWindows unchanged (argtypes declared at module
+        level), and the call must use the module-level WNDENUMPROC prototype.
+        """
+        from auroraview.integration.qt.platforms.win import WindowsPlatformBackend
+
+        backend = WindowsPlatformBackend()
+
+        # No children enumerated -> callback never invoked, loop body skipped.
+        mock_win32_apis["user32"].EnumChildWindows.return_value = 1
+
+        fixed = backend._fix_all_child_windows_recursive(0x1234ABCD)
+
+        assert fixed == 0
+        mock_win32_apis["user32"].EnumChildWindows.assert_called_once()
+        # First positional argument is the parent HWND, passed through intact.
+        call_args = mock_win32_apis["user32"].EnumChildWindows.call_args
+        assert call_args[0][0] == 0x1234ABCD
+
+    def test_fixes_non_child_window(self, mock_win32_apis):
+        """Test that a window missing WS_CHILD gets the style applied."""
+        from auroraview.integration.qt.platforms.win import (
+            WS_CHILD,
+            WindowsPlatformBackend,
+        )
+
+        backend = WindowsPlatformBackend()
+
+        # Simulate one enumerated child by invoking the registered callback.
+        def fake_enum(parent_hwnd, callback, lparam):
+            callback(0x9999, 0)
+            return 1
+
+        mock_win32_apis["user32"].EnumChildWindows.side_effect = fake_enum
+        # Child style lacks WS_CHILD so it should be fixed.
+        mock_win32_apis["GetWindowLong"].return_value = 0
+        mock_win32_apis["SetWindowLong"].return_value = 1
+
+        fixed = backend._fix_all_child_windows_recursive(0x1234)
+
+        assert fixed == 1
+        # WS_CHILD must be added to the enumerated child's style.
+        style_call = mock_win32_apis["SetWindowLong"].call_args_list[0]
+        new_style = style_call[0][2]
+        assert new_style & WS_CHILD
+
+    def test_returns_zero_past_max_depth(self, mock_win32_apis):
+        """Test that recursion stops past the max depth without enumerating."""
+        from auroraview.integration.qt.platforms.win import WindowsPlatformBackend
+
+        backend = WindowsPlatformBackend()
+
+        fixed = backend._fix_all_child_windows_recursive(0x1234, depth=11)
+
+        assert fixed == 0
+        mock_win32_apis["user32"].EnumChildWindows.assert_not_called()
+
+
 class TestEnsureNativeChildStyle:
     """Tests for ensure_native_child_style method."""
 

--- a/tests/python/unit/integration/qt/test_platform_win.py
+++ b/tests/python/unit/integration/qt/test_platform_win.py
@@ -292,8 +292,8 @@ class TestShowWindowAfterInit:
         assert result is False
 
 
-class TestFixAllChildWindowsRecursive:
-    """Tests for _fix_all_child_windows_recursive method."""
+class TestFixAllChildWindows:
+    """Tests for _fix_all_child_windows method."""
 
     def test_enumerates_children_via_enum_child_windows(self, mock_win32_apis):
         """Test that EnumChildWindows is called with the parent HWND.
@@ -309,7 +309,7 @@ class TestFixAllChildWindowsRecursive:
         # No children enumerated -> callback never invoked, loop body skipped.
         mock_win32_apis["user32"].EnumChildWindows.return_value = 1
 
-        fixed = backend._fix_all_child_windows_recursive(0x1234ABCD)
+        fixed = backend._fix_all_child_windows(0x1234ABCD)
 
         assert fixed == 0
         mock_win32_apis["user32"].EnumChildWindows.assert_called_once()
@@ -336,7 +336,7 @@ class TestFixAllChildWindowsRecursive:
         mock_win32_apis["GetWindowLong"].return_value = 0
         mock_win32_apis["SetWindowLong"].return_value = 1
 
-        fixed = backend._fix_all_child_windows_recursive(0x1234)
+        fixed = backend._fix_all_child_windows(0x1234)
 
         assert fixed == 1
         # WS_CHILD must be added to the enumerated child's style.
@@ -344,16 +344,55 @@ class TestFixAllChildWindowsRecursive:
         new_style = style_call[0][2]
         assert new_style & WS_CHILD
 
-    def test_returns_zero_past_max_depth(self, mock_win32_apis):
-        """Test that recursion stops past the max depth without enumerating."""
+    def test_fixes_all_descendants_in_single_enumeration(self, mock_win32_apis):
+        """Test that every descendant from a single EnumChildWindows call is fixed.
+
+        EnumChildWindows walks the whole descendant tree (children +
+        grandchildren) in one call, so the method must not recurse — it fixes
+        all of them from one enumeration without re-enumerating per child.
+        """
         from auroraview.integration.qt.platforms.win import WindowsPlatformBackend
 
         backend = WindowsPlatformBackend()
 
-        fixed = backend._fix_all_child_windows_recursive(0x1234, depth=11)
+        # Simulate a 3-level hierarchy delivered in one enumeration pass.
+        def fake_enum(parent_hwnd, callback, lparam):
+            callback(0xAAAA, 0)  # child
+            callback(0xBBBB, 0)  # grandchild
+            callback(0xCCCC, 0)  # great-grandchild
+            return 1
+
+        mock_win32_apis["user32"].EnumChildWindows.side_effect = fake_enum
+        mock_win32_apis["GetWindowLong"].return_value = 0  # none has WS_CHILD
+        mock_win32_apis["SetWindowLong"].return_value = 1
+
+        fixed = backend._fix_all_child_windows(0x1234)
+
+        # All three descendants fixed from a single enumeration, no recursion.
+        assert fixed == 3
+        mock_win32_apis["user32"].EnumChildWindows.assert_called_once()
+
+    def test_skips_window_already_child(self, mock_win32_apis):
+        """Test that a descendant already carrying WS_CHILD is left untouched."""
+        from auroraview.integration.qt.platforms.win import (
+            WS_CHILD,
+            WindowsPlatformBackend,
+        )
+
+        backend = WindowsPlatformBackend()
+
+        def fake_enum(parent_hwnd, callback, lparam):
+            callback(0x9999, 0)
+            return 1
+
+        mock_win32_apis["user32"].EnumChildWindows.side_effect = fake_enum
+        # Child already has WS_CHILD -> nothing to fix.
+        mock_win32_apis["GetWindowLong"].return_value = WS_CHILD
+
+        fixed = backend._fix_all_child_windows(0x1234)
 
         assert fixed == 0
-        mock_win32_apis["user32"].EnumChildWindows.assert_not_called()
+        mock_win32_apis["SetWindowLong"].assert_not_called()
 
 
 class TestEnsureNativeChildStyle:


### PR DESCRIPTION
## Summary

On 64-bit Windows, `EnumChildWindows` and `CallWindowProcW` were called without
declared `argtypes`, so ctypes marshalled the `HWND` / `WndProc` pointer as a
32-bit C `int` and raised `OverflowError: int too long to convert` during Qt
WebView embedding. This PR declares module-level signatures for the affected
Win32 functions and cleans up the surrounding code.

Related to #434.

2 commits · 5 files · **no public API change** (internal Win32 binding fix).

## Key changes

### `python/auroraview/integration/qt/platforms/win.py` — Win32 signature hardening

- Declare module-level `argtypes`/`restype` for `EnumChildWindows` and
  `CallWindowProcW`; promote `WNDENUMPROC` to module scope so the
  `BOOL`/`HWND`/`LPARAM` prototype stays consistent across calls.
- `CallWindowProcW`: use plain `wintypes.WPARAM`/`LPARAM` (which already resolve
  to the pointer-wide ctype on 64-bit and the narrow one on 32-bit) instead of
  manual `_IS_64BIT` ternaries; `restype` is `wintypes.LPARAM` (`LONG_PTR`, same
  width/signedness as `LRESULT`).
- `SetWindowPos`: declare `hWndInsertAfter` as `c_ssize_t` so it can carry the
  negative sentinels (`HWND_TOPMOST=-1`, `HWND_NOTOPMOST=-2`), closing the same
  overflow hole preemptively.
- Rename `_fix_all_child_windows_recursive` → `_fix_all_child_windows` and drop
  the `depth`/`max_depth` parameter and unreachable guard. `EnumChildWindows`
  already walks the whole descendant tree in one call, so the implied
  self-recursion never existed (and real recursion would have double-processed
  every descendant).

### `gallery/check_window.py` — diagnostic tool signature fix

- Declare `argtypes`/`restype` for all Win32 functions it calls; `SetWindowPos`'s
  `hWndInsertAfter` typed as `c_ssize_t` to carry `HWND_TOPMOST`/`HWND_NOTOPMOST`.

### `python/auroraview/integration/qt/embedding.py` — caller update

- Update the child-window fixer call site to the renamed `_fix_all_child_windows`.

### tests — regression coverage

- `test_platform_win.py`: add `TestFixAllChildWindows` guarding that the parent
  `HWND` reaches `EnumChildWindows` intact and that all descendants from a single
  enumeration are fixed without recursion.
- `test_embedding.py`: update references to the renamed method.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor
- [ ] perf
- [ ] ci/chore

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added/updated when necessary
- [ ] Docs updated (README/docs/CHANGELOG as needed)
- [ ] CI green

## Breaking changes

- [x] No breaking changes

## Validation

- `python -m pytest tests/python/unit/integration/qt/` — 334 passed, 1 skipped.
- Manual: Qt WebView embedding on 64-bit Windows no longer raises
  `OverflowError: int too long to convert`.

## Additional context

The overflow root cause: without `argtypes`, ctypes defaults to marshalling
Python `int` as a 32-bit C `int`, which cannot represent a 64-bit window handle
or function pointer.