### PR TITLE
fix(ci): install llvm-tools-preview through vx for rust coverage

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -576,6 +576,9 @@ jobs:
           tools: 'just bun'
           cache: 'false'
 
+      - name: Install llvm-tools-preview (vx managed Rust)
+        run: vx rustup component add llvm-tools-preview
+
       - name: Build frontend assets (required by auroraview-assets)
         run: vx just ci-assets-build
 


### PR DESCRIPTION
## Problem

The `rust-tests` CI job in `pr-checks.yml` fails on dependabot PRs because `vx cargo llvm-cov` can't find `llvm-profdata`:

```
error: failed to merge profile data: could not execute process
/home/runner/.vx/store/rust/1.29.0/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge ...
(never executed): No such file or directory (os error 2)
```

## Root Cause

The workflow uses `dtolnay/rust-toolchain@stable` to install `llvm-tools-preview` to the **system** Rust toolchain. However, `vx cargo llvm-cov` uses the **vx-managed** Rust store (`~/.vx/store/rust/...`) which lacks these tools.

## Fix

Add an explicit step after vx setup to install `llvm-tools-preview` through vx, ensuring the vx-managed Rust toolchain has the required `llvm-profdata` binary.

## Affected PRs

- #431 — build(deps): bump codecov/codecov-action from 6 to 7
- #429 — build(deps): bump memchr from 2.8.0 to 2.8.1