### PR TITLE
test(integration): realign integration tests with current source APIs

### DIFF
--- a/tests/python/integration/test_browser_integration.py
+++ b/tests/python/integration/test_browser_integration.py
@@ -224,7 +224,14 @@ class TestBrowserHtmlGeneration:
     """Tests for Browser HTML generation."""
 
     def test_html_contains_initial_tabs(self):
-        """Test generated HTML includes initial tabs."""
+        """Test generated HTML returns the browser controller shell.
+
+        The browser UI is now a Vite-built SPA: the Python side serves only
+        the static shell (``<div id="root">`` + the controller bundle), and
+        tabs/title are rendered client-side from IPC state. So we assert the
+        shell document is returned rather than looking for server-rendered
+        tab markup.
+        """
         from auroraview.browser.browser import Browser
 
         browser = Browser(title="Test Browser")
@@ -232,51 +239,53 @@ class TestBrowserHtmlGeneration:
 
         html = browser._get_browser_html()
 
-        assert "Test Browser" in html
-        assert "https://example.com" in html
+        assert "<!DOCTYPE html>" in html
+        assert 'id="root"' in html
+        assert "browser-controller" in html
 
     def test_html_has_required_elements(self):
-        """Test generated HTML has all required UI elements."""
+        """Test generated HTML is the Vite controller shell.
+
+        The hand-written tab-bar/url-bar/iframe markup was replaced by a
+        client-rendered SPA; the shell only needs the root mount point and
+        the controller bundle/stylesheet references.
+        """
         from auroraview.browser.browser import Browser
 
         browser = Browser()
         html = browser._get_browser_html()
 
-        # Tab bar
-        assert 'class="tab-bar"' in html
-        assert 'id="tabBar"' in html
+        # SPA mount point
+        assert 'id="root"' in html
 
-        # Navigation buttons
-        assert 'id="backBtn"' in html
-        assert 'id="forwardBtn"' in html
-        assert 'id="reloadBtn"' in html
-
-        # URL bar
-        assert 'id="urlBar"' in html
-        assert 'class="url-bar"' in html
-
-        # Content frame
-        assert 'id="contentFrame"' in html
-        assert "<iframe" in html
+        # Controller bundle is wired into the shell
+        assert "browser-controller" in html
+        assert "<script" in html
 
 
 class TestBrowserStateSync:
     """Tests for Browser state synchronization."""
 
     def test_sync_tabs_emits_event(self):
-        """Test _sync_tabs_to_ui emits browser:tabs_update event."""
+        """Test _sync_tabs_to_ui emits browser:tabs_changed via the emitter.
+
+        _sync_tabs_to_ui now goes through ``webview.create_emitter()`` and
+        emits ``browser:tabs_changed`` (not a direct ``webview.emit`` call),
+        so we assert against the emitter returned by the mock.
+        """
         from auroraview.browser.browser import Browser
 
         browser = Browser()
         browser._webview = MagicMock()
+        emitter = browser._webview.create_emitter.return_value
 
         browser.new_tab("https://example.com", "Tab 1")
         browser.new_tab("https://github.com", "Tab 2")
 
         browser._sync_tabs_to_ui()
 
-        browser._webview.emit.assert_called_with(
-            "browser:tabs_update",
+        emitter.emit.assert_called_with(
+            "browser:tabs_changed",
             {
                 "tabs": browser._tabs,
                 "activeTabId": browser._active_tab_id,
@@ -284,23 +293,24 @@ class TestBrowserStateSync:
         )
 
     def test_tab_operations_trigger_sync(self):
-        """Test tab operations trigger UI sync."""
+        """Test tab operations trigger UI sync through the emitter."""
         from auroraview.browser.browser import Browser
 
         browser = Browser()
         browser._webview = MagicMock()
+        emitter = browser._webview.create_emitter.return_value
 
         # new_tab should sync
         browser.new_tab("https://example.com")
-        assert browser._webview.emit.call_count >= 1
+        assert emitter.emit.call_count >= 1
 
-        browser._webview.emit.reset_mock()
+        emitter.emit.reset_mock()
 
         # close_tab should sync
         tab = browser.new_tab("https://github.com")
-        browser._webview.emit.reset_mock()
+        emitter.emit.reset_mock()
         browser.close_tab(tab["id"])
-        assert browser._webview.emit.call_count >= 1
+        assert emitter.emit.call_count >= 1
 
 
 class TestBrowserWithTabContainer:

--- a/tests/python/integration/test_cli_main.py
+++ b/tests/python/integration/test_cli_main.py
@@ -17,7 +17,10 @@ def test_main_success():
     # Mock run_standalone to avoid actual window creation
     with patch("auroraview._core.run_standalone") as mock_run_standalone:
         with patch.object(sys, "argv", ["auroraview", "--url", "https://example.com"]):
-            main()
+            # main() calls sys.exit(0) on the success path
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
 
             # Verify run_standalone was called with correct parameters
             mock_run_standalone.assert_called_once()
@@ -46,7 +49,9 @@ def test_main_with_arguments():
         # Mock run_standalone to avoid actual window creation
         with patch("auroraview._core.run_standalone") as mock_run_standalone:
             with patch.object(sys, "argv", test_args):
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
 
                 # Verify run_standalone was called with debug flag
                 mock_run_standalone.assert_called_once()
@@ -98,7 +103,9 @@ def test_main_with_html_auto_asset_root():
 
         with patch("auroraview._core.run_standalone") as mock_run_standalone:
             with patch.object(sys, "argv", test_args):
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
 
                 call_kwargs = mock_run_standalone.call_args.kwargs
                 # asset_root should be the directory containing the HTML file
@@ -126,7 +133,9 @@ def test_main_with_explicit_assets_root():
 
         with patch("auroraview._core.run_standalone") as mock_run_standalone:
             with patch.object(sys, "argv", test_args):
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
 
                 call_kwargs = mock_run_standalone.call_args.kwargs
                 # asset_root should be the explicitly provided directory
@@ -198,8 +207,11 @@ def test_main_module_execution():
         # Mock run_standalone to avoid actual window creation
         with patch("auroraview._core.run_standalone") as mock_run_standalone:
             with patch.object(sys, "argv", ["auroraview", "--url", "https://example.com"]):
-                # Execute the module
-                spec.loader.exec_module(module)
+                # Execute the module — the __main__ block calls main(),
+                # which exits with code 0 on the success path.
+                with pytest.raises(SystemExit) as exc_info:
+                    spec.loader.exec_module(module)
+                assert exc_info.value.code == 0
 
                 # Verify run_standalone was called
                 mock_run_standalone.assert_called_once()
@@ -215,7 +227,9 @@ def test_main_url_normalization():
             "auroraview.normalize_url", return_value="https://example.com/"
         ) as mock_normalize:
             with patch.object(sys, "argv", ["auroraview", "--url", "example.com"]):
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
 
                 # Verify normalize_url was called
                 mock_normalize.assert_called_once_with("example.com")
@@ -245,7 +259,9 @@ def test_main_html_rewriting():
         # Mock run_standalone to verify parameters
         with patch("auroraview._core.run_standalone") as mock_run_standalone:
             with patch.object(sys, "argv", ["auroraview", "--html", html_path]):
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
 
                 # Verify run_standalone was called with correct parameters
                 mock_run_standalone.assert_called_once()

--- a/tests/python/integration/test_event_timer.py
+++ b/tests/python/integration/test_event_timer.py
@@ -16,8 +16,15 @@ class MockWebView:
         self._should_close = False
         self._process_events_called = 0
         self._is_valid = True
-        self._core = MagicMock()
-        self._core.is_window_valid.return_value = True
+
+    @property
+    def is_ready(self) -> bool:
+        """EventTimer reads this as the single source of truth for readiness."""
+        return True
+
+    def is_window_valid(self) -> bool:
+        """EventTimer's validity probe (replaces the old ``_core`` path)."""
+        return self._is_valid
 
     def process_events(self):
         """Mock process_events method."""
@@ -31,7 +38,6 @@ class MockWebView:
     def invalidate_window(self):
         """Simulate window becoming invalid."""
         self._is_valid = False
-        self._core.is_window_valid.return_value = False
 
 
 class TestEventTimer:

--- a/tests/python/integration/test_event_timer.py
+++ b/tests/python/integration/test_event_timer.py
@@ -458,8 +458,6 @@ class TestEventTimer:
 
     def test_backend_stop_called(self):
         """Test that backend.stop() is called when timer stops."""
-        from unittest.mock import MagicMock
-
         from auroraview.utils.timer_backends import ThreadTimerBackend
 
         webview = MockWebView()
@@ -483,8 +481,6 @@ class TestEventTimer:
 
     def test_backend_stop_error_handling(self):
         """Test error handling when backend.stop() raises exception."""
-        from unittest.mock import MagicMock
-
         from auroraview.utils.timer_backends import ThreadTimerBackend
 
         webview = MockWebView()

--- a/tests/python/integration/test_ipc_channel_e2e.py
+++ b/tests/python/integration/test_ipc_channel_e2e.py
@@ -414,24 +414,6 @@ class TestRustJsonIntegration:
             pytest.skip("Rust core not available")
 
 
-class TestGalleryIpcChannelIntegration:
-    """Test Gallery integration with IPC channel."""
-
-    def test_gallery_run_sample_with_channel(self):
-        """Gallery's run_sample no longer wires up the IPC channel directly.
-
-        The gallery sample was refactored and no longer references
-        ``use_channel`` / ``spawn_ipc_channel`` / ``send_json_to_process`` in
-        ``gallery/main.py`` — that source-scraping check is stale. The real
-        channel-spawn behaviour is covered end-to-end by
-        ``TestIpcChannelSpawn`` instead, so this assertion is retired.
-        """
-        pytest.skip(
-            "gallery/main.py no longer demonstrates the IPC channel API; "
-            "channel spawning is covered by TestIpcChannelSpawn"
-        )
-
-
 class TestIpcChannelThreadSafety:
     """Test IPC channel thread safety."""
 

--- a/tests/python/integration/test_ipc_channel_e2e.py
+++ b/tests/python/integration/test_ipc_channel_e2e.py
@@ -418,27 +418,18 @@ class TestGalleryIpcChannelIntegration:
     """Test Gallery integration with IPC channel."""
 
     def test_gallery_run_sample_with_channel(self):
-        """Test that Gallery's run_sample supports use_channel parameter."""
-        # This test verifies the API signature, not actual execution
+        """Gallery's run_sample no longer wires up the IPC channel directly.
 
-        # Import the gallery main module to check function signature
-        gallery_path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "gallery",
-            "main.py",
+        The gallery sample was refactored and no longer references
+        ``use_channel`` / ``spawn_ipc_channel`` / ``send_json_to_process`` in
+        ``gallery/main.py`` — that source-scraping check is stale. The real
+        channel-spawn behaviour is covered end-to-end by
+        ``TestIpcChannelSpawn`` instead, so this assertion is retired.
+        """
+        pytest.skip(
+            "gallery/main.py no longer demonstrates the IPC channel API; "
+            "channel spawning is covered by TestIpcChannelSpawn"
         )
-
-        if os.path.exists(gallery_path):
-            # Read the file and check for use_channel parameter
-            with open(gallery_path, "r", encoding="utf-8") as f:
-                content = f.read()
-
-            assert "use_channel" in content
-            assert "spawn_ipc_channel" in content
-            assert "send_json_to_process" in content
 
 
 class TestIpcChannelThreadSafety:

--- a/tests/python/integration/test_multi_window_integration.py
+++ b/tests/python/integration/test_multi_window_integration.py
@@ -439,6 +439,10 @@ class TestCrossPanelCommunication:
 
         wm = get_window_manager()
         received_events: List[Any] = []
+        # WindowManager stores only a weakref to each window. Hold strong
+        # references here so the mocks aren't GC'd before broadcast_event()
+        # runs (otherwise _on_window_gc removes them and the count is flaky).
+        windows: List[Any] = []
 
         # Create windows that track received events
         for i in range(3):
@@ -452,6 +456,7 @@ class TestCrossPanelCommunication:
 
             wv.emit = make_handler(i)
             wm.register(wv)
+            windows.append(wv)
 
         # Broadcast state update
         state_data = {

--- a/tests/python/integration/test_multi_window_integration.py
+++ b/tests/python/integration/test_multi_window_integration.py
@@ -153,6 +153,10 @@ class TestWindowManagerIntegration:
 
         wm = get_window_manager()
         registered_ids: List[str] = []
+        # WindowManager stores only a weakref to each window. Hold strong
+        # references here so the mocks aren't GC'd before count() is checked
+        # (otherwise _on_window_gc removes them and the count is flaky).
+        windows: List[Any] = []
         lock = threading.Lock()
 
         def register_window(idx: int):
@@ -161,6 +165,7 @@ class TestWindowManagerIntegration:
             uid = wm.register(wv)
             with lock:
                 registered_ids.append(uid)
+                windows.append(wv)
 
         # Register concurrently
         threads = [threading.Thread(target=register_window, args=(i,)) for i in range(10)]
@@ -315,7 +320,9 @@ class TestTabContainerIntegration:
             )
 
         assert container.get_tab_count() == 2
-        assert container.get_active_tab_id() == tab1.id
+        # create_tab defaults to activate=True, so the most recently created
+        # tab (tab2) becomes the active one.
+        assert container.get_active_tab_id() == tab2.id
 
         # Switch tabs
         container.activate_tab(tab2.id)

--- a/tests/python/integration/test_qt_event_processor.py
+++ b/tests/python/integration/test_qt_event_processor.py
@@ -42,7 +42,7 @@ class TestQtEventProcessor(unittest.TestCase):
         processor = QtEventProcessor(webview)
 
         # Mock Qt and WebView process_events
-        with patch("auroraview.integration.qt.QCoreApplication") as mock_qt:
+        with patch("auroraview.integration.qt.event_processor.QCoreApplication") as mock_qt:
             # Call process
             processor.process()
 
@@ -73,10 +73,12 @@ class TestQtEventProcessor(unittest.TestCase):
         """Test WebView without processor uses default implementation."""
         webview = WebView()
 
-        # Mock _core.process_events
-        webview._core.process_events = MagicMock()
+        # Replace the native Rust core with a mock so we can observe the
+        # default-path call. The real `_core` is a builtins.WebView whose
+        # attributes can't be reassigned, so swap the whole object.
+        webview._core = MagicMock()
 
-        # Emit event (should use default implementation)
+        # Emit event (should use default implementation via _auto_process_events)
         webview.emit("test_event", {"data": 123})
 
         # Verify default implementation was called

--- a/tests/python/integration/test_qt_zombie_fix.py
+++ b/tests/python/integration/test_qt_zombie_fix.py
@@ -190,6 +190,7 @@ class TestZombieReferenceFix:
         from unittest.mock import MagicMock
 
         from qtpy.QtCore import QSize
+        from qtpy.QtGui import QResizeEvent
 
         from auroraview import QtWebView
 
@@ -202,11 +203,13 @@ class TestZombieReferenceFix:
             )
             webview._webview_container = mock_container
 
-            mock_event = MagicMock()
-            mock_event.size.return_value = QSize(800, 600)
+            # Use a real QResizeEvent: PySide6/PyQt strictly type-check the
+            # argument to QWidget.resizeEvent(), so a MagicMock is rejected
+            # before our dead-container handling is reached.
+            resize_event = QResizeEvent(QSize(800, 600), QSize(640, 480))
 
             with caplog.at_level(logging.WARNING):
-                webview.resizeEvent(mock_event)
+                webview.resizeEvent(resize_event)
 
             # Container should be cleared
             assert webview._webview_container is None

--- a/tests/python/integration/test_timer_integration.py
+++ b/tests/python/integration/test_timer_integration.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import time
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,9 +16,16 @@ class MockWebView:
     def __init__(self):
         self._should_close = False
         self._process_events_called = 0
-        self._core = MagicMock()
-        self._core.is_window_valid.return_value = True
-        self._core.hwnd.return_value = 0x12345678  # Mock HWND
+        self._is_valid = True
+
+    @property
+    def is_ready(self) -> bool:
+        """EventTimer reads this as the single source of truth for readiness."""
+        return True
+
+    def is_window_valid(self) -> bool:
+        """EventTimer's validity probe (replaces the old ``_core`` path)."""
+        return self._is_valid
 
     def process_events(self):
         """Mock process_events method."""


### PR DESCRIPTION
## Summary

Realign the Python integration test suite with source modules that drifted ahead of it, and stabilize two flaky/strict-binding cases. All changes are **test-only** — no production code or public API is touched.

4 commits · 8 files · +105 / −77.

## Key changes

### `test_event_timer.py` / `test_timer_integration.py` — EventTimer readiness probe
- `MockWebView` now exposes `is_ready` / `is_window_valid()` to match the `_is_core_ready()` single-source-of-truth probe.

### `test_cli_main.py` — CLI exit semantics
- `main()` now `sys.exit(0)` on success; success-path cases wrap in `pytest.raises(SystemExit)` and assert `code == 0`.

### `test_browser_integration.py` — browser HTML shell
- `_get_browser_html()` returns the Vite controller shell; assertions now check the SPA root/bundle instead of retired hand-written markup.

### `test_qt_event_processor.py` — Qt processor default path
- Patch `event_processor.QCoreApplication` and swap the whole native `_core` mock for the default-path assertion.

### `test_multi_window_integration.py` — tab activation + GC stability
- `create_tab` defaults `activate=True` (assert `tab2.id`).
- Hold strong refs to mocks so `WindowManager`'s weakrefs can't be GC'd mid-test, fixing flaky `count()`.

### `test_qt_zombie_fix.py` — strict binding + weakref hardening
- Use a real `QResizeEvent` in the dead-container resize test (PySide6/PyQt strictly type-check `resizeEvent()`, rejecting a `MagicMock`).
- Hold strong references to mock windows in the cross-panel broadcast test so weakref GC can't make the received-event count flaky.

### `test_ipc_channel_e2e.py` — drop retired gallery skip case
- `gallery/main.py` no longer wires the IPC channel; removed the empty skip-only `TestGalleryIpcChannelIntegration` shell. Real channel-spawn behaviour stays covered by `TestIpcChannelSpawn`.

## Type

- [x] test

## Breaking changes

None.

## Validation

- `vx just test` — full Python test suite (the 3 intentional `emit()`-signal zombie cases remain untouched).
