### PR TITLE
fix(ci): symlink system llvm-profdata into vx toolchain for rust coverage

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -579,6 +579,29 @@ jobs:
       - name: Install llvm-tools-preview (vx managed Rust)
         run: vx rustup component add llvm-tools-preview
 
+      - name: Fix llvm-profdata in vx toolchain
+        if: runner.os == 'Linux'
+        run: |
+          VX_PROFDATA="$(vx rustc --print sysroot)/lib/rustlib/$(vx rustc -vV | awk '/host:/ {print $2}')/bin/llvm-profdata"
+          if [ ! -f "$VX_PROFDATA" ]; then
+            echo "llvm-profdata not found at $VX_PROFDATA, linking from system toolchain..."
+            SYS_RUSTC="$HOME/.cargo/bin/rustc"
+            if [ -x "$SYS_RUSTC" ]; then
+              SYS_PROFDATA="$("$SYS_RUSTC" --print sysroot)/lib/rustlib/$("$SYS_RUSTC" -vV | awk '/host:/ {print $2}')/bin/llvm-profdata"
+              if [ -f "$SYS_PROFDATA" ]; then
+                mkdir -p "$(dirname "$VX_PROFDATA")"
+                ln -sf "$SYS_PROFDATA" "$VX_PROFDATA"
+                echo "Linked system llvm-profdata to vx toolchain"
+              else
+                echo "WARNING: system llvm-profdata not found at $SYS_PROFDATA"
+              fi
+            else
+              echo "WARNING: system rustc not found at $SYS_RUSTC"
+            fi
+          else
+            echo "llvm-profdata already present in vx toolchain"
+          fi
+
       - name: Build frontend assets (required by auroraview-assets)
         run: vx just ci-assets-build
 


### PR DESCRIPTION
## Summary

- `vx rustup component add llvm-tools-preview` reports the component as installed, but the `llvm-profdata` binary is actually missing at the expected path in the vx-managed Rust toolchain
- This causes `cargo-llvm-cov report` to fail with `could not execute process ... llvm-profdata merge (never executed): No such file or directory`
- Fixes dependabot PRs #427, #428, #429, #431 and all future CI runs with Rust coverage

## Fix

Added a fixup step after the vx llvm-tools-preview installation that:
1. Checks if `llvm-profdata` exists at the expected vx toolchain path
2. If not, finds it in the system-installed dtolnay/rust-toolchain and creates a symlink

The symlink approach is chosen over environment variables because cargo-llvm-cov determines the llvm tools path from the sysroot of the currently active `rustc`, and the vx-managed rustc always points to the vx store path.

## Test plan

- [ ] Re-run CI on this PR to confirm `Rust Tests & Coverage` passes
- [ ] If green, similar PRs (#427, #428, #429, #431) should also pass after rebase