### PR TITLE
feat: add packed headless CLI mode (RFC 0018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ server.stop()
 - [OK] **Example Runner**: Run any example with live stdout/stderr output
 - [OK] **Category Browser**: Organized examples by category with search
 - [OK] **Pack Command**: Build standalone Gallery executable with `auroraview pack`
+- [OK] **Headless CLI Mode**: Run a packed app's registered Python commands straight from a terminal (`app.exe run <cmd>`, `-h`, `list`) without opening a window — opt-in per command via `@webview.command(cli=...)`. See the [Packing guide](docs/guide/packing.md#headless-cli-mode).
 
 ### Security
 - [OK] **CSP Configuration**: Content Security Policy support

--- a/README_zh.md
+++ b/README_zh.md
@@ -175,6 +175,7 @@ AuroraView 为专业DCC应用程序（如Maya、3ds Max、Houdini、Blender、Ph
 - [OK] **示例运行器**: 运行任意示例，实时显示 stdout/stderr 输出
 - [OK] **分类浏览器**: 按类别组织示例，支持搜索
 - [OK] **Pack 命令**: 通过 `auroraview pack` 构建独立 Gallery 可执行文件
+- [OK] **命令行模式 (Headless CLI)**: 在终端里直接运行打包应用已注册的 Python 命令（`app.exe run <cmd>`、`-h`、`list`），无需打开窗口——通过 `@webview.command(cli=...)` 逐命令显式开启。详见[应用打包指南](docs/zh/guide/packing.md)的「命令行模式」一节。
 
 ### 安全
 - [OK] **CSP 配置**: 内容安全策略支持

--- a/crates/auroraview-cli/Cargo.toml
+++ b/crates/auroraview-cli/Cargo.toml
@@ -105,8 +105,11 @@ auroraview-workspace-hack = { version = "0.1", path = "../auroraview-workspace-h
 # WebView2 COM bindings for warmup
 webview2-com = "0.39"
 windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_Security",
     "Win32_System_Com",
     "Win32_System_Console",
+    "Win32_Storage_FileSystem",
 ] }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/auroraview-cli/src/cli/inspect.rs
+++ b/crates/auroraview-cli/src/cli/inspect.rs
@@ -57,6 +57,26 @@ pub fn run_inspect(args: InspectArgs) -> Result<()> {
         println!("  Strategy: {:?}", python.strategy);
     }
 
+    // Display CLI commands embedded at pack time (RFC 0018 §5)
+    if !overlay.config.cli_commands.is_empty() {
+        println!(
+            "\n[CLI Commands] ({} total)",
+            overlay.config.cli_commands.len()
+        );
+        for cmd in &overlay.config.cli_commands {
+            let aliases = if cmd.aliases.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", cmd.aliases.join(", "))
+            };
+            println!("  {}{}  {}", cmd.name, aliases, cmd.help);
+            for param in &cmd.params {
+                let req = if param.required { "required" } else { "optional" };
+                println!("      --{} <{}> [{}]", param.name, param.r#type, req);
+            }
+        }
+    }
+
     // Display assets
     println!("\n[Assets] ({} total)", overlay.assets.len());
 

--- a/crates/auroraview-cli/src/cli/inspect.rs
+++ b/crates/auroraview-cli/src/cli/inspect.rs
@@ -194,3 +194,120 @@ pub fn run_inspect(args: InspectArgs) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use auroraview_pack::{
+        CliCommandMeta, CliParamMeta, OverlayData, OverlayWriter, PackConfig,
+    };
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    /// Write an overlay onto a fake "executable" temp file and return the handle.
+    /// The `NamedTempFile` must be kept alive by the caller so the path stays valid.
+    fn packed_exe(config: PackConfig, assets: &[(&str, &[u8])]) -> NamedTempFile {
+        let temp = NamedTempFile::new().unwrap();
+        fs::write(temp.path(), b"fake-exe-bytes").unwrap();
+        let mut data = OverlayData::new(config);
+        for (path, content) in assets {
+            data.add_asset((*path).to_string(), content.to_vec());
+        }
+        OverlayWriter::write(temp.path(), &data).unwrap();
+        temp
+    }
+
+    fn cli_cmd(name: &str, aliases: &[&str]) -> CliCommandMeta {
+        CliCommandMeta {
+            name: name.to_string(),
+            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            help: "Help text".to_string(),
+            params: vec![CliParamMeta {
+                name: "path".to_string(),
+                r#type: "str".to_string(),
+                required: true,
+                default: serde_json::Value::Null,
+                help: "Output path".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn inspect_missing_file_errors() {
+        let args = InspectArgs {
+            exe_path: PathBuf::from("/no/such/packed-exe-xyz"),
+            show_content: false,
+            filter: None,
+        };
+        let err = run_inspect(args).unwrap_err();
+        assert!(err.to_string().contains("File not found"));
+    }
+
+    #[test]
+    fn inspect_plain_file_reports_no_overlay() {
+        let temp = NamedTempFile::new().unwrap();
+        fs::write(temp.path(), b"not a packed exe").unwrap();
+        let args = InspectArgs {
+            exe_path: temp.path().to_path_buf(),
+            show_content: false,
+            filter: None,
+        };
+        let err = run_inspect(args).unwrap_err();
+        assert!(err.to_string().contains("No overlay data"));
+    }
+
+    #[test]
+    fn inspect_url_overlay_with_assets_succeeds() {
+        let config = PackConfig::url("https://example.com").with_title("Inspect Me");
+        let temp = packed_exe(
+            config,
+            &[
+                ("index.html", b"<html><body>hi</body></html>"),
+                ("style.css", b"body{}"),
+            ],
+        );
+        let args = InspectArgs {
+            exe_path: temp.path().to_path_buf(),
+            show_content: true,
+            filter: None,
+        };
+        // run_inspect prints to stdout; we only assert it walks the whole path Ok.
+        run_inspect(args).expect("inspect should succeed on a valid URL overlay");
+    }
+
+    #[test]
+    fn inspect_fullstack_with_cli_commands_and_filter() {
+        // FullStack mode + embedded CLI commands + python asset exercises the
+        // Python-backend, CLI-commands, and diagnostics branches.
+        let config = PackConfig::fullstack("./dist", "app.main:run");
+        let mut data_config = config;
+        data_config.cli_commands = vec![cli_cmd("export", &["exp"]), cli_cmd("sync", &[])];
+        let temp = packed_exe(
+            data_config,
+            &[
+                ("frontend/index.html", b"<html></html>"),
+                ("python/main.py", b"print('x')"),
+                ("loading/index.html", b"<p>loading</p>"),
+            ],
+        );
+        let args = InspectArgs {
+            exe_path: temp.path().to_path_buf(),
+            show_content: false,
+            filter: Some("*.html".to_string()),
+        };
+        run_inspect(args).expect("inspect should succeed on a FullStack overlay");
+    }
+
+    #[test]
+    fn inspect_warns_when_index_missing() {
+        // No index.html anywhere -> the white-screen diagnostics branch runs.
+        let config = PackConfig::url("https://example.com");
+        let temp = packed_exe(config, &[("about.html", b"<html></html>")]);
+        let args = InspectArgs {
+            exe_path: temp.path().to_path_buf(),
+            show_content: false,
+            filter: None,
+        };
+        run_inspect(args).expect("inspect should still succeed (warning only)");
+    }
+}

--- a/crates/auroraview-cli/src/cli/inspect.rs
+++ b/crates/auroraview-cli/src/cli/inspect.rs
@@ -71,7 +71,11 @@ pub fn run_inspect(args: InspectArgs) -> Result<()> {
             };
             println!("  {}{}  {}", cmd.name, aliases, cmd.help);
             for param in &cmd.params {
-                let req = if param.required { "required" } else { "optional" };
+                let req = if param.required {
+                    "required"
+                } else {
+                    "optional"
+                };
                 println!("      --{} <{}> [{}]", param.name, param.r#type, req);
             }
         }
@@ -198,9 +202,7 @@ pub fn run_inspect(args: InspectArgs) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use auroraview_pack::{
-        CliCommandMeta, CliParamMeta, OverlayData, OverlayWriter, PackConfig,
-    };
+    use auroraview_pack::{CliCommandMeta, CliParamMeta, OverlayData, OverlayWriter, PackConfig};
     use std::fs;
     use tempfile::NamedTempFile;
 

--- a/crates/auroraview-cli/src/main.rs
+++ b/crates/auroraview-cli/src/main.rs
@@ -125,7 +125,12 @@ enum Commands {
 fn main() -> Result<()> {
     // Check if this is a packed executable first
     if is_packed() {
-        return packed::run_packed_app();
+        // RFC 0018 §4: a packed exe is GUI by default, but an explicit reserved
+        // verb/flag as the first argument routes to the headless CLI path.
+        return match packed::classify_packed_invocation(std::env::args()) {
+            packed::PackedInvocation::Gui => packed::run_packed_app(),
+            packed::PackedInvocation::Cli(cli_args) => packed::run_packed_cli(cli_args),
+        };
     }
 
     let cli = Cli::parse();

--- a/crates/auroraview-cli/src/packed/cli.rs
+++ b/crates/auroraview-cli/src/packed/cli.rs
@@ -226,4 +226,40 @@ mod tests {
             PackedInvocation::Gui
         );
     }
+
+    #[test]
+    fn program_name_is_non_empty() {
+        // Derived from the test binary's own path; never the "app" fallback here.
+        let name = program_name();
+        assert!(!name.is_empty());
+        assert!(!name.ends_with(".exe"), "exe suffix should be stripped");
+    }
+
+    #[test]
+    fn read_cli_commands_empty_without_overlay() {
+        // The test binary has no overlay, so the embedded table reads as empty
+        // rather than aborting (best-effort contract).
+        assert!(read_cli_commands().is_empty());
+    }
+
+    #[test]
+    fn run_packed_cli_version_prints_and_succeeds() {
+        // -V / --version render purely from the crate version, no overlay needed.
+        assert!(run_packed_cli(vec!["-V".to_string()]).is_ok());
+        assert!(run_packed_cli(vec!["--version".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn run_packed_cli_help_succeeds_without_overlay() {
+        // -h reads the (empty) command table from this test binary and renders
+        // help text; it must not error when no overlay is present.
+        assert!(run_packed_cli(vec!["-h".to_string()]).is_ok());
+        assert!(run_packed_cli(vec!["--help".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn run_packed_cli_list_succeeds_text_and_json() {
+        assert!(run_packed_cli(vec!["list".to_string()]).is_ok());
+        assert!(run_packed_cli(vec!["list".to_string(), "--json".to_string()]).is_ok());
+    }
 }

--- a/crates/auroraview-cli/src/packed/cli.rs
+++ b/crates/auroraview-cli/src/packed/cli.rs
@@ -72,9 +72,9 @@ where
 /// [`classify_packed_invocation`] (the reserved verb/flag followed by its
 /// arguments, without argv[0]).
 ///
-/// This currently implements the step-2 skeleton: console attach, `-V`/
-/// `--version`, and a placeholder `-h`. `run` / `list` rendering and command
-/// invocation land in later RFC steps.
+/// Handles `-V`/`--version` and `-h`/`--help`/`list` (rendered purely from the
+/// overlay's embedded command table — no Python launch, §13.4). `run` extracts
+/// Python and invokes the command in-process (§7 / §15.2).
 pub fn run_packed_cli(cli_args: Vec<String>) -> Result<()> {
     // Reconnect stdio to the launching terminal before printing anything
     // (§3.2). Harmless if there is no parent console.
@@ -88,15 +88,21 @@ pub fn run_packed_cli(cli_args: Vec<String>) -> Result<()> {
             Ok(())
         }
         "-h" | "--help" => {
-            // Placeholder until §13.4 overlay-driven rendering lands (step 6).
-            print_help_placeholder();
+            let commands = read_cli_commands();
+            print!("{}", super::render::render_help(&commands));
             Ok(())
         }
-        "run" | "list" => {
-            // Wired in later RFC steps (7 and 6 respectively).
-            eprintln!("auroraview: '{first}' is not implemented yet");
-            std::process::exit(2);
+        "list" => {
+            let json = cli_args.iter().skip(1).any(|a| a == "--json");
+            let commands = read_cli_commands();
+            if json {
+                println!("{}", super::render::render_list_json(&commands));
+            } else {
+                print!("{}", super::render::render_list(&commands));
+            }
+            Ok(())
         }
+        "run" => super::run::run_command(&cli_args[1..]),
         _ => {
             eprintln!("auroraview: unknown CLI invocation: {first}");
             std::process::exit(2);
@@ -104,16 +110,22 @@ pub fn run_packed_cli(cli_args: Vec<String>) -> Result<()> {
     }
 }
 
-/// Minimal help text shown until the overlay-driven command list is wired up.
-fn print_help_placeholder() {
-    println!("AuroraView packed application");
-    println!();
-    println!("USAGE:");
-    println!("    app.exe                       Launch the GUI window");
-    println!("    app.exe run <command> [args]  Run a registered command");
-    println!("    app.exe list [--json]         List available commands");
-    println!("    app.exe -h, --help            Show this help");
-    println!("    app.exe -V, --version         Show version");
+/// Read the embedded CLI command table from the packed executable's overlay.
+///
+/// Returns an empty list on any read failure — `-h`/`list` then show no
+/// commands rather than aborting, matching the best-effort pack-time embed.
+fn read_cli_commands() -> Vec<auroraview_pack::CliCommandMeta> {
+    let Ok(exe_path) = std::env::current_exe() else {
+        return Vec::new();
+    };
+    match auroraview_pack::OverlayReader::read(&exe_path) {
+        Ok(Some(overlay)) => overlay.config.cli_commands,
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            eprintln!("auroraview: failed to read overlay: {e}");
+            Vec::new()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/auroraview-cli/src/packed/cli.rs
+++ b/crates/auroraview-cli/src/packed/cli.rs
@@ -1,0 +1,198 @@
+//! Packed headless CLI mode entry and argv classification (RFC 0018 §4).
+//!
+//! A packed executable normally opens its GUI window on launch and ignores
+//! argv. RFC 0018 adds a *headless CLI* path so the same `app.exe` can also
+//! run registered commands from a terminal. To avoid hijacking ordinary
+//! launches (file associations, drag-and-drop paths, protocol activation), the
+//! CLI path is triggered **only** by an explicit reserved verb or flag as the
+//! first argument (§4.3):
+//!
+//! | First argument                 | Result                |
+//! |--------------------------------|-----------------------|
+//! | (none)                         | GUI                   |
+//! | `some/file.proj`               | GUI (open path later) |
+//! | `run <cmd> [--k v ...]`        | CLI: invoke a command |
+//! | `list [--json]`                | CLI: list commands    |
+//! | `-h` / `--help`                | CLI: print help       |
+//! | `-V` / `--version`             | CLI: print version    |
+//!
+//! Everything else falls through to GUI, so a bare path or unknown flag never
+//! gets misread as a command.
+
+use anyhow::Result;
+
+/// How a packed executable was invoked, after classifying argv (§4.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackedInvocation {
+    /// Open the GUI window (default / file-association / drag-drop launch).
+    Gui,
+    /// Run the headless CLI path with the given arguments (excluding argv[0]).
+    Cli(Vec<String>),
+}
+
+/// Reserved subcommand verbs that trigger the CLI path (§4.3, decision #1).
+const RESERVED_VERBS: &[&str] = &["run", "list"];
+
+/// Classify a packed invocation from the full process argument list.
+///
+/// `args` is expected to include argv[0] (the executable path), matching
+/// `std::env::args()`. Only the first *real* argument decides the mode.
+pub fn classify_packed_invocation<I, S>(args: I) -> PackedInvocation
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    // Drop argv[0]; the first remaining token is the discriminator.
+    let mut rest = args.into_iter().map(Into::into);
+    let _exe = rest.next();
+
+    let first = match rest.next() {
+        Some(tok) => tok,
+        None => return PackedInvocation::Gui, // bare launch → GUI
+    };
+
+    let is_cli_trigger = RESERVED_VERBS.contains(&first.as_str())
+        || matches!(first.as_str(), "-h" | "--help" | "-V" | "--version");
+
+    if !is_cli_trigger {
+        // Bare path / unknown flag / anything else → GUI (§4.3).
+        return PackedInvocation::Gui;
+    }
+
+    // Re-assemble the CLI argument vector (the trigger token + remainder).
+    let mut cli_args = Vec::new();
+    cli_args.push(first);
+    cli_args.extend(rest);
+    PackedInvocation::Cli(cli_args)
+}
+
+/// Run the packed headless CLI path (§7).
+///
+/// `cli_args` is the classified argument vector from
+/// [`classify_packed_invocation`] (the reserved verb/flag followed by its
+/// arguments, without argv[0]).
+///
+/// This currently implements the step-2 skeleton: console attach, `-V`/
+/// `--version`, and a placeholder `-h`. `run` / `list` rendering and command
+/// invocation land in later RFC steps.
+pub fn run_packed_cli(cli_args: Vec<String>) -> Result<()> {
+    // Reconnect stdio to the launching terminal before printing anything
+    // (§3.2). Harmless if there is no parent console.
+    super::attach_parent_console();
+
+    let first = cli_args.first().map(String::as_str).unwrap_or("");
+
+    match first {
+        "-V" | "--version" => {
+            println!("auroraview {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        "-h" | "--help" => {
+            // Placeholder until §13.4 overlay-driven rendering lands (step 6).
+            print_help_placeholder();
+            Ok(())
+        }
+        "run" | "list" => {
+            // Wired in later RFC steps (7 and 6 respectively).
+            eprintln!("auroraview: '{first}' is not implemented yet");
+            std::process::exit(2);
+        }
+        _ => {
+            eprintln!("auroraview: unknown CLI invocation: {first}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// Minimal help text shown until the overlay-driven command list is wired up.
+fn print_help_placeholder() {
+    println!("AuroraView packed application");
+    println!();
+    println!("USAGE:");
+    println!("    app.exe                       Launch the GUI window");
+    println!("    app.exe run <command> [args]  Run a registered command");
+    println!("    app.exe list [--json]         List available commands");
+    println!("    app.exe -h, --help            Show this help");
+    println!("    app.exe -V, --version         Show version");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(args: &[&str]) -> PackedInvocation {
+        classify_packed_invocation(args.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn bare_launch_is_gui() {
+        assert_eq!(classify(&["app.exe"]), PackedInvocation::Gui);
+    }
+
+    #[test]
+    fn no_args_at_all_is_gui() {
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(classify_packed_invocation(empty), PackedInvocation::Gui);
+    }
+
+    #[test]
+    fn bare_file_path_is_gui() {
+        // File association / drag-drop must never be read as a command.
+        assert_eq!(
+            classify(&["app.exe", "some/file.proj"]),
+            PackedInvocation::Gui
+        );
+        assert_eq!(
+            classify(&["app.exe", "C:\\docs\\thing.proj"]),
+            PackedInvocation::Gui
+        );
+    }
+
+    #[test]
+    fn unknown_leading_flag_is_gui() {
+        // Only the reserved flags trigger CLI; anything else stays GUI.
+        assert_eq!(classify(&["app.exe", "--open"]), PackedInvocation::Gui);
+        assert_eq!(classify(&["app.exe", "-x"]), PackedInvocation::Gui);
+    }
+
+    #[test]
+    fn run_verb_triggers_cli_with_args() {
+        assert_eq!(
+            classify(&["app.exe", "run", "export", "--path", "./out"]),
+            PackedInvocation::Cli(vec![
+                "run".into(),
+                "export".into(),
+                "--path".into(),
+                "./out".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn list_verb_triggers_cli() {
+        assert_eq!(
+            classify(&["app.exe", "list", "--json"]),
+            PackedInvocation::Cli(vec!["list".into(), "--json".into()])
+        );
+    }
+
+    #[test]
+    fn help_and_version_flags_trigger_cli() {
+        for flag in ["-h", "--help", "-V", "--version"] {
+            assert_eq!(
+                classify(&["app.exe", flag]),
+                PackedInvocation::Cli(vec![flag.into()]),
+                "flag {flag} should trigger CLI",
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_verb_only_matters_as_first_token() {
+        // A path that merely contains 'run' later is still GUI.
+        assert_eq!(
+            classify(&["app.exe", "myfile.proj", "run"]),
+            PackedInvocation::Gui
+        );
+    }
+}

--- a/crates/auroraview-cli/src/packed/cli.rs
+++ b/crates/auroraview-cli/src/packed/cli.rs
@@ -19,7 +19,26 @@
 //! Everything else falls through to GUI, so a bare path or unknown flag never
 //! gets misread as a command.
 
+use std::path::Path;
+
 use anyhow::Result;
+
+/// Best-effort program name for help/usage text (RFC 0018 §4).
+///
+/// The packed exe name is chosen by the developer at pack time (e.g.
+/// `packed-cli-demo`), so hardcoding `app` in `-h`/error output would tell the
+/// user to type a command that doesn't exist. Derive it from
+/// `std::env::current_exe()`'s file stem, dropping the `.exe` suffix on
+/// Windows. Falls back to `"app"` when the executable path is unavailable.
+pub(crate) fn program_name() -> String {
+    std::env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(Path::file_stem)
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| "app".to_string())
+}
 
 /// How a packed executable was invoked, after classifying argv (§4.2).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,7 +108,7 @@ pub fn run_packed_cli(cli_args: Vec<String>) -> Result<()> {
         }
         "-h" | "--help" => {
             let commands = read_cli_commands();
-            print!("{}", super::render::render_help(&commands));
+            print!("{}", super::render::render_help(&program_name(), &commands));
             Ok(())
         }
         "list" => {

--- a/crates/auroraview-cli/src/packed/console.rs
+++ b/crates/auroraview-cli/src/packed/console.rs
@@ -1,0 +1,106 @@
+//! Console attachment for the packed headless CLI mode (RFC 0018 §3).
+//!
+//! Packed executables have their PE subsystem rewritten to GUI (see
+//! `auroraview-pack` `resource_editor::set_subsystem`) so a double-click never
+//! flashes a console window. The downside is that a GUI-subsystem process does
+//! **not** inherit the parent shell's stdin/stdout/stderr, so anything printed
+//! from `app.exe -h` / `app.exe list` would otherwise vanish.
+//!
+//! [`attach_parent_console`] reconnects the standard streams to the launching
+//! console (when there is one) and switches the output code page to UTF-8 so
+//! that Chinese text and emoji render correctly. It is only meant to run on the
+//! CLI path: double-click launches have no parent console, `AttachConsole`
+//! returns an error, and we leave the GUI path untouched (§3.3).
+//!
+//! On non-Windows targets the whole thing is a no-op — `.app` / AppImage
+//! bundles don't have the GUI-subsystem stdio isolation problem (§9.4).
+
+/// Attach the current process to its parent console and route the standard
+/// streams there, using UTF-8 for output.
+///
+/// Returns `true` when a parent console was attached and the streams were
+/// reopened (i.e. we were launched from a terminal), `false` otherwise (e.g.
+/// double-click, where there is no parent console). On non-Windows platforms
+/// this always returns `false`.
+#[cfg(target_os = "windows")]
+pub fn attach_parent_console() -> bool {
+    use windows::Win32::System::Console::{
+        AttachConsole, SetConsoleOutputCP, ATTACH_PARENT_PROCESS,
+    };
+
+    // SAFETY: All calls are plain Win32 FFI with no shared-state invariants.
+    // `AttachConsole` is idempotent-safe to probe; on failure we bail out
+    // before touching any std handles.
+    unsafe {
+        if AttachConsole(ATTACH_PARENT_PROCESS).is_err() {
+            // No parent console (double-click / detached launch). Leave stdio
+            // as-is so the GUI path is unaffected (§3.3).
+            return false;
+        }
+
+        reopen_std_streams();
+
+        // CP_UTF8 = 65001. Without this the console mangles multi-byte text.
+        let _ = SetConsoleOutputCP(65001);
+    }
+
+    true
+}
+
+/// Re-point the process standard handles at the freshly attached console.
+///
+/// After `AttachConsole`, the `STD_*_HANDLE` slots may still reference the
+/// (invalid) handles inherited at startup. We open the console's own
+/// `CONOUT$` / `CONIN$` pseudo-files and install them via `SetStdHandle`.
+/// Rust's `std::io::{stdout, stderr, stdin}` re-query `GetStdHandle` on each
+/// access, so this is sufficient for `println!` / `eprintln!` to land in the
+/// parent console.
+#[cfg(target_os = "windows")]
+unsafe fn reopen_std_streams() {
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows::Win32::System::Console::{
+        SetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    };
+
+    // UTF-16, NUL-terminated names for the console pseudo-files.
+    let conout: Vec<u16> = "CONOUT$\0".encode_utf16().collect();
+    let conin: Vec<u16> = "CONIN$\0".encode_utf16().collect();
+
+    // Output side: CONOUT$ feeds both stdout and stderr.
+    if let Ok(out) = CreateFileW(
+        PCWSTR(conout.as_ptr()),
+        (GENERIC_READ | GENERIC_WRITE).0,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        None,
+        OPEN_EXISTING,
+        Default::default(),
+        None,
+    ) {
+        let _ = SetStdHandle(STD_OUTPUT_HANDLE, out);
+        let _ = SetStdHandle(STD_ERROR_HANDLE, out);
+    }
+
+    // Input side: CONIN$ feeds stdin.
+    if let Ok(inp) = CreateFileW(
+        PCWSTR(conin.as_ptr()),
+        (GENERIC_READ | GENERIC_WRITE).0,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        None,
+        OPEN_EXISTING,
+        Default::default(),
+        None,
+    ) {
+        let _ = SetStdHandle(STD_INPUT_HANDLE, inp);
+    }
+}
+
+/// Non-Windows stub: there is no GUI-subsystem stdio isolation to undo, so the
+/// standard streams already work. Always reports "no console attached".
+#[cfg(not(target_os = "windows"))]
+pub fn attach_parent_console() -> bool {
+    false
+}

--- a/crates/auroraview-cli/src/packed/mod.rs
+++ b/crates/auroraview-cli/src/packed/mod.rs
@@ -27,6 +27,8 @@ mod console;
 mod events;
 mod extract;
 mod license;
+mod render;
+mod run;
 mod utils;
 mod warmup;
 mod webview;

--- a/crates/auroraview-cli/src/packed/mod.rs
+++ b/crates/auroraview-cli/src/packed/mod.rs
@@ -22,6 +22,8 @@
 //! - Enables verbose logging
 
 mod backend;
+mod cli;
+mod console;
 mod events;
 mod extract;
 mod license;
@@ -44,6 +46,14 @@ pub use utils::{
 // Exposed for integration tests only; not part of the public API surface.
 #[doc(hidden)]
 pub use webview::resolve_packed_capture_file_drop;
+
+// RFC 0018 §3: attach the packed (GUI-subsystem) process to its parent console
+// so the headless CLI path can print to the launching terminal.
+pub use console::attach_parent_console;
+
+// RFC 0018 §4: classify a packed invocation (GUI vs headless CLI) and run the
+// CLI path. Exposed for integration tests covering the trigger convention.
+pub use cli::{classify_packed_invocation, run_packed_cli, PackedInvocation};
 
 // Re-export from auroraview-core
 pub use auroraview_core::assets::build_packed_init_script_with_csp;

--- a/crates/auroraview-cli/src/packed/render.rs
+++ b/crates/auroraview-cli/src/packed/render.rs
@@ -1,0 +1,170 @@
+//! Render the embedded CLI command table for `-h` / `list` (RFC 0018 §13.4).
+//!
+//! These functions consume the [`CliCommandMeta`] table read from the overlay
+//! and produce the human-readable (`-h`, `list`) and machine-readable
+//! (`list --json`) views. They never touch Python — the table was harvested at
+//! pack time (§5) — so rendering is allocation-only and instant.
+
+use auroraview_pack::CliCommandMeta;
+
+/// Render the `-h` / `--help` view: usage banner plus every command with its
+/// aliases, help text, and per-parameter detail.
+pub fn render_help(commands: &[CliCommandMeta]) -> String {
+    let mut out = String::new();
+    out.push_str("USAGE:\n");
+    out.push_str("    app run <command> [--key value ...]\n");
+    out.push_str("    app list [--json]\n");
+    out.push_str("    app -h | --help\n");
+    out.push_str("    app -V | --version\n");
+
+    if commands.is_empty() {
+        out.push_str("\nNo CLI commands are available in this application.\n");
+        return out;
+    }
+
+    out.push_str("\nCOMMANDS:\n");
+    for cmd in commands {
+        out.push_str(&format!("    {}", command_title(cmd)));
+        if !cmd.help.is_empty() {
+            out.push_str(&format!("   {}", cmd.help));
+        }
+        out.push('\n');
+        for param in &cmd.params {
+            out.push_str(&format!("        {}\n", param_line(param)));
+        }
+    }
+    out
+}
+
+/// Render the `list` view: one command per line (`name (alias) — help`).
+pub fn render_list(commands: &[CliCommandMeta]) -> String {
+    if commands.is_empty() {
+        return "No CLI commands are available in this application.\n".to_string();
+    }
+    let mut out = String::new();
+    for cmd in commands {
+        out.push_str(&command_title(cmd));
+        if !cmd.help.is_empty() {
+            out.push_str(&format!("   {}", cmd.help));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Render `list --json`: the §13.2 metadata array, verbatim and machine-readable.
+pub fn render_list_json(commands: &[CliCommandMeta]) -> String {
+    serde_json::to_string_pretty(commands).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// `name (alias1, alias2)` or just `name` when there are no aliases.
+fn command_title(cmd: &CliCommandMeta) -> String {
+    if cmd.aliases.is_empty() {
+        cmd.name.clone()
+    } else {
+        format!("{} ({})", cmd.name, cmd.aliases.join(", "))
+    }
+}
+
+/// `--name <type>  [required]/[default X]  help`.
+fn param_line(param: &auroraview_pack::CliParamMeta) -> String {
+    let tag = if param.required {
+        "[required]".to_string()
+    } else if param.default.is_null() {
+        "[optional]".to_string()
+    } else {
+        format!("[default {}]", render_default(&param.default))
+    };
+
+    let mut line = format!("--{} <{}>  {}", param.name, param.r#type, tag);
+    if !param.help.is_empty() {
+        line.push_str(&format!("  {}", param.help));
+    }
+    line
+}
+
+/// Compact one-line rendering of a JSON default value for help text.
+fn render_default(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use auroraview_pack::CliParamMeta;
+    use serde_json::json;
+
+    fn sample() -> Vec<CliCommandMeta> {
+        vec![CliCommandMeta {
+            name: "export-document-image".to_string(),
+            aliases: vec!["exi".to_string()],
+            help: "Export the current document as an image".to_string(),
+            params: vec![
+                CliParamMeta {
+                    name: "path".to_string(),
+                    r#type: "str".to_string(),
+                    required: true,
+                    default: json!(null),
+                    help: "Output directory".to_string(),
+                },
+                CliParamMeta {
+                    name: "dpi".to_string(),
+                    r#type: "int".to_string(),
+                    required: false,
+                    default: json!(300),
+                    help: "Resolution (DPI)".to_string(),
+                },
+            ],
+        }]
+    }
+
+    #[test]
+    fn help_includes_command_aliases_and_params() {
+        let out = render_help(&sample());
+        assert!(out.contains("USAGE:"));
+        assert!(out.contains("export-document-image (exi)"));
+        assert!(out.contains("--path <str>  [required]"));
+        assert!(out.contains("--dpi <int>  [default 300]"));
+        assert!(out.contains("Output directory"));
+    }
+
+    #[test]
+    fn help_handles_empty_table() {
+        let out = render_help(&[]);
+        assert!(out.contains("No CLI commands"));
+    }
+
+    #[test]
+    fn list_one_line_per_command() {
+        let out = render_list(&sample());
+        assert_eq!(out.lines().count(), 1);
+        assert!(out.contains("export-document-image (exi)"));
+        assert!(out.contains("Export the current document"));
+    }
+
+    #[test]
+    fn list_json_round_trips() {
+        let out = render_list_json(&sample());
+        let parsed: Vec<CliCommandMeta> = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed, sample());
+    }
+
+    #[test]
+    fn list_json_empty_is_array() {
+        assert_eq!(render_list_json(&[]), "[]");
+    }
+
+    #[test]
+    fn title_without_aliases_is_bare_name() {
+        let cmd = CliCommandMeta {
+            name: "sync".to_string(),
+            aliases: vec![],
+            help: String::new(),
+            params: vec![],
+        };
+        assert_eq!(command_title(&cmd), "sync");
+    }
+}

--- a/crates/auroraview-cli/src/packed/render.rs
+++ b/crates/auroraview-cli/src/packed/render.rs
@@ -9,13 +9,16 @@ use auroraview_pack::CliCommandMeta;
 
 /// Render the `-h` / `--help` view: usage banner plus every command with its
 /// aliases, help text, and per-parameter detail.
-pub fn render_help(commands: &[CliCommandMeta]) -> String {
+///
+/// `program` is the actual executable name (RFC 0018 §4) so the usage lines
+/// match what the user typed, instead of a hardcoded `app`.
+pub fn render_help(program: &str, commands: &[CliCommandMeta]) -> String {
     let mut out = String::new();
     out.push_str("USAGE:\n");
-    out.push_str("    app run <command> [--key value ...]\n");
-    out.push_str("    app list [--json]\n");
-    out.push_str("    app -h | --help\n");
-    out.push_str("    app -V | --version\n");
+    out.push_str(&format!("    {program} run <command> [--key value ...]\n"));
+    out.push_str(&format!("    {program} list [--json]\n"));
+    out.push_str(&format!("    {program} -h | --help\n"));
+    out.push_str(&format!("    {program} -V | --version\n"));
 
     if commands.is_empty() {
         out.push_str("\nNo CLI commands are available in this application.\n");
@@ -123,8 +126,10 @@ mod tests {
 
     #[test]
     fn help_includes_command_aliases_and_params() {
-        let out = render_help(&sample());
+        let out = render_help("myapp", &sample());
         assert!(out.contains("USAGE:"));
+        // The usage banner uses the real program name, not a hardcoded `app`.
+        assert!(out.contains("myapp run <command>"));
         assert!(out.contains("export-document-image (exi)"));
         assert!(out.contains("--path <str>  [required]"));
         assert!(out.contains("--dpi <int>  [default 300]"));
@@ -133,7 +138,7 @@ mod tests {
 
     #[test]
     fn help_handles_empty_table() {
-        let out = render_help(&[]);
+        let out = render_help("myapp", &[]);
         assert!(out.contains("No CLI commands"));
     }
 

--- a/crates/auroraview-cli/src/packed/run.rs
+++ b/crates/auroraview-cli/src/packed/run.rs
@@ -293,4 +293,56 @@ mod tests {
         let code = build_invoke_code(Path::new("/tmp/app"), "main.py");
         assert!(code.contains("runpy.run_path"));
     }
+
+    #[test]
+    fn invoke_code_includes_bootstrap_when_present() {
+        // A `__aurora_bootstrap__.py` beside the sources is imported first so
+        // the packed runtime path matches the GUI launcher.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("__aurora_bootstrap__.py"), b"# boot").unwrap();
+        let code = build_invoke_code(dir.path(), "pkg.main:run");
+        assert!(code.contains("import __aurora_bootstrap__;"));
+        assert!(code.contains("from pkg.main import run"));
+    }
+
+    #[test]
+    fn invoke_code_empty_function_defaults_to_main() {
+        let code = build_invoke_code(Path::new("/tmp/app"), "pkg.entry:");
+        assert!(code.contains("from pkg.entry import main"));
+        assert!(code.contains("main()"));
+    }
+
+    #[test]
+    fn extract_python_sources_writes_python_prefixed_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = PackConfig::url("about:blank");
+        config.cli_commands = vec![];
+        let mut overlay = OverlayData::new(config);
+        overlay.add_asset("python/pkg/mod.py", b"x = 1\n".to_vec());
+        overlay.add_asset("python/main.py", b"print('hi')\n".to_vec());
+        overlay.add_asset("web/index.html", b"<html></html>".to_vec());
+
+        extract_python_sources(&overlay, dir.path()).expect("extract");
+
+        assert!(dir.path().join("pkg/mod.py").exists());
+        assert!(dir.path().join("main.py").exists());
+        assert!(!dir.path().join("index.html").exists());
+    }
+
+    #[test]
+    fn extract_python_sources_skips_identical_existing_content() {
+        // A warm cache leaves byte-identical files untouched (no rewrite).
+        let dir = tempfile::tempdir().unwrap();
+        let mut overlay = OverlayData::new(PackConfig::url("about:blank"));
+        overlay.add_asset("python/main.py", b"same\n".to_vec());
+
+        // Pre-create the destination with identical content.
+        std::fs::write(dir.path().join("main.py"), b"same\n").unwrap();
+        extract_python_sources(&overlay, dir.path()).expect("extract");
+
+        assert_eq!(
+            std::fs::read(dir.path().join("main.py")).unwrap(),
+            b"same\n"
+        );
+    }
 }

--- a/crates/auroraview-cli/src/packed/run.rs
+++ b/crates/auroraview-cli/src/packed/run.rs
@@ -1,0 +1,293 @@
+//! Headless `run` execution for the packed CLI path (RFC 0018 §7 / §15.2).
+//!
+//! `app run <name|alias> [args...]` invokes a single registered command in a
+//! one-shot Python process and exits — it does **not** reuse the persistent
+//! JSON-RPC server the GUI path uses (§9.5), avoiding state pollution.
+//!
+//! Flow:
+//! 1. read the overlay and normalize `<alias>` → canonical name from the
+//!    embedded command table (§12, §15.2);
+//! 2. extract the bundled Python runtime + sources (shared hash-based cache as
+//!    the GUI path, so a warm cache means no re-extraction);
+//! 3. launch the entry point with `AURORAVIEW_CLI_INVOKE` + `AURORAVIEW_CLI_ARGS`
+//!    so Python builds `webview`/`commands` *without* `show()` and invokes the
+//!    command in-process (argument parsing per §6.3 lives Python-side, where the
+//!    signature is available);
+//! 4. inherit stdout/stderr straight to the terminal and map the child exit
+//!    code to the §4.4 convention.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+use auroraview_pack::{BundleStrategy, OverlayData, PackMode, PythonBundleConfig};
+
+use super::extract::{extract_lib_packages, extract_resources_parallel, extract_standalone_python};
+use super::utils::{build_module_search_paths, get_python_extract_dir_with_hash};
+
+/// Exit code for "command not found" / argument errors (§4.4).
+const EXIT_USAGE: i32 = 2;
+
+/// Entry point for `app run ...`. `args` is everything after the `run` verb
+/// (the command name/alias followed by its arguments).
+///
+/// Diverging exit codes are emitted via `std::process::exit` to honor §4.4
+/// precisely; the `Result` is reserved for unexpected internal failures.
+pub fn run_command(args: &[String]) -> Result<()> {
+    super::attach_parent_console();
+
+    let Some(requested) = args.first() else {
+        eprintln!("auroraview: 'run' requires a command name");
+        eprintln!("Try 'app -h' to list available commands.");
+        std::process::exit(EXIT_USAGE);
+    };
+
+    let exe_path = std::env::current_exe().context("locate current executable")?;
+    let overlay = match auroraview_pack::OverlayReader::read(&exe_path)? {
+        Some(o) => o,
+        None => {
+            eprintln!("auroraview: no packed overlay found");
+            std::process::exit(EXIT_USAGE);
+        }
+    };
+
+    // Resolve alias → canonical name against the embedded table (§15.2).
+    let canonical = match resolve_command(&overlay, requested) {
+        Some(name) => name,
+        None => {
+            eprintln!("auroraview: command not found: {requested}");
+            eprintln!("Try 'app list' to see available commands.");
+            std::process::exit(EXIT_USAGE);
+        }
+    };
+
+    let python = match &overlay.config.mode {
+        PackMode::FullStack { python, .. } => python.as_ref(),
+        _ => {
+            eprintln!("auroraview: this application has no Python backend to run commands");
+            std::process::exit(EXIT_USAGE);
+        }
+    };
+
+    let command_args: Vec<String> = args[1..].to_vec();
+    let code = invoke(&overlay, python, &canonical, &command_args)?;
+    std::process::exit(code);
+}
+
+/// Resolve a requested token to a canonical command name, accepting either the
+/// canonical name itself or any alias. Returns `None` if no CLI command matches.
+fn resolve_command(overlay: &OverlayData, requested: &str) -> Option<String> {
+    overlay.config.cli_commands.iter().find_map(|cmd| {
+        if cmd.name == requested || cmd.aliases.iter().any(|a| a == requested) {
+            Some(cmd.name.clone())
+        } else {
+            None
+        }
+    })
+}
+
+/// Extract Python, launch the one-shot invoke process, and return its exit code.
+fn invoke(
+    overlay: &OverlayData,
+    python: &PythonBundleConfig,
+    command: &str,
+    command_args: &[String],
+) -> Result<i32> {
+    let python_exe = match python.strategy {
+        BundleStrategy::Standalone => {
+            // First launch extracts the runtime (seconds); warm cache is instant.
+            // A one-line hint to stderr avoids looking hung (RFC §9.2).
+            let cache = get_python_extract_dir_with_hash(&overlay.content_hash);
+            if !cache.join(".cache_valid").exists() {
+                eprintln!("auroraview: preparing runtime (first run may take a few seconds)...");
+            }
+            extract_standalone_python(overlay).context("extract bundled Python runtime")?
+        }
+        _ => PathBuf::from("python"),
+    };
+
+    let temp_dir = get_python_extract_dir_with_hash(&overlay.content_hash);
+    fs::create_dir_all(&temp_dir)?;
+    let marker = temp_dir.join(".cache_valid");
+    let cache_valid = marker.exists();
+    let (resources_dir, site_packages_dir) = if cache_valid {
+        // Warm cache: reuse the previously extracted dirs (matches GUI path).
+        (temp_dir.join("resources"), temp_dir.join("site-packages"))
+    } else {
+        extract_python_sources(overlay, &temp_dir)?;
+        let resources = extract_resources_parallel(overlay, &temp_dir)?;
+        let site_packages = extract_lib_packages(overlay, &temp_dir)?;
+        // Mark the cache valid so the next run (and the GUI path) skip extraction.
+        let _ = fs::write(&marker, "1");
+        (resources, site_packages)
+    };
+
+    let module_paths = build_module_search_paths(
+        &python.module_search_paths,
+        &temp_dir,
+        &resources_dir,
+        &site_packages_dir,
+    );
+    let pythonpath = module_paths.join(if cfg!(windows) { ";" } else { ":" });
+
+    let code = build_invoke_code(&temp_dir, &python.entry_point);
+
+    let args_json = serde_json::to_string(command_args).unwrap_or_else(|_| "[]".to_string());
+
+    let mut cmd = Command::new(&python_exe);
+    cmd.args(["-c", &code])
+        .current_dir(&temp_dir)
+        // Headless invoke streams results straight to the user's terminal.
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .env("AURORAVIEW_PACKED", "1")
+        .env("AURORAVIEW_CLI_INVOKE", command)
+        .env("AURORAVIEW_CLI_ARGS", args_json)
+        .env("AURORAVIEW_RESOURCES_DIR", &resources_dir)
+        .env("PYTHONPATH", &pythonpath)
+        .env("PYTHONUNBUFFERED", "1")
+        .env("PYTHONIOENCODING", "utf-8");
+
+    if let Some(home) = python_exe.parent() {
+        cmd.env("PYTHONHOME", home);
+    }
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to launch interpreter: {}", python_exe.display()))?;
+
+    // §4.4: the Python invoke path already maps its own outcomes to 0/1/2 and
+    // exits with them. Propagate the child's code; default to 1 if it was
+    // terminated by a signal (no code available).
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Write every `python/<rel>` overlay asset to `root/<rel>`.
+///
+/// Mirrors the GUI extraction path. Files already present with identical
+/// content are left untouched (warm-cache reuse); a locked file with matching
+/// content is treated as success.
+fn extract_python_sources(overlay: &OverlayData, root: &Path) -> Result<()> {
+    let assets: Vec<_> = overlay
+        .assets
+        .iter()
+        .filter(|(p, _)| p.starts_with("python/"))
+        .collect();
+
+    let dirs: HashSet<PathBuf> = assets
+        .iter()
+        .filter_map(|(p, _)| {
+            let rel = p.strip_prefix("python/").unwrap_or(p);
+            root.join(rel).parent().map(Path::to_path_buf)
+        })
+        .collect();
+    for dir in &dirs {
+        fs::create_dir_all(dir)?;
+    }
+
+    for (path, content) in assets {
+        let rel = path.strip_prefix("python/").unwrap_or(path);
+        let dest = root.join(rel);
+        if let Ok(existing) = fs::read(&dest) {
+            if existing == *content {
+                continue;
+            }
+        }
+        if let Err(e) = fs::write(&dest, content) {
+            // A locked file whose content already matches is fine.
+            if e.raw_os_error() == Some(32) {
+                if let Ok(existing) = fs::read(&dest) {
+                    if existing == *content {
+                        continue;
+                    }
+                }
+            }
+            return Err(e).with_context(|| format!("write {}", dest.display()));
+        }
+    }
+    Ok(())
+}
+
+/// Build the `python -c` snippet that imports/runs the entry point. Mirrors the
+/// GUI launcher (`backend.rs`) and the pack-time dump so all three agree on how
+/// the user module is loaded.
+fn build_invoke_code(temp_dir: &Path, entry_point: &str) -> String {
+    let dir = temp_dir.display();
+    let has_bootstrap = temp_dir.join("__aurora_bootstrap__.py").exists();
+    let bootstrap = if has_bootstrap {
+        "import __aurora_bootstrap__; "
+    } else {
+        ""
+    };
+
+    if let Some((module, function)) = entry_point.split_once(':') {
+        let module = module.replace(['/', '\\'], ".");
+        let module = module.trim_end_matches(".py");
+        let function = if function.is_empty() { "main" } else { function };
+        format!(
+            "import sys; sys.path.insert(0, r'{dir}'); {bootstrap}from {module} import {function}; {function}()"
+        )
+    } else {
+        let script = temp_dir.join(entry_point);
+        format!(
+            "import sys; sys.path.insert(0, r'{dir}'); {bootstrap}import runpy; runpy.run_path(r'{}', run_name='__main__')",
+            script.display()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use auroraview_pack::{CliCommandMeta, PackConfig};
+
+    fn overlay_with(commands: Vec<CliCommandMeta>) -> OverlayData {
+        let mut config = PackConfig::url("about:blank");
+        config.cli_commands = commands;
+        OverlayData::new(config)
+    }
+
+    fn cmd(name: &str, aliases: &[&str]) -> CliCommandMeta {
+        CliCommandMeta {
+            name: name.to_string(),
+            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            help: String::new(),
+            params: vec![],
+        }
+    }
+
+    #[test]
+    fn resolve_matches_canonical_name() {
+        let o = overlay_with(vec![cmd("export", &["exp"])]);
+        assert_eq!(resolve_command(&o, "export").as_deref(), Some("export"));
+    }
+
+    #[test]
+    fn resolve_matches_alias() {
+        let o = overlay_with(vec![cmd("export", &["exp", "e"])]);
+        assert_eq!(resolve_command(&o, "e").as_deref(), Some("export"));
+    }
+
+    #[test]
+    fn resolve_unknown_is_none() {
+        let o = overlay_with(vec![cmd("export", &["exp"])]);
+        assert!(resolve_command(&o, "missing").is_none());
+    }
+
+    #[test]
+    fn invoke_code_module_function_form() {
+        let code = build_invoke_code(Path::new("/tmp/app"), "pkg.main:run");
+        assert!(code.contains("from pkg.main import run"));
+        assert!(code.contains("run()"));
+        assert!(!code.contains("__aurora_bootstrap__"));
+    }
+
+    #[test]
+    fn invoke_code_script_form() {
+        let code = build_invoke_code(Path::new("/tmp/app"), "main.py");
+        assert!(code.contains("runpy.run_path"));
+    }
+}

--- a/crates/auroraview-cli/src/packed/run.rs
+++ b/crates/auroraview-cli/src/packed/run.rs
@@ -229,7 +229,11 @@ fn build_invoke_code(temp_dir: &Path, entry_point: &str) -> String {
     if let Some((module, function)) = entry_point.split_once(':') {
         let module = module.replace(['/', '\\'], ".");
         let module = module.trim_end_matches(".py");
-        let function = if function.is_empty() { "main" } else { function };
+        let function = if function.is_empty() {
+            "main"
+        } else {
+            function
+        };
         format!(
             "import sys; sys.path.insert(0, r'{dir}'); {bootstrap}from {module} import {function}; {function}()"
         )

--- a/crates/auroraview-cli/src/packed/run.rs
+++ b/crates/auroraview-cli/src/packed/run.rs
@@ -38,9 +38,12 @@ const EXIT_USAGE: i32 = 2;
 pub fn run_command(args: &[String]) -> Result<()> {
     super::attach_parent_console();
 
+    // Real exe name for hint text, so suggestions match what the user typed.
+    let prog = super::cli::program_name();
+
     let Some(requested) = args.first() else {
         eprintln!("auroraview: 'run' requires a command name");
-        eprintln!("Try 'app -h' to list available commands.");
+        eprintln!("Try '{prog} -h' to list available commands.");
         std::process::exit(EXIT_USAGE);
     };
 
@@ -58,7 +61,7 @@ pub fn run_command(args: &[String]) -> Result<()> {
         Some(name) => name,
         None => {
             eprintln!("auroraview: command not found: {requested}");
-            eprintln!("Try 'app list' to see available commands.");
+            eprintln!("Try '{prog} list' to see available commands.");
             std::process::exit(EXIT_USAGE);
         }
     };

--- a/crates/auroraview-pack/src/builder/win.rs
+++ b/crates/auroraview-pack/src/builder/win.rs
@@ -152,6 +152,13 @@ impl Builder for WinBuilder {
             overlay.add_asset(path.clone(), content.clone());
         }
 
+        // RFC 0018 §5: harvest CLI command metadata into the overlay so the
+        // runtime `-h`/`list` path is zero-latency. Best-effort — a skip just
+        // leaves `cli_commands` empty (see `collect_cli_metadata`).
+        if let PackMode::FullStack { ref python, .. } = &overlay_config.mode {
+            self.embed_cli_metadata(&mut overlay, python)?;
+        }
+
         // Apply Windows resources
         #[cfg(target_os = "windows")]
         self.apply_resources(ctx, &output_path)?;
@@ -428,6 +435,33 @@ impl WinBuilder {
 
         tracing::info!("Python runtime added to overlay");
         Ok(())
+    }
+
+    /// Collect CLI command metadata and embed it into the overlay config
+    /// (RFC 0018 §5). Best-effort: a skip leaves `cli_commands` empty and only
+    /// logs a warning; a §12.4 alias conflict in a successful dump is fatal.
+    fn embed_cli_metadata(
+        &self,
+        overlay: &mut OverlayData,
+        python: &PythonBundleConfig,
+    ) -> BuildResult<()> {
+        match crate::collect_cli_metadata(overlay, python) {
+            Ok(crate::CliDumpOutcome::Collected(commands)) => {
+                tracing::info!("Embedded {} CLI command(s) into overlay", commands.len());
+                overlay.config.cli_commands = commands;
+                Ok(())
+            }
+            Ok(crate::CliDumpOutcome::Skipped(reason)) => {
+                tracing::warn!(
+                    "Skipped CLI metadata collection ({reason}); \
+                     `-h`/`list` will list no commands until repacked"
+                );
+                Ok(())
+            }
+            Err(conflict) => Err(PackError::Config(format!(
+                "CLI command alias conflict: {conflict}"
+            ))),
+        }
     }
 
     /// Add Python source files from include_paths to overlay

--- a/crates/auroraview-pack/src/builder/win.rs
+++ b/crates/auroraview-pack/src/builder/win.rs
@@ -166,6 +166,26 @@ impl Builder for WinBuilder {
         // Write overlay
         OverlayWriter::write(&output_path, &overlay)?;
 
+        // RFC 0018 §3: the packed exe is GUI-subsystem so a double-click never
+        // flashes a console. The downside is that cmd.exe / PowerShell do NOT
+        // wait for a GUI-subsystem process, so `app.exe run ...` returns to the
+        // prompt before the command's output lands. When the pack exposes CLI
+        // commands (and isn't already console-subsystem), drop a `<name>.cmd`
+        // shim beside the exe that runs it via `start /wait` so terminals block
+        // and the exit code propagates. Best-effort: a write failure only logs.
+        let console = ctx
+            .config
+            .platform
+            .windows
+            .as_ref()
+            .map(|w| w.console)
+            .unwrap_or(false);
+        if !console && !overlay.config.cli_commands.is_empty() {
+            if let Err(e) = self.write_cli_shim(&output_path, &exe_name) {
+                tracing::warn!("Failed to write CLI .cmd shim: {}", e);
+            }
+        }
+
         let size = fs::metadata(&output_path)?.len();
         tracing::info!(
             "Build complete: {} ({:.2} MB)",
@@ -434,6 +454,36 @@ impl WinBuilder {
         overlay.add_asset("python_runtime.tar.gz", archive_bytes);
 
         tracing::info!("Python runtime added to overlay");
+        Ok(())
+    }
+
+    /// Write a `<name>.cmd` shim beside the packed exe (RFC 0018 §3).
+    ///
+    /// A GUI-subsystem exe doesn't make the shell wait, so terminal users get
+    /// the prompt back before output appears. The shim forces synchronous
+    /// execution and forwards every argument and the exit code:
+    ///
+    /// ```bat
+    /// @echo off
+    /// start "" /wait /b "%~dp0app.exe" %*
+    /// exit /b %ERRORLEVEL%
+    /// ```
+    ///
+    /// `%~dp0` is the shim's own directory (trailing slash included), so the
+    /// shim resolves the exe relative to itself regardless of the caller's CWD.
+    fn write_cli_shim(&self, exe_path: &Path, exe_name: &str) -> BuildResult<()> {
+        let stem = exe_name.strip_suffix(".exe").unwrap_or(exe_name);
+        let shim_path = exe_path.with_file_name(format!("{stem}.cmd"));
+
+        // CRLF line endings: this is a Windows batch file.
+        let contents = format!(
+            "@echo off\r\n\
+             start \"\" /wait /b \"%~dp0{exe_name}\" %*\r\n\
+             exit /b %ERRORLEVEL%\r\n"
+        );
+
+        fs::write(&shim_path, contents)?;
+        tracing::info!("Wrote CLI shim: {}", shim_path.display());
         Ok(())
     }
 
@@ -735,5 +785,40 @@ impl WinBuilder {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn shim_runs_exe_via_start_wait_and_forwards_exit_code() {
+        let dir = tempdir().unwrap();
+        let exe_path = dir.path().join("packed-cli-demo.exe");
+        WinBuilder::new()
+            .write_cli_shim(&exe_path, "packed-cli-demo.exe")
+            .unwrap();
+
+        let shim = dir.path().join("packed-cli-demo.cmd");
+        assert!(shim.exists(), "shim should be written beside the exe");
+
+        let body = fs::read_to_string(&shim).unwrap();
+        // Synchronous launch so the terminal waits for the GUI-subsystem exe.
+        assert!(body.contains("start \"\" /wait /b \"%~dp0packed-cli-demo.exe\" %*"));
+        // Exit code propagation and CRLF line endings (it's a .bat-style file).
+        assert!(body.contains("exit /b %ERRORLEVEL%"));
+        assert!(body.contains("\r\n"));
+    }
+
+    #[test]
+    fn shim_path_drops_exe_suffix() {
+        let dir = tempdir().unwrap();
+        let exe_path = dir.path().join("myapp.exe");
+        WinBuilder::new()
+            .write_cli_shim(&exe_path, "myapp.exe")
+            .unwrap();
+        assert!(dir.path().join("myapp.cmd").exists());
     }
 }

--- a/crates/auroraview-pack/src/cli_dump.rs
+++ b/crates/auroraview-pack/src/cli_dump.rs
@@ -279,6 +279,7 @@ fn check_alias_conflicts(commands: &[CliCommandMeta]) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PackConfig;
 
     fn cmd(name: &str, aliases: &[&str]) -> CliCommandMeta {
         CliCommandMeta {
@@ -339,5 +340,154 @@ mod tests {
     fn build_code_script_path() {
         let code = build_dump_code(Path::new("/tmp/x"), "main.py");
         assert!(code.contains("runpy.run_path"));
+    }
+
+    #[test]
+    fn build_code_empty_function_defaults_to_main() {
+        // An entry point ending in ':' (no function) falls back to main().
+        let code = build_dump_code(Path::new("/tmp/x"), "app.entry:");
+        assert!(code.contains("from app.entry import main"));
+        assert!(code.contains("main()"));
+    }
+
+    #[test]
+    fn build_code_strips_py_suffix_from_module() {
+        let code = build_dump_code(Path::new("/tmp/x"), "pkg/app.py:run");
+        // Path separators become dots and the .py suffix is trimmed.
+        assert!(code.contains("from pkg.app import run"));
+    }
+
+    #[test]
+    fn normalize_backfills_empty_param_type() {
+        let commands = vec![CliCommandMeta {
+            name: "export".to_string(),
+            aliases: vec![],
+            help: String::new(),
+            params: vec![
+                CliParamMeta {
+                    name: "path".to_string(),
+                    r#type: String::new(),
+                    required: true,
+                    default: serde_json::Value::Null,
+                    help: String::new(),
+                },
+                CliParamMeta {
+                    name: "dpi".to_string(),
+                    r#type: "int".to_string(),
+                    required: false,
+                    default: serde_json::Value::Null,
+                    help: String::new(),
+                },
+            ],
+        }];
+        let out = normalize(commands);
+        assert_eq!(out[0].params[0].r#type, "any");
+        // A populated type is left untouched.
+        assert_eq!(out[0].params[1].r#type, "int");
+    }
+
+    #[test]
+    fn parse_picks_last_matching_payload() {
+        // Two payloads on separate lines; the scanner walks from the end, so
+        // the last valid cli_metadata line wins.
+        let stdout = b"{\"type\":\"cli_metadata\",\"commands\":[{\"name\":\"old\",\"aliases\":[],\"help\":\"\",\"params\":[]}]}\n{\"type\":\"cli_metadata\",\"commands\":[{\"name\":\"new\",\"aliases\":[],\"help\":\"\",\"params\":[]}]}\n";
+        let commands = parse_dump_stdout(stdout).expect("parse");
+        assert_eq!(commands[0].name, "new");
+    }
+
+    #[test]
+    fn parse_skips_non_payload_json_lines() {
+        // A JSON line with the wrong `type` is ignored; parsing falls through
+        // to the error path.
+        let stdout = b"{\"type\":\"something_else\",\"commands\":[]}\n";
+        assert!(parse_dump_stdout(stdout).is_err());
+    }
+
+    #[test]
+    fn collect_skips_non_fullstack() {
+        // URL/Frontend apps have no Python commands to dump.
+        let overlay = OverlayData::new(PackConfig::url("about:blank"));
+        let python = PythonBundleConfig::new("main:run");
+        match collect_cli_metadata(&overlay, &python) {
+            Ok(CliDumpOutcome::Skipped(reason)) => assert!(reason.contains("FullStack")),
+            _ => panic!("expected Skipped for a non-FullStack app"),
+        }
+    }
+
+    #[test]
+    fn collect_skips_non_standalone_strategy() {
+        // Only Standalone bundles an interpreter that can run at pack time.
+        let overlay = OverlayData::new(PackConfig::fullstack("./dist", "main:run"));
+        let mut python = PythonBundleConfig::new("main:run");
+        python.strategy = BundleStrategy::System;
+        match collect_cli_metadata(&overlay, &python) {
+            Ok(CliDumpOutcome::Skipped(reason)) => assert!(reason.contains("System")),
+            _ => panic!("expected Skipped for a non-Standalone strategy"),
+        }
+    }
+
+    #[test]
+    fn runtime_target_reads_target_field() {
+        let mut overlay = OverlayData::new(PackConfig::fullstack("./dist", "main:run"));
+        overlay.add_asset(
+            "python_runtime.json",
+            br#"{"target":"x86_64-pc-windows-msvc"}"#.to_vec(),
+        );
+        assert_eq!(
+            runtime_target(&overlay).as_deref(),
+            Some("x86_64-pc-windows-msvc")
+        );
+    }
+
+    #[test]
+    fn runtime_target_none_when_absent() {
+        let overlay = OverlayData::new(PackConfig::fullstack("./dist", "main:run"));
+        assert!(runtime_target(&overlay).is_none());
+    }
+
+    #[test]
+    fn collect_skips_cross_platform_pack() {
+        // A Standalone FullStack app whose embedded runtime targets a different
+        // triple than the host cannot be executed here -> Skipped.
+        let mut overlay = OverlayData::new(PackConfig::fullstack("./dist", "main:run"));
+        overlay.add_asset(
+            "python_runtime.json",
+            br#"{"target":"definitely-not-a-real-host-triple"}"#.to_vec(),
+        );
+        let mut python = PythonBundleConfig::new("main:run");
+        python.strategy = BundleStrategy::Standalone;
+        match collect_cli_metadata(&overlay, &python) {
+            Ok(CliDumpOutcome::Skipped(reason)) => assert!(reason.contains("cross-platform")),
+            _ => panic!("expected cross-platform Skipped"),
+        }
+    }
+
+    #[test]
+    fn extract_python_sources_writes_only_python_prefixed_assets() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let mut overlay = OverlayData::new(PackConfig::fullstack("./dist", "main:run"));
+        overlay.add_asset("python/pkg/mod.py", b"x = 1\n".to_vec());
+        overlay.add_asset("python/main.py", b"print('hi')\n".to_vec());
+        // A non-python asset must be ignored by the extractor.
+        overlay.add_asset("web/index.html", b"<html></html>".to_vec());
+
+        extract_python_sources(&overlay, root).expect("extract");
+
+        assert!(root.join("pkg/mod.py").exists());
+        assert!(root.join("main.py").exists());
+        assert!(!root.join("index.html").exists());
+        assert_eq!(
+            std::fs::read_to_string(root.join("main.py")).unwrap(),
+            "print('hi')\n"
+        );
+    }
+
+    #[test]
+    fn extract_runtime_errors_without_archive() {
+        let dir = TempDir::new().unwrap();
+        let overlay = OverlayData::new(PackConfig::fullstack("./dist", "main:run"));
+        let err = extract_runtime(&overlay, dir.path()).unwrap_err();
+        assert!(err.contains("no python_runtime.tar.gz"));
     }
 }

--- a/crates/auroraview-pack/src/cli_dump.rs
+++ b/crates/auroraview-pack/src/cli_dump.rs
@@ -1,0 +1,343 @@
+//! Pack-time CLI metadata collection (RFC 0018 §5.1 / §13.3).
+//!
+//! To make the runtime `-h`/`list` path zero-latency, the command table is
+//! harvested **at pack time** and embedded into the overlay. This module runs
+//! the already-bundled entry point once with `AURORAVIEW_CLI_DUMP=1` inside the
+//! target Python environment, captures the `{"type":"cli_metadata", ...}` JSON
+//! it prints, and converts it into [`CliCommandMeta`] for
+//! [`PackConfig::cli_commands`].
+//!
+//! The whole thing is **best-effort**: when the dump cannot run (cross-platform
+//! packing, missing runtime, a failing entry point) the caller logs a warning
+//! and proceeds with an empty command table. Only the §12.4 alias conflict
+//! check is fatal — a successful dump that contains conflicting aliases means
+//! the developer made a mistake worth surfacing.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+use tempfile::TempDir;
+
+use crate::config::{CliCommandMeta, CliParamMeta};
+use crate::overlay::OverlayData;
+use crate::python_standalone::PythonTarget;
+use crate::{BundleStrategy, PackMode, PythonBundleConfig};
+
+/// Reserved CLI verbs/flags an alias must never collide with (RFC 0018 §12.4).
+/// Mirrors the Python-side `_RESERVED_CLI_VERBS`.
+const RESERVED_CLI_VERBS: &[&str] = &["run", "list", "help", "version"];
+
+/// Raw JSON shape emitted by the Python `dump_cli_metadata` entry point.
+#[derive(Debug, Deserialize)]
+struct CliDumpPayload {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    commands: Vec<CliCommandMeta>,
+}
+
+/// Outcome of a pack-time dump attempt.
+pub enum CliDumpOutcome {
+    /// The dump ran and produced a (possibly empty) command table.
+    Collected(Vec<CliCommandMeta>),
+    /// The dump was skipped; the string explains why (for a warning log).
+    Skipped(String),
+}
+
+/// Collect CLI command metadata for a built overlay (best-effort).
+///
+/// Returns [`CliDumpOutcome::Skipped`] (never an error) for any non-fatal
+/// reason the dump can't run — not FullStack, not Standalone, cross-platform,
+/// no runtime archive, subprocess failure. Returns `Err` only for a fatal
+/// alias conflict (§12.4) in an otherwise successful dump.
+pub fn collect_cli_metadata(
+    overlay: &OverlayData,
+    python: &PythonBundleConfig,
+) -> Result<CliDumpOutcome, String> {
+    // Only FullStack apps have Python commands to dump.
+    if !matches!(overlay.config.mode, PackMode::FullStack { .. }) {
+        return Ok(CliDumpOutcome::Skipped("not a FullStack app".into()));
+    }
+
+    // The dump executes the bundled interpreter, which only exists for the
+    // Standalone strategy (others rely on a system Python at runtime).
+    if python.strategy != BundleStrategy::Standalone {
+        return Ok(CliDumpOutcome::Skipped(format!(
+            "bundle strategy {:?} has no embedded interpreter to run at pack time",
+            python.strategy
+        )));
+    }
+
+    // Cross-platform packing cannot execute the target interpreter on the host.
+    let host = match PythonTarget::current() {
+        Ok(t) => t,
+        Err(e) => return Ok(CliDumpOutcome::Skipped(format!("unknown host target: {e}"))),
+    };
+    if let Some(meta) = runtime_target(overlay) {
+        if meta != host.triple() {
+            return Ok(CliDumpOutcome::Skipped(format!(
+                "cross-platform pack (runtime target {meta} != host {})",
+                host.triple()
+            )));
+        }
+    }
+
+    match run_dump(overlay, python, host) {
+        Ok(commands) => {
+            check_alias_conflicts(&commands)?;
+            Ok(CliDumpOutcome::Collected(commands))
+        }
+        Err(reason) => Ok(CliDumpOutcome::Skipped(reason)),
+    }
+}
+
+/// Read the bundled runtime's target triple from `python_runtime.json`.
+fn runtime_target(overlay: &OverlayData) -> Option<String> {
+    let raw = overlay
+        .assets
+        .iter()
+        .find(|(p, _)| p == "python_runtime.json")
+        .map(|(_, c)| c.clone())?;
+    let meta: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    meta.get("target")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Extract the bundled runtime + sources to a temp dir and run the entry point
+/// with `AURORAVIEW_CLI_DUMP=1`, returning the parsed command table.
+fn run_dump(
+    overlay: &OverlayData,
+    python: &PythonBundleConfig,
+    host: PythonTarget,
+) -> Result<Vec<CliCommandMeta>, String> {
+    let temp = TempDir::new().map_err(|e| format!("temp dir: {e}"))?;
+    let root = temp.path();
+
+    extract_runtime(overlay, root)?;
+    extract_python_sources(overlay, root)?;
+
+    let python_exe = root.join(host.python_path());
+    if !python_exe.exists() {
+        return Err(format!(
+            "bundled interpreter missing at {}",
+            python_exe.display()
+        ));
+    }
+
+    let code = build_dump_code(root, &python.entry_point);
+
+    let output = Command::new(&python_exe)
+        .args(["-c", &code])
+        .current_dir(root)
+        .env("AURORAVIEW_CLI_DUMP", "1")
+        .env("PYTHONUNBUFFERED", "1")
+        .env("PYTHONIOENCODING", "utf-8")
+        .output()
+        .map_err(|e| format!("failed to launch interpreter: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "dump process exited with {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+
+    parse_dump_stdout(&output.stdout)
+}
+
+/// Parse the `{"type":"cli_metadata", "commands":[...]}` line from stdout.
+///
+/// Tolerates leading log noise by scanning for the last non-empty line that
+/// parses as the expected payload.
+fn parse_dump_stdout(stdout: &[u8]) -> Result<Vec<CliCommandMeta>, String> {
+    let text = String::from_utf8_lossy(stdout);
+    for line in text.lines().rev() {
+        let line = line.trim();
+        if line.is_empty() || !line.starts_with('{') {
+            continue;
+        }
+        if let Ok(payload) = serde_json::from_str::<CliDumpPayload>(line) {
+            if payload.kind == "cli_metadata" {
+                return Ok(normalize(payload.commands));
+            }
+        }
+    }
+    Err("no cli_metadata JSON found in dump output".into())
+}
+
+/// Backfill defaults the Python side may omit (e.g. an absent param `type`).
+fn normalize(commands: Vec<CliCommandMeta>) -> Vec<CliCommandMeta> {
+    commands
+        .into_iter()
+        .map(|mut c| {
+            c.params = c
+                .params
+                .into_iter()
+                .map(|mut p| {
+                    if p.r#type.is_empty() {
+                        p.r#type = "any".to_string();
+                    }
+                    p
+                })
+                .collect::<Vec<CliParamMeta>>();
+            c
+        })
+        .collect()
+}
+
+/// Build the `python -c` snippet that imports/runs the entry point. Mirrors the
+/// runtime launcher in `auroraview-cli` so dump and run see the same module.
+fn build_dump_code(root: &Path, entry_point: &str) -> String {
+    let root_str = root.display();
+    if let Some((module, function)) = entry_point.split_once(':') {
+        let module = module.replace(['/', '\\'], ".");
+        let module = module.trim_end_matches(".py");
+        let function = if function.is_empty() { "main" } else { function };
+        format!(
+            "import sys; sys.path.insert(0, r'{root_str}'); from {module} import {function}; {function}()"
+        )
+    } else {
+        let script = root.join(entry_point);
+        format!(
+            "import sys; sys.path.insert(0, r'{root_str}'); import runpy; runpy.run_path(r'{}', run_name='__main__')",
+            script.display()
+        )
+    }
+}
+
+/// Unpack `python_runtime.tar.gz` into `root`.
+fn extract_runtime(overlay: &OverlayData, root: &Path) -> Result<(), String> {
+    let archive = overlay
+        .assets
+        .iter()
+        .find(|(p, _)| p == "python_runtime.tar.gz")
+        .map(|(_, c)| c.clone())
+        .ok_or_else(|| "no python_runtime.tar.gz in overlay".to_string())?;
+
+    let decoder = flate2::read::GzDecoder::new(&archive[..]);
+    let mut tar = tar::Archive::new(decoder);
+    tar.unpack(root)
+        .map_err(|e| format!("failed to unpack runtime: {e}"))
+}
+
+/// Write every `python/<rel>` overlay asset to `root/<rel>`.
+fn extract_python_sources(overlay: &OverlayData, root: &Path) -> Result<(), String> {
+    for (path, content) in &overlay.assets {
+        let Some(rel) = path.strip_prefix("python/") else {
+            continue;
+        };
+        let dest = root.join(rel);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+        }
+        std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
+    }
+    Ok(())
+}
+
+/// Fail-fast alias conflict detection over a collected command table (§12.4).
+///
+/// An alias must not collide with a reserved verb, any canonical command name,
+/// or any other command's alias. The Python registration path already guards
+/// per-registry; this catches conflicts that only surface once both registries
+/// are merged at pack time.
+fn check_alias_conflicts(commands: &[CliCommandMeta]) -> Result<(), String> {
+    let names: HashSet<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+    let mut claimed: HashSet<String> = HashSet::new();
+
+    for cmd in commands {
+        for alias in &cmd.aliases {
+            if RESERVED_CLI_VERBS.contains(&alias.as_str()) {
+                return Err(format!(
+                    "alias '{alias}' for command '{}' collides with a reserved CLI verb",
+                    cmd.name
+                ));
+            }
+            if names.contains(alias.as_str()) && alias != &cmd.name {
+                return Err(format!(
+                    "alias '{alias}' for command '{}' collides with command name '{alias}'",
+                    cmd.name
+                ));
+            }
+            if !claimed.insert(alias.clone()) {
+                return Err(format!(
+                    "alias '{alias}' for command '{}' is already used by another command",
+                    cmd.name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cmd(name: &str, aliases: &[&str]) -> CliCommandMeta {
+        CliCommandMeta {
+            name: name.to_string(),
+            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            help: String::new(),
+            params: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn parse_extracts_commands_ignoring_log_noise() {
+        let stdout = b"[info] starting\n{\"type\":\"cli_metadata\",\"commands\":[{\"name\":\"export\",\"aliases\":[\"exp\"],\"help\":\"\",\"params\":[]}]}\n";
+        let commands = parse_dump_stdout(stdout).expect("parse");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "export");
+        assert_eq!(commands[0].aliases, vec!["exp"]);
+    }
+
+    #[test]
+    fn parse_errors_without_payload() {
+        assert!(parse_dump_stdout(b"just logs\n").is_err());
+    }
+
+    #[test]
+    fn conflict_detects_reserved_verb() {
+        let err = check_alias_conflicts(&[cmd("export", &["list"])]).unwrap_err();
+        assert!(err.contains("reserved"));
+    }
+
+    #[test]
+    fn conflict_detects_alias_vs_name() {
+        let err =
+            check_alias_conflicts(&[cmd("export", &["sync"]), cmd("sync", &[])]).unwrap_err();
+        assert!(err.contains("command name"));
+    }
+
+    #[test]
+    fn conflict_detects_duplicate_alias() {
+        let err =
+            check_alias_conflicts(&[cmd("export", &["e"]), cmd("edit", &["e"])]).unwrap_err();
+        assert!(err.contains("already used"));
+    }
+
+    #[test]
+    fn conflict_allows_clean_table() {
+        assert!(check_alias_conflicts(&[cmd("export", &["exp"]), cmd("sync", &["sy"])]).is_ok());
+    }
+
+    #[test]
+    fn build_code_module_function() {
+        let code = build_dump_code(Path::new("/tmp/x"), "app.main:run");
+        assert!(code.contains("from app.main import run"));
+        assert!(code.contains("run()"));
+    }
+
+    #[test]
+    fn build_code_script_path() {
+        let code = build_dump_code(Path::new("/tmp/x"), "main.py");
+        assert!(code.contains("runpy.run_path"));
+    }
+}

--- a/crates/auroraview-pack/src/cli_dump.rs
+++ b/crates/auroraview-pack/src/cli_dump.rs
@@ -197,7 +197,11 @@ fn build_dump_code(root: &Path, entry_point: &str) -> String {
     if let Some((module, function)) = entry_point.split_once(':') {
         let module = module.replace(['/', '\\'], ".");
         let module = module.trim_end_matches(".py");
-        let function = if function.is_empty() { "main" } else { function };
+        let function = if function.is_empty() {
+            "main"
+        } else {
+            function
+        };
         format!(
             "import sys; sys.path.insert(0, r'{root_str}'); from {module} import {function}; {function}()"
         )
@@ -312,15 +316,13 @@ mod tests {
 
     #[test]
     fn conflict_detects_alias_vs_name() {
-        let err =
-            check_alias_conflicts(&[cmd("export", &["sync"]), cmd("sync", &[])]).unwrap_err();
+        let err = check_alias_conflicts(&[cmd("export", &["sync"]), cmd("sync", &[])]).unwrap_err();
         assert!(err.contains("command name"));
     }
 
     #[test]
     fn conflict_detects_duplicate_alias() {
-        let err =
-            check_alias_conflicts(&[cmd("export", &["e"]), cmd("edit", &["e"])]).unwrap_err();
+        let err = check_alias_conflicts(&[cmd("export", &["e"]), cmd("edit", &["e"])]).unwrap_err();
         assert!(err.contains("already used"));
     }
 

--- a/crates/auroraview-pack/src/config.rs
+++ b/crates/auroraview-pack/src/config.rs
@@ -294,6 +294,60 @@ pub struct ExtensionRemoteSource {
     pub strip_components: usize,
 }
 
+/// CLI parameter metadata embedded in the overlay (RFC 0018 §13.2).
+///
+/// Mirrors the per-parameter dict produced by the Python
+/// `CliCommandMeta.params()` introspection so the runtime `-h`/`list` path can
+/// render argument help without starting Python.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CliParamMeta {
+    /// Parameter name (as declared in the Python signature).
+    pub name: String,
+
+    /// Annotation name (`str`/`int`/...), or `"any"` when unannotated.
+    #[serde(default = "default_param_type")]
+    pub r#type: String,
+
+    /// Whether the parameter is required (no default value).
+    #[serde(default)]
+    pub required: bool,
+
+    /// Default value when the parameter is optional (`null` when required).
+    #[serde(default)]
+    pub default: serde_json::Value,
+
+    /// Per-parameter help text (from `args_help`), empty when absent.
+    #[serde(default)]
+    pub help: String,
+}
+
+fn default_param_type() -> String {
+    "any".to_string()
+}
+
+/// CLI command metadata embedded in the overlay (RFC 0018 §13.2).
+///
+/// Collected at pack time by running the bundled entry point with
+/// `AURORAVIEW_CLI_DUMP=1` and serialized into [`PackConfig::cli_commands`].
+/// The runtime `-h`/`list` path reads this verbatim — no Python launch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CliCommandMeta {
+    /// Canonical command name.
+    pub name: String,
+
+    /// CLI aliases (`cli="x"` / `cli=["x","y"]`); empty for `cli=True`.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+
+    /// Help text; the Python side falls back to the docstring first line.
+    #[serde(default)]
+    pub help: String,
+
+    /// Ordered parameter metadata.
+    #[serde(default)]
+    pub params: Vec<CliParamMeta>,
+}
+
 /// Complete pack configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PackConfig {
@@ -401,6 +455,16 @@ pub struct PackConfig {
     /// trade-off.
     #[serde(default)]
     pub capture_file_drop: bool,
+
+    /// CLI command metadata collected at pack time (RFC 0018 §13.3).
+    ///
+    /// Populated by running the bundled entry point with
+    /// `AURORAVIEW_CLI_DUMP=1` during packing. The runtime `-h`/`list` path
+    /// renders directly from this, so no Python is started. Empty when the app
+    /// exposes no CLI commands or when the pack-time dump could not run (e.g.
+    /// cross-platform packing).
+    #[serde(default)]
+    pub cli_commands: Vec<CliCommandMeta>,
 }
 
 /// Default compression level (19 = high compression, good for releases)
@@ -472,6 +536,7 @@ impl PackConfig {
             extensions: ExtensionsRuntimeConfig::default(),
             content_security_policy: None,
             capture_file_drop: false,
+            cli_commands: Vec::new(),
         }
     }
 
@@ -787,6 +852,8 @@ impl PackConfig {
                 .as_ref()
                 .and_then(|s| s.capture_file_drop)
                 .unwrap_or(false),
+            // RFC 0018: populated later in the pack flow by the pack-time dump.
+            cli_commands: Vec::new(),
         };
 
         Ok(config)

--- a/crates/auroraview-pack/src/lib.rs
+++ b/crates/auroraview-pack/src/lib.rs
@@ -85,6 +85,7 @@
 //! ```
 
 mod bundle;
+mod cli_dump;
 pub mod common;
 mod config;
 mod deps_collector;
@@ -117,7 +118,10 @@ pub use common::{
 };
 
 // Re-export config types (runtime configuration)
-pub use config::{PackConfig, PackMode, PythonBundleConfig};
+pub use config::{CliCommandMeta, CliParamMeta, PackConfig, PackMode, PythonBundleConfig};
+
+// RFC 0018: pack-time CLI metadata collection
+pub use cli_dump::{collect_cli_metadata, CliDumpOutcome};
 
 pub use deps_collector::{CollectedDeps, DepsCollector, FileHashCache};
 pub use downloader::Downloader;

--- a/crates/auroraview-pack/tests/overlay_tests.rs
+++ b/crates/auroraview-pack/tests/overlay_tests.rs
@@ -69,8 +69,8 @@ fn cli_param_meta_type_defaults_to_any() {
 fn cli_param_meta_type_preserved_when_present() {
     use auroraview_pack::CliParamMeta;
 
-    let param: CliParamMeta = serde_json::from_str(r#"{"name": "dpi", "type": "int"}"#)
-        .expect("deserialize param");
+    let param: CliParamMeta =
+        serde_json::from_str(r#"{"name": "dpi", "type": "int"}"#).expect("deserialize param");
     assert_eq!(param.r#type, "int");
 }
 

--- a/crates/auroraview-pack/tests/overlay_tests.rs
+++ b/crates/auroraview-pack/tests/overlay_tests.rs
@@ -52,6 +52,29 @@ fn overlay_cli_commands_default_empty() {
 }
 
 #[test]
+fn cli_param_meta_type_defaults_to_any() {
+    // A param JSON that omits `type` must deserialize to "any" via the
+    // `default_param_type` serde default (RFC 0018 §13.2).
+    use auroraview_pack::CliParamMeta;
+
+    let param: CliParamMeta =
+        serde_json::from_str(r#"{"name": "path"}"#).expect("deserialize param");
+    assert_eq!(param.name, "path");
+    assert_eq!(param.r#type, "any");
+    assert!(!param.required);
+    assert!(param.help.is_empty());
+}
+
+#[test]
+fn cli_param_meta_type_preserved_when_present() {
+    use auroraview_pack::CliParamMeta;
+
+    let param: CliParamMeta = serde_json::from_str(r#"{"name": "dpi", "type": "int"}"#)
+        .expect("deserialize param");
+    assert_eq!(param.r#type, "int");
+}
+
+#[test]
 fn overlay_roundtrip() {
     let temp = NamedTempFile::new().unwrap();
     std::fs::write(temp.path(), b"fake executable content").unwrap();

--- a/crates/auroraview-pack/tests/overlay_tests.rs
+++ b/crates/auroraview-pack/tests/overlay_tests.rs
@@ -4,6 +4,54 @@ use auroraview_pack::{OverlayData, OverlayReader, OverlayWriter, PackConfig};
 use tempfile::NamedTempFile;
 
 #[test]
+fn overlay_cli_commands_roundtrip() {
+    use auroraview_pack::{CliCommandMeta, CliParamMeta};
+
+    let temp = NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), b"bin").unwrap();
+
+    let mut config = PackConfig::url("https://example.com");
+    config.cli_commands = vec![CliCommandMeta {
+        name: "export".to_string(),
+        aliases: vec!["exp".to_string()],
+        help: "Export the project".to_string(),
+        params: vec![CliParamMeta {
+            name: "path".to_string(),
+            r#type: "str".to_string(),
+            required: true,
+            default: serde_json::Value::Null,
+            help: "Output directory".to_string(),
+        }],
+    }];
+    let data = OverlayData::new(config);
+
+    OverlayWriter::write(temp.path(), &data).unwrap();
+
+    let read = OverlayReader::read(temp.path()).unwrap().unwrap();
+    assert_eq!(read.config.cli_commands.len(), 1);
+    let cmd = &read.config.cli_commands[0];
+    assert_eq!(cmd.name, "export");
+    assert_eq!(cmd.aliases, vec!["exp".to_string()]);
+    assert_eq!(cmd.params.len(), 1);
+    assert_eq!(cmd.params[0].name, "path");
+    assert!(cmd.params[0].required);
+}
+
+#[test]
+fn overlay_cli_commands_default_empty() {
+    // An older overlay JSON without the `cli_commands` field must still
+    // deserialize (serde default) to an empty vec.
+    let temp = NamedTempFile::new().unwrap();
+    std::fs::write(temp.path(), b"bin").unwrap();
+
+    let data = OverlayData::new(PackConfig::url("https://example.com"));
+    OverlayWriter::write(temp.path(), &data).unwrap();
+
+    let read = OverlayReader::read(temp.path()).unwrap().unwrap();
+    assert!(read.config.cli_commands.is_empty());
+}
+
+#[test]
 fn overlay_roundtrip() {
     let temp = NamedTempFile::new().unwrap();
     std::fs::write(temp.path(), b"fake executable content").unwrap();

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -96,6 +96,40 @@ auroraview-cli pack --frontend ./dist --output myapp
 auroraview-cli pack --config auroraview.pack.toml
 ```
 
+## Packed App CLI (Headless Mode)
+
+Beyond the two CLIs above, a **packed application** is itself a third command-line
+interface. A packed exe is a GUI app by default — double-clicking it opens the
+window — but it can *also* run your registered Python commands from a terminal
+without opening a window:
+
+```bash
+my-app.exe                          # GUI window (unchanged)
+my-app.exe -h                       # list CLI-enabled commands
+my-app.exe list                     # list commands (--json for machine output)
+my-app.exe run export --path ./out  # run one command, print result, exit
+my-app.exe -V                       # print version
+```
+
+Only an explicit reserved verb (`run`, `list`) or flag (`-h`/`--help`,
+`-V`/`--version`) as the **first** argument triggers the CLI path — a bare file
+path (file association, drag-and-drop) always opens the GUI.
+
+Exposure is opt-in per command via `@webview.command(cli=...)`:
+
+```python
+@webview.command(name="export", help="Export the project", cli=True)
+def export(path: str, dpi: int = 300) -> dict:
+    return {"written": path, "dpi": dpi}
+```
+
+Exit codes follow `0` success, `1` the command raised, `2` not found / bad args.
+On Windows, invoke the generated `my-app.cmd` shim in a terminal so output and
+exit codes propagate correctly. See the
+[Packing guide](/guide/packing#headless-cli-mode) for the full reference
+(aliases, argument passing, the `.cmd` shim, and how the command list is
+collected at pack time).
+
 ## Examples
 
 ### Quick Web Preview (Python)

--- a/docs/guide/packing.md
+++ b/docs/guide/packing.md
@@ -535,6 +535,90 @@ exclude = [
 ]
 ```
 
+## Headless CLI Mode
+
+A packed executable is a GUI app by default — double-clicking it (or launching
+with no arguments) opens the window exactly as before. It can *also* run your
+registered Python commands from a terminal, without opening a window.
+
+```bash
+my-app.exe                          # GUI window (unchanged)
+my-app.exe -h                       # list CLI-enabled commands
+my-app.exe list                     # list commands (add --json for machine output)
+my-app.exe run export --path ./out  # run one command, print result, exit
+my-app.exe -V                       # print version
+```
+
+Only an explicit reserved verb (`run`, `list`) or flag (`-h`/`--help`,
+`-V`/`--version`) as the **first** argument triggers the CLI path. A bare file
+path (file association, drag-and-drop) always opens the GUI, so nothing existing
+breaks.
+
+### Exposing commands to the CLI
+
+CLI exposure is **opt-in** — commands are GUI-only unless you say otherwise. Set
+`cli` on `@webview.command`:
+
+```python
+@webview.command(name="export", help="Export the project", cli=True)
+def export(path: str, dpi: int = 300) -> dict:
+    return {"written": path, "dpi": dpi}
+
+# Add a short alias:
+@webview.command(name="export-document-image", cli="exi")
+def export_document_image(path: str) -> dict: ...
+
+# Multiple aliases:
+@webview.command(name="validate", cli=["val", "v"])
+def validate() -> dict: ...
+```
+
+The `cli` value doubles as the on/off switch and the alias list:
+
+| `cli` value          | Meaning                          |
+|----------------------|----------------------------------|
+| `False` (default)    | GUI only, not exposed to the CLI |
+| `True`               | exposed, no alias                |
+| `"exi"`              | exposed, alias `exi`             |
+| `["exi", "edi"]`     | exposed, multiple aliases        |
+
+Use `help=` and `args_help={...}` to enrich the `-h` output; both fall back to
+the function docstring / signature when omitted. To bulk-enable existing
+commands, call `webview.commands.enable_cli("export", "validate")` or pass a
+`{name: alias}` mapping.
+
+### Passing arguments
+
+Both keyword and positional forms work, and they can be mixed (positional
+first, keywords after):
+
+```bash
+my-app.exe run export --path ./out --dpi 600   # keyword
+my-app.exe run export ./out 600                 # positional (signature order)
+my-app.exe run export ./out --dpi 600           # mixed
+```
+
+Values are coerced from the parameter's type annotation (`int`, `float`, `bool`,
+`str`); anything else is parsed as JSON (`--config '{"a":1}'`). Booleans accept
+`--flag` / `--no-flag`. Exit codes follow: `0` success, `1` the command raised,
+`2` command not found or bad arguments.
+
+### How it works
+
+The command list shown by `-h`/`list` is collected **at pack time** and embedded
+in the overlay, so those commands return instantly without starting Python. The
+collection runs the bundled entry point once with `AURORAVIEW_CLI_DUMP=1`. This
+requires running the bundled interpreter on the build host, so it is skipped
+(with a warning) when cross-platform packing or when not using the `standalone`
+Python strategy — `-h`/`list` then show no commands until repacked on a matching
+host. `run` extracts the Python runtime on first use (cached afterwards) and
+invokes the command in a one-shot process — it does not reuse the GUI's
+persistent backend.
+
+On Windows the packed exe attaches to the parent console at startup so CLI
+output reaches the terminal (a double-click still shows no console). On
+macOS/Linux there is no GUI-subsystem stdio isolation, so output works directly.
+
 ## Best Practices
 
 1. **Use `site-packages` for dependencies**: All third-party packages go to `python/site-packages/`

--- a/docs/guide/packing.md
+++ b/docs/guide/packing.md
@@ -619,6 +619,41 @@ On Windows the packed exe attaches to the parent console at startup so CLI
 output reaches the terminal (a double-click still shows no console). On
 macOS/Linux there is no GUI-subsystem stdio isolation, so output works directly.
 
+### The Windows `.cmd` shim
+
+The packed exe is GUI-subsystem so a double-click never flashes a console. The
+trade-off is that `cmd.exe` and PowerShell do **not** wait for a GUI-subsystem
+process — `app.exe run export ...` would return to the prompt before the
+command's output lands, and the exit code would be lost.
+
+To fix this, when the pack exposes CLI commands and is **not** built
+console-subsystem (the default), the builder drops a `<name>.cmd` shim beside
+the exe:
+
+```bat
+@echo off
+start "" /wait /b "%~dp0app.exe" %*
+exit /b %ERRORLEVEL%
+```
+
+`start /wait` runs the exe synchronously so the terminal blocks until it
+finishes, `%*` forwards every argument, and `exit /b %ERRORLEVEL%` propagates
+the exit code. `%~dp0` resolves the exe relative to the shim's own directory, so
+it works regardless of the caller's current directory.
+
+In a terminal, invoke the shim so output and exit codes behave correctly:
+
+```bash
+app.cmd -h                       # blocks, prints help, then returns
+app.cmd run export --path ./out  # blocks until the command finishes
+app.exe                          # double-click / GUI launch still uses the exe
+```
+
+The shim is best-effort: if it can't be written (e.g. a read-only output
+directory) the build still succeeds and only logs a warning. It is not produced
+for console-subsystem builds (`[bundle.platform.windows] console = true`), where
+the exe already blocks the terminal on its own.
+
 ## Best Practices
 
 1. **Use `site-packages` for dependencies**: All third-party packages go to `python/site-packages/`

--- a/docs/rfcs/0018-packed-cli-mode.md
+++ b/docs/rfcs/0018-packed-cli-mode.md
@@ -1,0 +1,576 @@
+# RFC 0018: Packed EXE Headless CLI Mode
+
+- Number: 0018
+- Title: Headless CLI for packed apps — register commands via Python decorators and invoke them directly without opening a window
+- Status: Draft
+- Created: 2026-06-15
+- Authors: AuroraView Core Team
+- Affected code: `crates/auroraview-cli`, `crates/auroraview-pack`, `python/auroraview/core`
+
+---
+
+## 0. Purpose
+
+This RFC proposes adding a **headless CLI mode** to AuroraView packaged artifacts (the standalone exe):
+
+```bash
+my-app.exe                          # double-click / no args: open the window as today (unchanged)
+my-app.exe -h                       # print help: list every command exposed to the CLI
+my-app.exe run export --path ./out  # invoke a registered command, print the result, exit — no window
+my-app.exe list                     # list available commands (machine- or human-readable)
+```
+
+Command registration and exposure are driven by **Python decorators**, reusing the existing `@webview.command` / `bind_call` machinery and only extending the metadata:
+
+```python
+@webview.command(name="export", help="Export the current project to a given format", cli=True)
+def export(path: str, format: str = "json") -> dict:
+    ...
+```
+
+This document covers motivation, feasibility evidence, architecture, the key technical obstacle (the Windows subsystem), the implementation work breakdown, and the trade-offs, for review and confirmation.
+
+---
+
+## 1. Motivation
+
+Today the packaged artifact **can only run as a GUI app**: once `main.rs:127` detects the overlay it calls `run_packed_app()` directly, and that function never reads command-line arguments — it unconditionally creates a window and enters the event loop.
+
+This imposes several limits:
+
+1. **No scripting / automation.** CI, batch jobs, and other programs cannot drive the business logic already inside the app; they can only open the window and operate it by hand.
+2. **Duplicated logic.** Developers have already written "export", "validate", "sync" commands in Python and exposed them to the front-end, but a command-line scenario forces them to write a second standalone script.
+3. **Limited DCC integration.** Maya/Houdini batch workflows (mayabatch, hython) want to drive app commands directly rather than spin up a full GUI.
+
+Goal: **one exe, one set of decorator-registered commands** — callable both from the front-end inside the window and directly from the command line — without breaking the existing GUI double-click behavior.
+
+---
+
+## 2. Current State and Feasibility Evidence
+
+Investigation conclusion: most of the underlying machinery is already in place; there is no architectural blocker.
+
+### 2.1 The command registry already exists
+
+- The decorator `@webview.command` / `webview.commands.register(name)` adds the function to `CommandRegistry._commands` (`python/auroraview/core/commands.py:131-302`).
+- `bind_call` / `bind_api` add the function to `WebViewApiMixin._bound_functions` (`python/auroraview/core/mixins/api.py:37,180-405`).
+- At runtime the packed app's `run_api_server` reads from `_bound_functions` and sends a ready signal to Rust carrying the handler-name list (`python/auroraview/core/packed.py:218,236`).
+
+So "register and expose a command via a decorator" is **already done** by the framework — it is just exposed only to the front-end `window.auroraview.call`, never to the command line.
+
+### 2.2 Command invocation does not depend on the window
+
+- `CommandRegistry.invoke(name, **kwargs)` (`commands.py:338`) itself does not depend on a window or an event loop.
+- Only `webview.show()` enters the persistent JSON-RPC loop (`packed.py:263-300`). Headless mode just **skips `show()`** and can invoke a command, print, and exit.
+
+### 2.3 The entry_point resolver already supports function-level calls
+
+- `backend.rs:447-454` already supports the `"module:function"` form — it can import a module and call the named function; it also supports `runpy.run_path` for running a script.
+
+### 2.4 Console allocation already has precedent
+
+- In debug mode `allocate_console()` (`packed/mod.rs:140-143` plus the Windows implementation) already demonstrates operating a console from a packed GUI process — a useful starting point for the CLI output work.
+
+**Conclusion**: (a) the command registry exists; (b) it is invoked once at entry_point startup; (c) the backend is a persistent JSON-RPC server, but headless can bypass it; (d) there is no fundamental blocker to invoking a single command, printing the result, and exiting.
+
+The new work concentrates in three places: **entry-point argv routing**, **Windows console output**, and **decorator + pack-time metadata written into the overlay**.
+
+---
+
+## 3. Core Technical Obstacle: the Windows Subsystem (must be solved first)
+
+This is the make-or-break item of this RFC, not a corner-case detail.
+
+### 3.1 The problem
+
+At pack time, to eliminate the double-click black console window, `WinBuilder` rewrites the PE-header subsystem field to **GUI(2)** (`resource_editor.rs`, written directly at PE+68). On Windows a **GUI-subsystem process is not attached to the parent console's stdin/stdout/stderr by default**.
+
+Consequence: running `my-app.exe -h` in `cmd` / PowerShell returns the prompt immediately and the help text has nowhere to go — the CLI mode is effectively dead.
+
+This is the classic "dual-mode exe" GUI/CLI problem (VS Code, Node, and the py launcher all hit it).
+
+### 3.2 Candidate solutions
+
+| Option | Approach | Assessment |
+|------|------|------|
+| **A. Runtime AttachConsole (recommended)** | Early in startup call `AttachConsole(ATTACH_PARENT_PROCESS)` and redirect stdout/stderr/stdin back to the parent console; if it fails (no parent console, e.g. double-click) skip it | Single file, no black window on double-click, output on the command line. The mainstream industry solution |
+| B. Two exes | Pack out `app.exe` (GUI) + `app-cli.exe` (console) | Works but violates the single-file principle and doubles the size |
+| C. Pack with console=true | Keep subsystem = console | Double-click pops a black window — unacceptable for most desktop scenarios |
+
+**Option A is selected.** The existing `allocate_console()` uses `AllocConsole` (opens a new window, for debug); we need a new `attach_parent_console()` path:
+
+```rust
+// Windows-only, pseudocode
+fn attach_parent_console() -> bool {
+    unsafe {
+        if AttachConsole(ATTACH_PARENT_PROCESS) != 0 {
+            // redirect CRT/std handles to CONOUT$/CONIN$
+            reopen_std_streams();
+            true
+        } else {
+            false // double-click launch, no parent console; CLI output falls back to a log file
+        }
+    }
+}
+```
+
+### 3.3 Boundaries
+
+- On double-click launch (no parent console) `AttachConsole` returns 0, and the CLI path should not be triggered anyway (see the §4 trigger convention), so there is no impact.
+- When launched from `cmd` but in GUI mode (no CLI arguments), **do not attach** — keep current behavior and avoid bolting a console onto a window app for no reason.
+- Output encoding: the Windows console must handle UTF-8 (`SetConsoleOutputCP(CP_UTF8)`, or explicit wide chars), otherwise non-ASCII text is garbled.
+
+---
+
+## 4. Entry-Point argv Routing Design
+
+### 4.1 Current state
+
+`main.rs:125-129`:
+
+```rust
+fn main() -> Result<()> {
+    if is_packed() {
+        return packed::run_packed_app();   // argv ignored entirely
+    }
+    let cli = Cli::parse();
+    ...
+}
+```
+
+`run_packed_app()` never reads argv and unconditionally opens a window.
+
+### 4.2 The change
+
+Parse argv inside the packed branch and decide GUI vs CLI:
+
+```rust
+if is_packed() {
+    return match classify_packed_invocation(std::env::args()) {
+        PackedInvocation::Gui              => packed::run_packed_app(),
+        PackedInvocation::Cli(cli_args)    => packed::run_packed_cli(cli_args),
+    };
+}
+```
+
+### 4.3 Trigger convention (critical — avoid confusion with normal startup)
+
+A packed app may legitimately start with arguments (file associations, dropped file paths, protocol activation). **A bare `--flag` or a bare path must never trigger the CLI**, or double-clicking an associated file would be misread as a command.
+
+We use an **explicit subcommand verb** as the sole trigger:
+
+| Invocation | Verdict | Behavior |
+|------|------|------|
+| `app.exe` | GUI | open window |
+| `app.exe some/file.proj` | GUI | open window with the path as an open argument (current/future file association) |
+| `app.exe run <cmd> [--k v ...]` | CLI | invoke command, print, exit |
+| `app.exe list [--json]` | CLI | list commands |
+| `app.exe -h` / `--help` | CLI | print help |
+| `app.exe -V` / `--version` | CLI | print version |
+
+Rule: enter CLI **only when the first argument is a reserved verb (`run`/`list`) or a reserved flag (`-h`/`--help`/`-V`/`--version`)**; everything else is GUI. The reserved-verb set's prefix is configurable in the overlay config to lower the chance of collision with business file names.
+
+### 4.4 Exit-code convention
+
+- Success: `0`
+- Command not found: `2`
+- Argument error: `2`
+- Exception thrown inside the command: `1`, with a structured error on stderr (reusing `CommandError`'s code/message)
+
+---
+
+## 5. Source of the Command List for `-h` / `list`
+
+`-h` and `list` need to know "which commands exist, their help, aliases, and parameters".
+
+### 5.1 Static embedding (the chosen design, zero latency)
+
+**Review decision 3: `-h` must have zero startup latency.** The command list is therefore collected **at pack time** and written into the overlay config; at runtime `-h`/`list` **read the overlay only and never start Python**, returning in milliseconds.
+
+Collection method (to avoid the side effects / missing-dependency risk of `import`ing the user module directly on the packaging machine): the pack flow runs the entry_point once as a subprocess **inside the already-bundled target Python environment** with `AURORAVIEW_CLI_DUMP=1`, letting Python build `webview`/`commands` (**without calling `show()`**) and serialize the command metadata table back to the packager, which writes it into the overlay config's `cli_commands` field (see §13.2 for the structure).
+
+- This subprocess runs **once at pack time**; the runtime is never involved.
+- The target environment already has all dependencies, so `import` is safe.
+- At runtime `-h`/`list` have zero latency and zero Python startup, satisfying §10 acceptance.
+
+### 5.2 Dynamic (only for the actual `run` execution)
+
+`run <cmd>` does need to start Python anyway, and it `invoke`s in-process following the unified lookup order (see §15.2).
+
+**Conclusion**: `-h`/`list` use static embedding (5.1: collect at pack time → overlay → zero-latency read at runtime); `run` uses dynamic execution (5.2).
+
+---
+
+## 6. Python Decorator Extension
+
+### 6.1 Current state
+
+`@webview.command(name=...)` records only name + callable.
+
+### 6.2 Extension
+
+Add optional CLI metadata (backward compatible; old usage is unaffected). **`cli` carries both the "switch" and the "alias" roles** (review decision 3 — alias and CLI switch are merged):
+
+```python
+@webview.command(
+    name="export-document-image",
+    help="Export the current document as an image",   # used by -h
+    cli="exi",                                          # enable CLI + alias exi
+    args_help={                                         # per-parameter description (used by -h)
+        "path": "Output directory",
+        "dpi": "Resolution (DPI)",
+    },
+)
+def export_document_image(path: str, dpi: int = 300) -> dict:
+    """Export the current document as an image."""     # help falls back to the docstring's first line
+    return {"written": path, "dpi": dpi}
+```
+
+The semantics of the `cli` argument's value (a single argument; no separate `aliases=`):
+
+| `cli` value | Meaning |
+|-----------|------|
+| `False` (default) | Not exposed to the command line; front-end only |
+| `True` | Exposed to the command line, no alias |
+| `"exi"` (str) | Exposed to the command line, alias `exi` |
+| `["exi", "edi"]` (list[str]) | Exposed to the command line, multiple aliases |
+
+- Default `False`, **explicit opt-in**, to avoid accidentally exposing sensitive/dangerous commands to the command line (§9.3, §14).
+- `help`: help text; falls back to the docstring's first line.
+- `args_help`: per-parameter description used by `-h` (parameter name, type, and default are auto-filled from `inspect.signature`).
+
+### 6.3 Parameter mapping
+
+Support **both `--key value` and positional parameters, mixable** (review decision 5):
+
+```bash
+app.exe run export-document-image --path ./out --dpi 600   # keyword
+app.exe run exi ./out 600                                  # positional (in signature order)
+app.exe run exi ./out --dpi 600                            # mixed: positional first, keyword override
+```
+
+Mapping rules:
+
+- **Positional parameters**: filled in order following `inspect.signature`.
+- **Keyword parameters**: `--key value` overrides/supplements the matching formal parameter; specifying the same formal parameter both positionally and by keyword → argument error (exit code 2).
+- Type conversion follows the annotation: `int`/`float`/`bool`/`str`; complex types go through JSON (`--config '{"a":1}'`).
+- Defaults come from the signature's default values; no default and not provided → argument error (exit code 2).
+- Booleans: `--flag` means `True`, `--no-flag` means `False`; in positional form a boolean is parsed as `true`/`false`/`1`/`0`.
+
+---
+
+## 7. Headless Execution Flow
+
+The flow of `run_packed_cli` (the CLI path, corrected per §15 to a one-shot in-process call):
+
+```
+attach_parent_console() + reopen_std_streams()    # §3.2: attach exists, add reopen of CONOUT$/CONIN$
+SetConsoleOutputCP(CP_UTF8)
+read_overlay()                                     # reuse existing overlay read
+if -h / list:
+    read overlay.config.cli_commands -> render -> exit(0)    # zero Python startup (review decision 4)
+if run <name|alias>:
+    extract_standalone_python()                    # reuse existing extraction (latency on first run)
+    alias -> canonical-name normalization (using the alias table in overlay.cli_commands)
+    launch entry_point with AURORAVIEW_CLI_INVOKE=<name> + AURORAVIEW_CLI_PARAMS=<json>
+        -> Python builds webview/commands (without calling show())
+        -> in-process invoke following the §15.2 lookup order
+        -> result JSON to stdout / structured error to stderr
+        -> exit (per the §4.4 exit code)
+```
+
+Reuse points: overlay read, Python extraction, and entry_point process launch (`backend.rs:447`) **already exist**. Headless and the GUI's persistent JSON-RPC server are **two independent paths**; they do not share a process (§9.5).
+
+A new one-shot Python entry that does not call `show()` (§15.2) invokes following the "`CommandRegistry.invoke` → `_bound_functions` fallback" order and serializes the result to stdout.
+
+---
+
+## 8. Development Steps (to fix the implementation process)
+
+> Review has decided **not** to deliver incrementally as P1–P5. The following is an **implementation-level work breakdown**, ordered by dependency; each step notes "files changed / verification". Parallelizable items are flagged.
+
+### Step 1 — Windows console output (hard prerequisite)
+
+- Changes: `crates/auroraview-cli/src/packed/mod.rs`. Add `attach_parent_console()`, reusing the existing `AttachConsole(ATTACH_PARENT_PROCESS)` (`mod.rs:133`), **adding `reopen_std_streams()`** (freopen `CONOUT$`/`CONIN$`, or `SetStdHandle` + CRT fd rebind), and add `SetConsoleOutputCP(CP_UTF8)`. No-op on non-Windows.
+- Verify: temporarily print a line of non-ASCII + emoji early in the packed entry, run from cmd / PowerShell to confirm no garbling and no black window on double-click.
+
+### Step 2 — Entry-point argv routing (independent of Python)
+
+- Changes: `crates/auroraview-cli/src/main.rs:127`, `packed/mod.rs`. Add `classify_packed_invocation(args)` and `PackedInvocation::{Gui, Cli}`; route inside `run_packed_app`; the CLI branch calls `run_packed_cli(cli_args)`. Implement the §4.3 trigger convention (only `run`/`list`/`-h`/`--help`/`-V`/`--version` enter CLI).
+- Implement the `-V`/`--version` and `-h` skeleton first (`-h` prints a placeholder for now).
+- Verify: `app.exe`, `app.exe foo.proj` still open the window; `app.exe -V` prints the version; no GUI regression.
+
+### Step 3 — Decorator `cli` argument (switch + alias merged) + `args_help`
+
+- Changes: `python/auroraview/core/mixins/commands.py`, `python/auroraview/core/commands.py`.
+  - `command()` / `register()` gain `cli` (`False`/`True`/`str`/`list[str]`), `help`, `args_help`. Store the metadata on the handler (e.g. `func.__av_cli__`) or in a parallel dict on `CommandRegistry`.
+  - Add `CommandRegistry.enable_cli(*names | mapping)` (§14.2).
+  - Registration-time conflict detection (§12.4): alias vs canonical name / alias / reserved verb.
+- Verify: Python unit tests covering the four `cli` values, alias-conflict errors, `args_help` reading, docstring fallback.
+
+### Step 4 — Command metadata collection (unify the two registries)
+
+- Changes: `python/auroraview/core/packed.py`. Add `iter_cli_commands(webview)` (walk `CommandRegistry._commands` + `_bound_functions`, take `cli != False`, normalize aliases), `collect_cli_commands()`, and `dump_cli_metadata()` (take this path when `AURORAVIEW_CLI_DUMP=1`, serialize the §13.2 structure then exit).
+- The entry must detect `AURORAVIEW_CLI_DUMP` before `show()` and short-circuit (do not enter GUI/server).
+- Verify: locally set `AURORAVIEW_CLI_DUMP=1` and run the demo app's entry_point, confirm stdout is the expected JSON and no window opens.
+
+### Step 5 — Pack-time overlay embedding (zero runtime latency)
+
+- Changes:
+  - `crates/auroraview-pack/src/config.rs`: `PackConfig` gains `cli_commands: Vec<CliCommandMeta>` (default empty); define `CliCommandMeta`/`CliParamMeta` (serde).
+  - Pack flow (FullStack/Python branch): once the bundled Python environment is ready, run the entry_point as an `AURORAVIEW_CLI_DUMP=1` subprocess, parse the stdout JSON, do §12.4 conflict detection (pack fails on conflict), write `cli_commands`.
+- Verify: after `app pack`, dump the overlay via the `inspect` subcommand (`main.rs:115`) and confirm it contains `cli_commands`.
+
+### Step 6 — `-h` / `list` rendering (overlay read only)
+
+- Changes: `packed/mod.rs` or a new `packed/cli.rs`. In `run_packed_cli`, render `-h`/`list`/`list --json` from `overlay.config.cli_commands` (§13.4). **Do not start Python.**
+- Verify: `app.exe -h`, `app.exe list`, `app.exe list --json` output correctly, include aliases and parameters, zero latency; redirecting to a file is consistent.
+
+### Step 7 — `run` headless execution (in-process invoke)
+
+- Changes:
+  - Rust (`packed/cli.rs`): alias normalization → extract Python → launch entry_point with `AURORAVIEW_CLI_INVOKE` + `AURORAVIEW_CLI_PARAMS` → pass through stdout/stderr → map exit codes (§4.4).
+  - Python (`packed.py`): the entry detects `AURORAVIEW_CLI_INVOKE`, invokes following the §15.2 order, serializes the result/error then exits, **without calling `show()`**.
+  - Parameter parsing (§6.3): positional + `--key value` mixing, type conversion, booleans, required-field validation. Positional parsing can live in Rust or Python; **the Python side** is recommended (it holds `inspect.signature`).
+- Verify: `run <name> --k v`, `run <alias> <pos>`, mixing, missing required (exit code 2), command not found (2), command throws (1).
+
+### Step 8 — Wrap-up
+
+- Structured errors (reuse `CommandError` code/message), end-to-end exit codes, timeouts;
+- Docs and examples (README / `docs/`);
+- Cross-platform verification: attach is a no-op on macOS/Linux, but `-h`/`run` stdout behavior is verified on each.
+
+### Dependencies
+
+```
+Step1 ─┐
+Step2 ─┼─→ Step6 (-h/list render) ─┐
+Step3 ─→ Step4 ─→ Step5 ───────────┴─→ Step7 (run) ─→ Step8
+```
+
+- Steps 1, 2, 3 can start in parallel (mutually independent).
+- Step 6 depends on 2 (routing) + 5 (overlay has data).
+- Step 7 depends on 5 (alias table) + 4 (Python invoke entry).
+
+---
+
+## 9. Trade-offs and Risks
+
+1. **Robustness of the trigger convention**: explicit verbs (`run`/`list`) + opt-in `cli` (default `False`) provide double insurance, avoiding file-association/dropped-path misreads as commands. Conflicts between reserved verbs and business command names/aliases are detected and errored at pack-time collection (§12.4).
+2. **First-run latency**: under the standalone strategy `run`'s first launch must extract Python (a few seconds); mitigated by content_hash cache reuse on a hit, and the docs must explain this. `-h`/`list` use pack-time static embedding (§13.3) — zero startup latency, unaffected.
+3. **Security boundary**: CLI-exposed commands are off by default (`cli=False`); developers must explicitly opt in. Commands that write/delete files or touch the network should note in the docs that auth and confirmation responsibility lies with the integrator.
+4. **Cross-platform consistency**: this RFC focuses on Windows (the subsystem problem is most acute there). macOS/Linux .app/AppImage have no GUI-subsystem isolation problem; the attach logic is a cross-platform no-op fallback, but stdout behavior must be verified on each.
+5. **Relationship to the persistent backend**: headless is "invoke once and exit", a separate path from the GUI's persistent JSON-RPC server; they do not share a process, avoiding state pollution.
+
+---
+
+## 10. Acceptance Criteria
+
+- `app.exe` (double-click / no args) behaves exactly as today — no black window, no regression.
+- `app.exe -h` correctly prints the command list (with help, aliases, parameters) under cmd / PowerShell, **reading the overlay only, zero Python startup**, UTF-8 without garbling.
+- `app.exe run <cmd|alias> --k v` and `app.exe run <cmd|alias> <pos...>` both correctly invoke the command, output the result JSON to stdout, with exit codes per §4.4.
+- Commands with CLI disabled (`cli=False`) do not appear in `list`/`-h`, and a `run` invocation reports "command not found".
+- Output is consistent across cmd / PowerShell / redirect-to-file (`app.exe list > out.txt`).
+
+---
+
+## 11. Review Decisions (confirmed)
+
+| # | Topic | Decision |
+|---|------|------|
+| 1 | Trigger verb | Use `run` / `list` (keep the §4.3 trigger convention) |
+| 2 | `cli` default | Off by default (`cli=False`), explicit opt-in |
+| 3 | Alias and switch | **Merged into a single `cli` argument**: `cli=True` (on, no alias) / `cli="exi"` (on + alias) / `cli=["exi","edi"]` (multiple aliases). No separate `aliases=` |
+| 4 | `-h` latency | **Must be zero latency**: the command list is collected at pack time and embedded into the overlay; the runtime reads it directly, never starting Python |
+| 5 | Positional parameters | **Supported**, mixable with `--key value` (§6.3) |
+
+---
+
+## 12. Add-on Feature A: Command Aliases (merged into the `cli` argument)
+
+### 12.1 Requirement
+
+Allow declaring a short alias for a long command name, e.g. `export-document-image` can be invoked as `exi`.
+
+### 12.2 Design: alias and CLI switch merged into a single `cli` argument (review decision 3)
+
+No separate `aliases=` is introduced; the alias is written directly on `cli` (value semantics in §6.2):
+
+```python
+@webview.command(name="export-document-image", cli="exi")          # alias exi
+def export_document_image(path: str, dpi: int = 300) -> dict: ...
+
+@webview.command(name="validate", cli=["val", "v"])                # multiple aliases
+def validate(...): ...
+
+@webview.command(name="sync", cli=True)                            # enabled but no alias
+def sync(...): ...
+```
+
+- Alias and canonical name share the same handler and same metadata, shown in `list`/`-h` as `export-document-image (exi)`.
+- The front-end JS side still uses only the canonical name (`window.auroraview.invoke("export-document-image", ...)`); aliases apply to the command line only, to avoid namespace bloat.
+
+### 12.3 Where aliases are resolved (to avoid clashing with the trigger convention)
+
+§4.3 states CLI is entered only when the first token is a reserved verb `run`/`list` or a reserved flag `-h`/`-V`. Therefore **the alias is resolved as an argument to `run`**, not as a top-level bare token:
+
+```bash
+app.exe run export-document-image --path ./out   # canonical name
+app.exe run exi --path ./out                      # alias, equivalent
+app.exe run exi ./out                             # alias + positional
+```
+
+We do not make `-exi` (a bare short flag with a leading `-`) a top-level trigger: it conflicts with §4.3 ("a bare `--flag`/bare path is always GUI" — file association/dropped paths would be misread), and a leading `-` would collide with clap's top-level flag parsing. **The alias form is fixed as a short word with no leading `-`, resolved uniformly under `run <name|alias>`.**
+
+### 12.4 Conflict detection
+
+Validated during pack-time collection (§5.1); a duplicate is an immediate error (fail-fast):
+
+- An alias duplicates any canonical name;
+- An alias duplicates another alias;
+- An alias hits the reserved-verb set (`run`/`list`/`help`/`version`, etc.).
+
+---
+
+## 13. Add-on Feature B: `-h` Auto-Collects the Command List (with descriptions and parameters)
+
+### 13.1 Requirement
+
+`app.exe -h` automatically lists **all CLI-enabled (`cli != False`)** commands and shows: command name, aliases, command description, and each parameter (name, type, default, whether required, parameter description). **Zero Python startup** (review decision 4).
+
+### 13.2 Metadata structure
+
+The metadata collected for each command (written into the overlay `cli_commands` field):
+
+```jsonc
+{
+  "name": "export-document-image",
+  "aliases": ["exi"],               // from cli="exi" / cli=["exi",...]
+  "help": "Export the current document as an image",   // command(help=); falls back to docstring first line
+  "params": [
+    {"name": "path", "type": "str", "required": true,  "default": null, "help": "Output directory"},
+    {"name": "dpi",  "type": "int", "required": false, "default": 300,  "help": "Resolution (DPI)"}
+  ]
+}
+```
+
+- `aliases`: `cli` is str → single element; list → multiple elements; `True` → empty.
+- `help`: `command(help=)`, falling back to the docstring's first line.
+- `params`: `inspect.signature` auto-fills `type` (annotation name, `"any"` if unannotated), `required` (required if no default), and `default`; `help` comes from `args_help`.
+
+### 13.3 Collection mechanism: pack-time static embedding (zero runtime latency)
+
+**Do not dump at runtime.** The command list is collected once in the pack flow and written into the overlay; at runtime `-h`/`list` read the overlay only:
+
+```
+Pack time (inside the pack flow, target bundled Python environment is ready):
+    run the entry_point as an AURORAVIEW_CLI_DUMP=1 subprocess
+        -> Python builds webview/commands (without calling show())
+        -> collect_cli_commands(webview) serializes the command metadata table -> stdout -> exit(0)
+    the packager receives the JSON, does §12.4 conflict detection, writes PackConfig.cli_commands
+
+Runtime (every app.exe -h / list):
+    read overlay.config.cli_commands -> render -> exit(0)    # zero Python startup, milliseconds
+```
+
+- Collection happens only at pack time; the target environment already has the dependencies, so `import` is safe.
+- The runtime never extracts/starts Python, satisfying the §10 zero-latency acceptance.
+
+A new lightweight Python entry (not entering the persistent loop):
+
+```python
+# new in packed.py
+def dump_cli_metadata(webview: "WebView") -> None:
+    table = collect_cli_commands(webview)   # only cli != False commands + parameter introspection
+    _get_writer().write_json({"type": "cli_metadata", "commands": table})
+```
+
+`collect_cli_commands` must walk **both** `CommandRegistry._commands` and `_bound_functions` (see §15) and take their `cli != False` subset.
+
+### 13.4 Rendering
+
+Human-readable (`-h`) and machine-readable (`list --json` emits the §13.2 JSON array directly) share the same metadata. `-h` example:
+
+```
+USAGE:
+    app.exe run <command> [--key value ...]
+
+COMMANDS:
+    export-document-image (exi)   Export the current document as an image
+        --path <str>              [required] Output directory
+        --dpi  <int>              [default 300] Resolution (DPI)
+```
+
+---
+
+## 14. Add-on Feature C: CLI Off by Default, Explicit Opt-In Required
+
+### 14.1 Requirement
+
+Registered commands **do not enable** CLI support by default; CLI support must be added manually before a command can be invoked from the command line.
+
+### 14.2 Design (consistent with §6.2, formalized here)
+
+- The `cli` argument of `@webview.command` defaults to `False` (review decision 2).
+- Only `cli != False` commands enter the §13 list and can be invoked by `run` (canonical/alias); the rest return "command not found" (exit code 2) on a `run` invocation and do not appear in `list`/`-h`.
+- Two opt-in granularities are provided:
+
+```python
+# Granularity 1: enable a single command (can also give an alias)
+@webview.command(name="export", cli=True)        # enabled, no alias
+@webview.command(name="export", cli="exp")       # enabled + alias
+
+# Granularity 2: bulk enable (registry level, convenient for projects with many existing commands)
+webview.commands.enable_cli("export", "validate")               # enable only
+webview.commands.enable_cli({"export": "exp", "validate": "v"}) # enable + alias
+```
+
+- **No** "enable everything by default" global switch is provided, to avoid accidentally exposing file-write/delete/network commands to the command line (a secure default, echoing §9.3).
+
+### 14.3 Default behavior
+
+A command without a declared `cli` (i.e. `cli=False`) is entirely invisible to the command line and cannot be invoked by `run` — this is the default and only secure state. Developers must explicitly declare `cli` for each command they want to expose.
+
+---
+
+## 15. Defect Fix: Bridge the Two Command Registries (added in review)
+
+### 15.1 The problem
+
+The code has two independent registries:
+
+- `@webview.command` / `commands.register` → `CommandRegistry._commands` (`commands.py:281`), exposed via the `__invoke__` IPC callback (`commands.py:159`);
+- `bind_call` / `bind_api` → `_bound_functions` (`api.py:243`), exposed via the JSON-RPC `_handle_request` (`packed.py:345`).
+
+`run_api_server` reads only `_bound_functions` (`packed.py:218`), and `_handle_request` looks up only `bound_functions.get(method)` (`packed.py:345`). So if §7 reused the JSON-RPC server, commands registered by `@webview.command` would be **entirely unreachable**, contradicting the §1/§6 examples.
+
+### 15.2 The fix
+
+Headless `run` **does not reuse the persistent JSON-RPC server loop**; it is a one-shot in-process call that resolves the command following a unified lookup order:
+
+```
+1. CommandRegistry.invoke(name, **params)   # commands registered by @webview.command (§2.2 confirmed window-independent)
+2. fall back to _bound_functions[name](**params)   # commands registered by bind_call/bind_api
+3. neither -> exit code 2 "command not found"
+```
+
+The §7 flow is correspondingly corrected to:
+
+```
+attach_parent_console() + reopen_std_streams()   # §3.2 fix: attach exists, add reopen
+read_overlay()
+if -h / list:
+    read the §13 cache (dump once if needed) -> render -> exit(0)
+if run <name|alias>:
+    extract_standalone_python()
+    launch entry_point with AURORAVIEW_CLI_INVOKE=<name> + params(JSON)
+        -> Python builds webview/commands, [no show()]
+        -> invoke following the §15.2 lookup order, result JSON to stdout / error to stderr
+        -> exit (per the corresponding exit code)
+```
+
+Aliases (§12) are normalized alias→canonical before the step 1/2 lookup (the normalization table likewise comes from pack-time-collected metadata, read alongside the overlay at runtime).
+
+### 15.3 Consistency with metadata collection
+
+`collect_cli_commands` (§13.3) and headless `run` (§15.2) must share the same "walk both registries + alias normalization" logic, so the commands listed by `-h` match the commands `run` can actually invoke. Extracting a single `iter_cli_commands(webview)` generator for both is recommended.

--- a/docs/zh/guide/cli.md
+++ b/docs/zh/guide/cli.md
@@ -96,6 +96,31 @@ auroraview-cli pack --frontend ./dist --output myapp
 auroraview-cli pack --config auroraview.pack.toml
 ```
 
+## 打包应用 CLI（Headless 模式）
+
+除了上面两个 CLI，**打包后的应用**本身就是第三个命令行界面。打包 exe 默认是 GUI 应用——双击即打开窗口——但它**同时**支持在终端里直接运行已注册的 Python 命令，无需打开窗口：
+
+```bash
+my-app.exe                          # 打开 GUI 窗口（行为不变）
+my-app.exe -h                       # 列出已开启 CLI 的命令
+my-app.exe list                     # 列出命令（--json 输出机器可读格式）
+my-app.exe run export --path ./out  # 执行单个命令，打印结果后退出
+my-app.exe -V                       # 打印版本
+```
+
+只有当**首个参数**是保留动词（`run`、`list`）或保留标志（`-h`/`--help`、`-V`/`--version`）时才进入 CLI 路径——裸文件路径（文件关联、拖拽）一律打开 GUI。
+
+暴露是逐命令显式开启的，通过 `@webview.command(cli=...)`：
+
+```python
+@webview.command(name="export", help="导出工程", cli=True)
+def export(path: str, dpi: int = 300) -> dict:
+    return {"written": path, "dpi": dpi}
+```
+
+退出码：`0` 成功，`1` 命令抛异常，`2` 命令未找到或参数错误。Windows 上请在终端里调用生成的 `my-app.cmd` 包装脚本，输出与退出码才会正确传递。完整参考（别名、传参、`.cmd` 包装脚本、命令清单如何在打包期采集）见
+[应用打包指南](/zh/guide/packing)的「命令行模式」一节。
+
 ## 示例
 
 ### 快速 Web 预览 (Python)

--- a/docs/zh/guide/packing.md
+++ b/docs/zh/guide/packing.md
@@ -452,6 +452,30 @@ my-app.exe run export ./out --dpi 600           # 混用
 
 Windows 上打包 exe 启动时会附着到父控制台，使 CLI 输出能回到终端（双击仍无黑窗）。macOS/Linux 无 GUI 子系统的 stdio 隔离问题，输出直接生效。
 
+### Windows `.cmd` 包装脚本
+
+打包 exe 是 GUI 子系统的，双击不会闪出黑窗。代价是 `cmd.exe` 和 PowerShell **不会等待** GUI 子系统进程——`app.exe run export ...` 会在命令输出落地之前就返回提示符，退出码也会丢失。
+
+为此，当打包产物暴露了 CLI 命令、且**不是**以 console 子系统构建（默认情况）时，打包器会在 exe 旁生成一个 `<name>.cmd` 包装脚本：
+
+```bat
+@echo off
+start "" /wait /b "%~dp0app.exe" %*
+exit /b %ERRORLEVEL%
+```
+
+`start /wait` 同步运行 exe，使终端阻塞到其结束；`%*` 透传所有参数；`exit /b %ERRORLEVEL%` 传递退出码。`%~dp0` 以脚本自身所在目录解析 exe，因此与调用方当前目录无关。
+
+在终端里请调用 `.cmd`，输出与退出码才会正确：
+
+```bash
+app.cmd -h                       # 阻塞，打印帮助后返回
+app.cmd run export --path ./out  # 阻塞直到命令结束
+app.exe                          # 双击 / GUI 启动仍使用 exe
+```
+
+该脚本是 best-effort 的：若无法写入（例如输出目录只读），构建仍会成功，只打印一条警告。console 子系统构建（`[bundle.platform.windows] console = true`）不会生成它——此时 exe 本身就会阻塞终端。
+
 ## 最佳实践
 
 1. **使用 `site-packages` 存放依赖**: 所有第三方包放到 `python/site-packages/`

--- a/docs/zh/guide/packing.md
+++ b/docs/zh/guide/packing.md
@@ -391,6 +391,67 @@ exclude = [
 ]
 ```
 
+## 命令行模式（Headless CLI）
+
+打包后的可执行文件默认是 GUI 应用——双击（或无参数启动）照常打开窗口。它**同时**支持在终端里直接运行已注册的 Python 命令，无需打开窗口。
+
+```bash
+my-app.exe                          # 打开 GUI 窗口（行为不变）
+my-app.exe -h                       # 列出已开启 CLI 的命令
+my-app.exe list                     # 列出命令（加 --json 输出机器可读格式）
+my-app.exe run export --path ./out  # 执行单个命令，打印结果后退出
+my-app.exe -V                       # 打印版本
+```
+
+只有当**首个参数**是保留动词（`run`、`list`）或保留标志（`-h`/`--help`、`-V`/`--version`）时才进入 CLI 路径。裸文件路径（文件关联、拖拽）一律打开 GUI，因此不会破坏既有行为。
+
+### 把命令暴露给 CLI
+
+CLI 暴露是**显式开启**的——命令默认仅 GUI 可用。通过 `@webview.command` 的 `cli` 参数开启：
+
+```python
+@webview.command(name="export", help="导出工程", cli=True)
+def export(path: str, dpi: int = 300) -> dict:
+    return {"written": path, "dpi": dpi}
+
+# 指定短别名：
+@webview.command(name="export-document-image", cli="exi")
+def export_document_image(path: str) -> dict: ...
+
+# 多个别名：
+@webview.command(name="validate", cli=["val", "v"])
+def validate() -> dict: ...
+```
+
+`cli` 取值同时承担开关与别名两个职责：
+
+| `cli` 取值           | 含义                       |
+|----------------------|----------------------------|
+| `False`（默认）      | 仅 GUI，不暴露到命令行     |
+| `True`               | 暴露，无别名               |
+| `"exi"`              | 暴露，别名 `exi`           |
+| `["exi", "edi"]`     | 暴露，多个别名             |
+
+用 `help=` 和 `args_help={...}` 丰富 `-h` 输出；缺省时回退到 docstring / 签名。批量开启已有命令可调用 `webview.commands.enable_cli("export", "validate")`，或传入 `{名称: 别名}` 映射。
+
+### 传参
+
+支持关键字与位置两种形态，可混用（位置在前，关键字在后）：
+
+```bash
+my-app.exe run export --path ./out --dpi 600   # 关键字
+my-app.exe run export ./out 600                 # 位置（按签名顺序）
+my-app.exe run export ./out --dpi 600           # 混用
+```
+
+参数按类型注解（`int`/`float`/`bool`/`str`）转换，其余按 JSON 解析（`--config '{"a":1}'`）。布尔支持 `--flag` / `--no-flag`。退出码：`0` 成功，`1` 命令抛异常，`2` 命令未找到或参数错误。
+
+### 实现原理
+
+`-h`/`list` 显示的命令清单在**打包期**采集并嵌入 overlay，因此这两个命令毫秒级返回、完全不启动 Python。采集时以 `AURORAVIEW_CLI_DUMP=1` 跑一次打包的入口。由于需要在构建主机上运行打包的解释器，跨平台打包或非 `standalone` 策略时会跳过（并打印警告）——此时 `-h`/`list` 不列出任何命令，需在匹配的主机上重新打包。`run` 首次执行时解压 Python 运行时（之后缓存复用），在一次性进程中调用命令——不复用 GUI 的常驻后端。
+
+Windows 上打包 exe 启动时会附着到父控制台，使 CLI 输出能回到终端（双击仍无黑窗）。macOS/Linux 无 GUI 子系统的 stdio 隔离问题，输出直接生效。
+
 ## 最佳实践
 
 1. **使用 `site-packages` 存放依赖**: 所有第三方包放到 `python/site-packages/`

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -33,6 +33,7 @@ Available Examples:
     - multi_window_demo.py: Multiple windows with communication
     - signals_advanced_demo.py: Qt-style signal-slot system
     - cookie_management_demo.py: Session and persistent cookies
+    - packed_cli_demo.py: Packed exe headless CLI mode (@command(cli=...), RFC 0018)
 
     DCC Integration:
     - maya_qt_echo_demo.py: Maya integration with QtWebView

--- a/examples/maya_qt_echo_demo.py
+++ b/examples/maya_qt_echo_demo.py
@@ -24,9 +24,10 @@ Note:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, List, Dict
 
 import maya.OpenMayaUI as omui
+import maya.cmds as cmds
 from qtpy.QtWidgets import QDialog, QVBoxLayout, QWidget
 from shiboken2 import wrapInstance
 
@@ -52,7 +53,7 @@ class _ShelfAPI:
     when bound via :class:`AuroraView` / ``bind_api``.
     """
 
-    def rename_selected(self, prefix: str = "av_") -> dict[str, Any]:
+    def rename_selected(self, prefix: str = "av_") -> Dict[str, Any]:
         """Rename the currently selected Maya objects and print to Script Editor.
 
         Args:
@@ -61,25 +62,24 @@ class _ShelfAPI:
         Returns:
             A dictionary with summary information for debugging in DevTools.
         """
-
-        import maya.cmds as cmds
-
         sel = cmds.ls(selection=True, long=False) or []
         if not sel:
             msg = "[AuroraView] No objects selected to rename."
             print(msg)
             return {"ok": False, "message": msg, "renamed": []}
 
-        renamed: list[dict[str, str]] = []
+        renamed: List[Dict[str, str]] = []
         for index, obj in enumerate(sel, start=1):
             new_name = f"{prefix}{index:02d}"
             try:
                 actual_new = cmds.rename(obj, new_name)
                 renamed.append({"old": obj, "new": actual_new})
-            except Exception as exc:  # pragma: no cover - runs only inside Maya
+            except RuntimeError as exc:  # pragma: no cover - runs only inside Maya
                 print(f"[AuroraView] Failed to rename {obj}: {exc}")
 
-        msg = f"[AuroraView] Renamed {len(renamed)}/{len(sel)} selected objects."
+        success_count = len(renamed)
+        total_count = len(sel)
+        msg = f"[AuroraView] Renamed {success_count}/{total_count} selected objects."
         print(msg)
         return {"ok": True, "message": msg, "renamed": renamed}
 
@@ -143,22 +143,16 @@ class AuroraViewMayaDialog(QDialog):
         def _log_event(name: str, payload: Any) -> None:
             print(f"[AuroraView Demo] {name}: {payload!r}")
 
-        def _handle_viewport_orbit(data: Any) -> None:
-            _log_event("viewport.orbit", data)
+        # Register event handlers with consistent logging
+        event_handlers = {
+            "viewport.orbit": _log_event,
+            "viewport.zoom": _log_event,
+            "ui.view.pan": _log_event,
+            "ui.view.zoom": _log_event,
+        }
 
-        def _handle_viewport_zoom(data: Any) -> None:
-            _log_event("viewport.zoom", data)
-
-        def _handle_ui_pan(data: Any) -> None:
-            _log_event("ui.view.pan", data)
-
-        def _handle_ui_zoom(data: Any) -> None:
-            _log_event("ui.view.zoom", data)
-
-        self.webview.on("viewport.orbit")(_handle_viewport_orbit)
-        self.webview.on("viewport.zoom")(_handle_viewport_zoom)
-        self.webview.on("ui.view.pan")(_handle_ui_pan)
-        self.webview.on("ui.view.zoom")(_handle_ui_zoom)
+        for event_name, handler in event_handlers.items():
+            self.webview.on(event_name)(lambda data, name=event_name: handler(name, data))
 
         # Load HTML from an external file next to this module and feed it
         # via load_html() so we avoid `file://` restrictions in embedded

--- a/examples/pack/python/packed-cli-demo.pack.toml
+++ b/examples/pack/python/packed-cli-demo.pack.toml
@@ -1,0 +1,115 @@
+# AuroraView Pack - Packed Headless CLI Demo (RFC 0018)
+# ============================================================================
+#
+# Packs examples/packed_cli_demo.py into a standalone exe that:
+#   - opens its GUI window when double-clicked (unchanged behavior), and
+#   - runs @webview.command(cli=...) commands straight from a terminal:
+#       packed-cli-demo.exe -h
+#       packed-cli-demo.exe list --json
+#       packed-cli-demo.exe run import-image --path C:/pics/logo.png
+#       packed-cli-demo.exe run now --utc
+#
+# Build it:
+#   av pack examples/pack/python/packed-cli-demo.pack.toml
+#   # or: python -m auroraview.cli pack examples/pack/python/packed-cli-demo.pack.toml
+#
+# At pack time AuroraView runs the entry point once with AURORAVIEW_CLI_DUMP=1
+# to harvest the CLI command table (name/aliases/help/params) and embeds it in
+# the overlay, so `-h`/`list` are zero-latency at runtime (RFC 0018 §5.1, §13).
+#
+# NOTE: paths below are relative to this file's directory. Adjust them to your
+# own project layout; this template assumes the demo and a small frontend live
+# beside it. The demo also serves an inline HTML page when run as a plain
+# script (`python examples/packed_cli_demo.py`), independent of the packed
+# frontend bundled here.
+
+# ============================================================================
+# Package Metadata
+# ============================================================================
+[package]
+name = "packed-cli-demo"
+version = "1.0.0"
+title = "Packed CLI Demo"
+identifier = "com.auroraview.packed-cli-demo"
+description = "RFC 0018 headless CLI mode: one exe, GUI on double-click, commands from the terminal"
+authors = ["AuroraView Core Team"]
+
+# ============================================================================
+# Frontend Configuration
+# ============================================================================
+# FullStack packs require a frontend path. Point this at your built web assets
+# (e.g. a Vite/Webpack ./dist). For this demo a single static index.html is
+# enough; the buttons there call the same commands the CLI exposes.
+[frontend]
+path = "./web"
+
+# ============================================================================
+# Backend Configuration (Python)
+# ============================================================================
+[backend]
+type = "python"
+
+[backend.python]
+version = "3.11"
+# "module:function" - the launcher imports the module and calls the function.
+# Both the GUI path and the headless CLI path go through this same entry point.
+entry_point = "packed_cli_demo:main"
+# Bundle the demo module plus the auroraview package it imports. include_paths
+# walk directories; files land under the overlay's python/ root preserving the
+# relative tree, so `packed_cli_demo.py` imports as `packed_cli_demo` and
+# `../../../python/auroraview/...` imports as `auroraview`.
+#
+# In your own project you would instead list `packages = ["auroraview"]` to
+# pip-install it into the bundle; this example points at the in-repo source so
+# it builds without publishing.
+include_paths = ["../..", "../../../python"]
+exclude = [
+    "*.pyc",
+    "__pycache__",
+    "*.egg-info",
+    "tests",
+    ".pytest_cache",
+    ".venv",
+    "venv",
+]
+optimize = 1
+# "standalone" embeds a python-build-standalone runtime so the exe is fully
+# offline. It is also the only strategy whose interpreter exists at pack time,
+# which the CLI metadata dump needs (RFC 0018 §5.1).
+strategy = "standalone"
+
+# ============================================================================
+# Window Configuration
+# ============================================================================
+[window]
+width = 760
+height = 560
+resizable = true
+start_position = "center"
+
+# ============================================================================
+# Bundle Configuration
+# ============================================================================
+[bundle]
+copyright = "Copyright 2026 AuroraView"
+
+[bundle.windows]
+# Keep the console hidden: double-click stays window-only. The headless CLI
+# path re-attaches to the parent terminal at runtime via AttachConsole, so
+# `-h`/`run` still print correctly without a black window on launch
+# (RFC 0018 §3).
+console = false
+
+# ============================================================================
+# Build Configuration
+# ============================================================================
+[build]
+out_dir = "./pack-output"
+release = true
+
+# ============================================================================
+# Debug Configuration
+# ============================================================================
+[debug]
+enabled = false
+devtools = false

--- a/examples/pack/python/web/index.html
+++ b/examples/pack/python/web/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Packed CLI Demo</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 720px;
+            margin: 40px auto;
+            padding: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+        .card {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+        }
+        h1 { color: #333; margin-top: 0; }
+        p { color: #666; }
+        button {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white; border: none; padding: 12px 20px;
+            border-radius: 6px; cursor: pointer; font-size: 14px; margin: 5px;
+        }
+        button:hover { opacity: 0.9; }
+        #output {
+            background: #1e1e1e; color: #f8f8f2; border-radius: 8px;
+            padding: 16px; font-family: 'Consolas', monospace; font-size: 13px;
+            white-space: pre-wrap; margin-top: 12px;
+        }
+        code { background: #f0f0f0; padding: 2px 6px; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Packed CLI Demo</h1>
+        <p>The same commands below are callable from this packed exe's command
+           line, e.g. <code>packed-cli-demo.exe run get-time</code>. Try the
+           buttons, then call them from a terminal.</p>
+        <button onclick="callStatus()">get-app-status (cli=False, GUI only)</button>
+        <button onclick="callTime()">get-time (CLI-enabled)</button>
+        <div id="output">Ready.</div>
+    </div>
+
+    <script>
+        function show(obj) {
+            document.getElementById('output').textContent =
+                typeof obj === 'object' ? JSON.stringify(obj, null, 2) : String(obj);
+        }
+        async function callStatus() {
+            try { show(await auroraview.invoke('get-app-status')); }
+            catch (e) { show('Error: ' + e.message); }
+        }
+        async function callTime() {
+            try { show(await auroraview.invoke('get-time', {})); }
+            catch (e) { show('Error: ' + e.message); }
+        }
+    </script>
+</body>
+</html>

--- a/examples/packed_cli_demo.py
+++ b/examples/packed_cli_demo.py
@@ -75,21 +75,21 @@ def register_commands(view: WebView) -> None:
     @view.command(
         name="import-image",
         cli="imp",
-        help="导入一张本地图片",
-        args_help={"path": "图片的本地绝对路径"},
+        help="Import a local image",
+        args_help={"path": "Absolute local path to the image"},
     )
     def import_image(path: str) -> Dict[str, Any]:
-        """导入一张本地图片，成功后返回导入信息。"""
+        """Import a local image and return its info on success."""
         if not os.path.isfile(path):
             raise CommandError(
                 CommandErrorCode.INVALID_ARGUMENTS,
-                f"图片不存在: {path}",
+                f"Image not found: {path}",
                 {"path": path},
             )
         size = os.path.getsize(path)
         return {
             "ok": True,
-            "message": "导入成功",
+            "message": "Imported successfully",
             "path": os.path.abspath(path),
             "size_bytes": size,
         }
@@ -98,18 +98,18 @@ def register_commands(view: WebView) -> None:
     @view.command(
         name="process-image",
         cli="proc",
-        help="处理图片：在原路径旁复制一份带后缀的副本",
+        help="Process an image: copy it beside the original with a name suffix",
         args_help={
-            "path": "源图片的本地绝对路径",
-            "suffix": "追加到文件名(扩展名前)的后缀",
+            "path": "Absolute local path to the source image",
+            "suffix": "Suffix appended to the file name (before the extension)",
         },
     )
     def process_image(path: str, suffix: str = "_processed") -> Dict[str, Any]:
-        """复制原图片并追加名字后缀，输出到原图片旁边。"""
+        """Copy the source image with a name suffix, beside the original."""
         if not os.path.isfile(path):
             raise CommandError(
                 CommandErrorCode.INVALID_ARGUMENTS,
-                f"图片不存在: {path}",
+                f"Image not found: {path}",
                 {"path": path},
             )
         root, ext = os.path.splitext(os.path.abspath(path))
@@ -117,7 +117,7 @@ def register_commands(view: WebView) -> None:
         shutil.copy2(path, dest)
         return {
             "ok": True,
-            "message": "处理完成",
+            "message": "Processed successfully",
             "source": os.path.abspath(path),
             "output": dest,
         }
@@ -126,11 +126,11 @@ def register_commands(view: WebView) -> None:
     @view.command(
         name="write-text",
         cli=["wt", "txt"],
-        help="把文本内容写入本地 txt 文件",
-        args_help={"path": "输出文件路径", "content": "要写入的文本内容"},
+        help="Write text content to a local txt file",
+        args_help={"path": "Output file path", "content": "Text content to write"},
     )
     def write_text(path: str, content: str) -> Dict[str, Any]:
-        """在本地写入一个 txt 文件。"""
+        """Write a txt file locally."""
         out = os.path.abspath(path)
         parent = os.path.dirname(out)
         if parent:
@@ -139,7 +139,7 @@ def register_commands(view: WebView) -> None:
             fh.write(content)
         return {
             "ok": True,
-            "message": "写入成功",
+            "message": "Written successfully",
             "path": out,
             "bytes_written": len(content.encode("utf-8")),
         }
@@ -148,11 +148,11 @@ def register_commands(view: WebView) -> None:
     @view.command(
         name="get-time",
         cli=["now"],
-        help="获取当前日期和时间",
-        args_help={"utc": "为 true 时返回 UTC 时间，否则返回本地时间"},
+        help="Get the current date and time",
+        args_help={"utc": "Return UTC time when true, otherwise local time"},
     )
     def get_time(utc: bool = False) -> Dict[str, Any]:
-        """返回现在的日期和时间。"""
+        """Return the current date and time."""
         now = datetime.datetime.utcnow() if utc else datetime.datetime.now()
         return {
             "date": now.strftime("%Y-%m-%d"),
@@ -164,7 +164,7 @@ def register_commands(view: WebView) -> None:
     # Default cli=False: front-end callable, hidden from the CLI (safe default).
     @view.command(name="get-app-status")
     def get_app_status() -> Dict[str, Any]:
-        """返回应用状态，仅供前端调用，不暴露给命令行。"""
+        """Return app status; front-end only, not exposed to the CLI."""
         return {"status": "running", "cli_exposed": False}
 
 

--- a/examples/packed_cli_demo.py
+++ b/examples/packed_cli_demo.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+"""Packed Headless CLI Demo - AuroraView (RFC 0018).
+
+This example demonstrates AuroraView's *packed headless CLI* mode: the same
+packed ``app.exe`` opens its GUI window when double-clicked, yet can also run
+registered commands straight from a terminal - no window, JSON to stdout, exit.
+
+Commands are exposed with ``@webview.command(cli=...)``. The ``cli`` argument is
+both the CLI on/off switch and the alias declaration (RFC 0018 §6.2):
+
+    cli=False           # default: front-end only, hidden from the CLI
+    cli=True            # CLI-enabled, no alias
+    cli="imp"           # CLI-enabled, single alias
+    cli=["wt", "txt"]   # CLI-enabled, multiple aliases
+
+Run as a normal script (opens a window):
+    python examples/packed_cli_demo.py
+
+Pack it into a standalone exe:
+    av pack examples/pack/python/packed-cli-demo.pack.toml
+    # or: python -m auroraview.cli pack examples/pack/python/packed-cli-demo.pack.toml
+
+Then call it from the command line (no window opens):
+    # List CLI-enabled commands (reads the embedded table, zero Python startup)
+    packed-cli-demo.exe -h
+    packed-cli-demo.exe list
+    packed-cli-demo.exe list --json
+
+    # 2.1 Import an image (returns success message)
+    packed-cli-demo.exe run import-image --path C:/pics/logo.png
+    packed-cli-demo.exe run imp C:/pics/logo.png            # via alias + positional
+
+    # 2.2 Process an image (copies original with a "_processed" suffix beside it)
+    packed-cli-demo.exe run process-image --path C:/pics/logo.png
+    packed-cli-demo.exe run process-image C:/pics/logo.png --suffix _v2
+
+    # 2.3 Write a text file
+    packed-cli-demo.exe run write-text --path C:/out/note.txt --content "hello"
+    packed-cli-demo.exe run wt C:/out/note.txt "hello world"
+
+    # 2.4 Get the current date and time
+    packed-cli-demo.exe run get-time
+    packed-cli-demo.exe run now --utc          # alias + boolean flag
+
+Exit codes (RFC 0018 §4.4):
+    0  success                     1  command raised an exception
+    2  command not found / bad arguments
+
+Note: ``get_app_status`` below uses the default ``cli=False`` - it stays
+callable from the front-end but is hidden from ``-h``/``list`` and reports
+"command not found" if invoked via ``run``. This is the safe default: commands
+must opt in to the command line explicitly.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import shutil
+from typing import Any, Dict
+
+from auroraview import WebView
+from auroraview.core.commands import CommandError, CommandErrorCode
+
+
+def register_commands(view: WebView) -> None:
+    """Register every demo command on ``view``.
+
+    Kept separate from :func:`main` so the pack-time metadata dump and the
+    headless invoke path (which build the WebView without calling ``show()``)
+    register the exact same commands the GUI does.
+    """
+
+    # 2.1 - Import an image. Takes a local image path, returns a success result.
+    @view.command(
+        name="import-image",
+        cli="imp",
+        help="导入一张本地图片",
+        args_help={"path": "图片的本地绝对路径"},
+    )
+    def import_image(path: str) -> Dict[str, Any]:
+        """导入一张本地图片，成功后返回导入信息。"""
+        if not os.path.isfile(path):
+            raise CommandError(
+                CommandErrorCode.INVALID_ARGUMENTS,
+                f"图片不存在: {path}",
+                {"path": path},
+            )
+        size = os.path.getsize(path)
+        return {
+            "ok": True,
+            "message": "导入成功",
+            "path": os.path.abspath(path),
+            "size_bytes": size,
+        }
+
+    # 2.2 - Process an image: copy the original with a name suffix, beside it.
+    @view.command(
+        name="process-image",
+        cli="proc",
+        help="处理图片：在原路径旁复制一份带后缀的副本",
+        args_help={
+            "path": "源图片的本地绝对路径",
+            "suffix": "追加到文件名(扩展名前)的后缀",
+        },
+    )
+    def process_image(path: str, suffix: str = "_processed") -> Dict[str, Any]:
+        """复制原图片并追加名字后缀，输出到原图片旁边。"""
+        if not os.path.isfile(path):
+            raise CommandError(
+                CommandErrorCode.INVALID_ARGUMENTS,
+                f"图片不存在: {path}",
+                {"path": path},
+            )
+        root, ext = os.path.splitext(os.path.abspath(path))
+        dest = f"{root}{suffix}{ext}"
+        shutil.copy2(path, dest)
+        return {
+            "ok": True,
+            "message": "处理完成",
+            "source": os.path.abspath(path),
+            "output": dest,
+        }
+
+    # 2.3 - Write a text file. Params: output path, content.
+    @view.command(
+        name="write-text",
+        cli=["wt", "txt"],
+        help="把文本内容写入本地 txt 文件",
+        args_help={"path": "输出文件路径", "content": "要写入的文本内容"},
+    )
+    def write_text(path: str, content: str) -> Dict[str, Any]:
+        """在本地写入一个 txt 文件。"""
+        out = os.path.abspath(path)
+        parent = os.path.dirname(out)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        return {
+            "ok": True,
+            "message": "写入成功",
+            "path": out,
+            "bytes_written": len(content.encode("utf-8")),
+        }
+
+    # 2.4 - Get the current date and time.
+    @view.command(
+        name="get-time",
+        cli=["now"],
+        help="获取当前日期和时间",
+        args_help={"utc": "为 true 时返回 UTC 时间，否则返回本地时间"},
+    )
+    def get_time(utc: bool = False) -> Dict[str, Any]:
+        """返回现在的日期和时间。"""
+        now = datetime.datetime.utcnow() if utc else datetime.datetime.now()
+        return {
+            "date": now.strftime("%Y-%m-%d"),
+            "time": now.strftime("%H:%M:%S"),
+            "iso": now.isoformat(timespec="seconds"),
+            "tz": "UTC" if utc else "local",
+        }
+
+    # Default cli=False: front-end callable, hidden from the CLI (safe default).
+    @view.command(name="get-app-status")
+    def get_app_status() -> Dict[str, Any]:
+        """返回应用状态，仅供前端调用，不暴露给命令行。"""
+        return {"status": "running", "cli_exposed": False}
+
+
+# Minimal front-end: proves the same commands are reachable from JavaScript.
+# Note get-app-status (cli=False) is callable here but NOT from the terminal.
+_HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Packed CLI Demo</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 720px;
+            margin: 40px auto;
+            padding: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+        .card {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+            margin-bottom: 20px;
+        }
+        h1 { color: #333; margin-top: 0; }
+        p  { color: #666; }
+        button {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white; border: none; padding: 12px 20px;
+            border-radius: 6px; cursor: pointer; font-size: 14px; margin: 5px;
+        }
+        button:hover { opacity: 0.9; }
+        #output {
+            background: #1e1e1e; color: #f8f8f2; border-radius: 8px;
+            padding: 16px; font-family: 'Consolas', monospace; font-size: 13px;
+            white-space: pre-wrap; margin-top: 12px;
+        }
+        code { background: #f0f0f0; padding: 2px 6px; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Packed CLI Demo</h1>
+        <p>The same commands below are callable from a packed exe's command line,
+           e.g. <code>app.exe run get-time</code>. Try the buttons here, then pack
+           and call them from a terminal.</p>
+        <button onclick="callStatus()">get-app-status (cli=False, GUI only)</button>
+        <button onclick="callTime()">get-time (CLI-enabled)</button>
+        <div id="output">Ready.</div>
+    </div>
+
+    <script>
+        function show(obj) {
+            document.getElementById('output').textContent =
+                typeof obj === 'object' ? JSON.stringify(obj, null, 2) : String(obj);
+        }
+        async function callStatus() {
+            try { show(await auroraview.invoke('get-app-status')); }
+            catch (e) { show('Error: ' + e.message); }
+        }
+        async function callTime() {
+            try { show(await auroraview.invoke('get-time', {})); }
+            catch (e) { show('Error: ' + e.message); }
+        }
+    </script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    """Run the demo as a GUI window (also the packed entry point)."""
+    view = WebView(title="Packed CLI Demo", html=_HTML, width=760, height=560)
+    register_commands(view)
+
+    # In packed mode show() transparently switches to API-server / headless-CLI
+    # mode based on AURORAVIEW_* env vars set by the Rust launcher; as a plain
+    # script it just opens the window.
+    view.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/auroraview/core/cli_invoke.py
+++ b/python/auroraview/core/cli_invoke.py
@@ -4,9 +4,9 @@
 When the Rust launcher sets ``AURORAVIEW_CLI_INVOKE=<name>`` and
 ``AURORAVIEW_CLI_ARGS=<json-list>``, the entry point calls :func:`run_cli_invoke`
 instead of opening a window. It parses the raw argument tokens against the
-target callable's signature (§6.3), invokes the command in-process using the
-unified lookup order (§15.2), serializes the JSON result to stdout, and returns
-the §4.4 exit code.
+target callable's signature (§6.3), invokes the command in-process — resolving
+only CLI-exposed commands (§15.2) — serializes the JSON result to stdout, and
+returns the §4.4 exit code.
 
 Exit codes (§4.4):
     0  success
@@ -60,18 +60,35 @@ def run_cli_invoke(webview: "WebView", command: str, raw_args: List[str]) -> int
 
 
 def _lookup_command(webview: "WebView", command: str) -> Optional[Callable[..., Any]]:
-    """Resolve a canonical command name via the unified order (§15.2).
+    """Resolve a CLI-exposed command by canonical name or alias (§15.2).
 
-    1. ``CommandRegistry`` (``@webview.command`` / ``commands.register``)
-    2. fallback to ``_bound_functions`` (``bind_call`` / ``bind_api``)
+    Only commands that opted into the CLI via ``cli != False`` are resolvable,
+    mirroring the Rust ``resolve_command`` gate (which matches against the
+    embedded ``cli_commands`` table — itself sourced solely from ``_cli_meta``).
+    This is defense in depth: the Rust launcher already normalizes alias →
+    canonical name before setting ``AURORAVIEW_CLI_INVOKE``, but gating here too
+    means a hand-set ``AURORAVIEW_CLI_INVOKE`` can never reach a command that was
+    never CLI-exposed (e.g. a ``bind_call``/``bind_api`` handler, which carries
+    no CLI metadata).
+
+    Accepts either the canonical name or any registered alias, matching Rust.
     """
     registry = getattr(webview, "_commands", None)
-    if registry is not None and command in registry:
+    if registry is None:
+        return None
+
+    cli_meta = getattr(registry, "_cli_meta", None)
+    if not isinstance(cli_meta, dict):
+        return None
+
+    # Exact canonical-name match.
+    if command in cli_meta:
         return registry._commands.get(command)
 
-    bound = getattr(webview, "_bound_functions", None)
-    if isinstance(bound, dict) and command in bound:
-        return bound[command]
+    # Alias match → resolve to the owning canonical name.
+    for name, meta in cli_meta.items():
+        if command in getattr(meta, "aliases", ()):
+            return registry._commands.get(name)
 
     return None
 

--- a/python/auroraview/core/cli_invoke.py
+++ b/python/auroraview/core/cli_invoke.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+"""Headless CLI command invocation for packed apps (RFC 0018 §7 / §15.2).
+
+When the Rust launcher sets ``AURORAVIEW_CLI_INVOKE=<name>`` and
+``AURORAVIEW_CLI_ARGS=<json-list>``, the entry point calls :func:`run_cli_invoke`
+instead of opening a window. It parses the raw argument tokens against the
+target callable's signature (§6.3), invokes the command in-process using the
+unified lookup order (§15.2), serializes the JSON result to stdout, and returns
+the §4.4 exit code.
+
+Exit codes (§4.4):
+    0  success
+    1  the command raised an exception
+    2  command not found / argument error
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from .webview import WebView
+
+EXIT_OK = 0
+EXIT_COMMAND_ERROR = 1
+EXIT_USAGE = 2
+
+
+class _UsageError(Exception):
+    """Raised for argument/lookup problems that map to exit code 2."""
+
+
+def run_cli_invoke(webview: "WebView", command: str, raw_args: List[str]) -> int:
+    """Invoke ``command`` with ``raw_args`` and return the exit code.
+
+    Writes the JSON result to stdout on success, or a structured error to
+    stderr on failure. Never raises — every outcome is mapped to an exit code.
+    """
+    try:
+        func = _lookup_command(webview, command)
+        if func is None:
+            _print_error("CommandNotFound", f"command not found: {command}")
+            return EXIT_USAGE
+
+        kwargs = _parse_args(func, raw_args)
+    except _UsageError as exc:
+        _print_error("UsageError", str(exc))
+        return EXIT_USAGE
+
+    try:
+        result = func(**kwargs)
+    except Exception as exc:  # noqa: BLE001 - surface as structured stderr
+        _print_command_error(exc)
+        return EXIT_COMMAND_ERROR
+
+    print(json.dumps(result, ensure_ascii=False, default=str), flush=True)
+    return EXIT_OK
+
+
+def _lookup_command(webview: "WebView", command: str) -> Optional[Callable[..., Any]]:
+    """Resolve a canonical command name via the unified order (§15.2).
+
+    1. ``CommandRegistry`` (``@webview.command`` / ``commands.register``)
+    2. fallback to ``_bound_functions`` (``bind_call`` / ``bind_api``)
+    """
+    registry = getattr(webview, "_commands", None)
+    if registry is not None and command in registry:
+        return registry._commands.get(command)
+
+    bound = getattr(webview, "_bound_functions", None)
+    if isinstance(bound, dict) and command in bound:
+        return bound[command]
+
+    return None
+
+
+def _parse_args(func: Callable[..., Any], raw_args: List[str]) -> Dict[str, Any]:
+    """Map raw CLI tokens onto ``func``'s parameters (§6.3).
+
+    Supports positional and ``--key value`` forms, mixed (positional first,
+    keywords after). Boolean flags accept ``--flag`` / ``--no-flag``. Types are
+    coerced from the signature annotation; complex types parse as JSON. A
+    parameter supplied both positionally and by keyword, an unknown ``--key``,
+    or a missing required argument all raise :class:`_UsageError`.
+    """
+    sig = _signature(func)
+    params = [
+        p
+        for p in sig.parameters.values()
+        if p.name != "self"
+        and p.kind
+        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    ]
+    by_name = {p.name: p for p in params}
+
+    positionals, keywords = _split_tokens(raw_args, by_name)
+
+    if len(positionals) > len(params):
+        raise _UsageError(
+            f"too many positional arguments: expected at most {len(params)}, "
+            f"got {len(positionals)}"
+        )
+
+    bound: Dict[str, Any] = {}
+
+    # Positional tokens fill parameters in signature order.
+    for param, token in zip(params, positionals):
+        bound[param.name] = _coerce(param, token)
+
+    # Keyword tokens override/补 by name; reject double-assignment.
+    for key, raw_value in keywords.items():
+        if key not in by_name:
+            raise _UsageError(f"unknown option: --{key}")
+        if key in bound:
+            raise _UsageError(f"argument '{key}' given both positionally and as --{key}")
+        bound[key] = _coerce(by_name[key], raw_value)
+
+    # Validate required parameters are present.
+    for param in params:
+        if param.name in bound:
+            continue
+        if param.default is inspect.Parameter.empty:
+            raise _UsageError(f"missing required argument: {param.name}")
+
+    return bound
+
+
+def _split_tokens(
+    raw_args: List[str],
+    by_name: Dict[str, inspect.Parameter],
+) -> Tuple[List[str], Dict[str, Any]]:
+    """Partition tokens into positionals and a ``{key: value}`` keyword map.
+
+    ``--key value`` consumes the following token as the value. ``--flag`` with
+    no following value (or followed by another option) is a boolean ``True``;
+    ``--no-flag`` is boolean ``False``. Positionals may only appear before the
+    first keyword (§6.3: "positional in front, keyword overrides").
+    """
+    positionals: List[str] = []
+    keywords: Dict[str, Any] = {}
+    seen_keyword = False
+
+    i = 0
+    n = len(raw_args)
+    while i < n:
+        token = raw_args[i]
+        if token.startswith("--"):
+            seen_keyword = True
+            name = token[2:]
+            if not name:
+                raise _UsageError("empty option name '--'")
+
+            if name.startswith("no-") and _is_bool_param(by_name.get(name[3:])):
+                keywords[name[3:]] = False
+                i += 1
+                continue
+
+            # A bool flag without an explicit value defaults to True.
+            if _is_bool_param(by_name.get(name)):
+                nxt = raw_args[i + 1] if i + 1 < n else None
+                if nxt is None or nxt.startswith("--"):
+                    keywords[name] = True
+                    i += 1
+                    continue
+                keywords[name] = nxt
+                i += 2
+                continue
+
+            if i + 1 >= n:
+                raise _UsageError(f"option --{name} requires a value")
+            keywords[name] = raw_args[i + 1]
+            i += 2
+        else:
+            if seen_keyword:
+                raise _UsageError(
+                    f"positional argument '{token}' must come before keyword options"
+                )
+            positionals.append(token)
+            i += 1
+
+    return positionals, keywords
+
+
+def _is_bool_param(param: Optional[inspect.Parameter]) -> bool:
+    """Whether ``param`` is annotated (or defaulted) as ``bool``."""
+    if param is None:
+        return False
+    if _annotation_name(param.annotation) == "bool":
+        return True
+    return isinstance(param.default, bool)
+
+
+def _coerce(param: inspect.Parameter, value: Any) -> Any:
+    """Coerce a raw token to the parameter's annotated type (§6.3)."""
+    if isinstance(value, bool):
+        return value
+
+    kind = _annotation_name(param.annotation)
+    if kind in ("", "str"):
+        return value
+
+    if kind == "bool":
+        return _parse_bool(value)
+    if kind == "int":
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            raise _UsageError(f"argument '{param.name}': expected int, got '{value}'")
+    if kind == "float":
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            raise _UsageError(f"argument '{param.name}': expected float, got '{value}'")
+
+    # Complex / unknown annotations: parse as JSON, fall back to the raw string.
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return value
+
+
+def _annotation_name(annotation: Any) -> str:
+    """Normalize an annotation to a lowercase type name.
+
+    Handles both real type objects and *string* annotations (which is what
+    ``inspect.signature`` yields when the defining module uses
+    ``from __future__ import annotations``). Returns ``""`` when there is no
+    usable annotation.
+    """
+    if annotation is inspect.Parameter.empty or annotation is None:
+        return ""
+    if isinstance(annotation, type):
+        return annotation.__name__
+    # String annotation (PEP 563) or a typing construct: use its text form,
+    # taking the leading bare word (e.g. "int", "str", "dict").
+    text = str(annotation).strip()
+    return text.split("[", 1)[0].split(".")[-1]
+
+
+def _parse_bool(value: Any) -> bool:
+    """Parse a positional boolean token (``true``/``false``/``1``/``0``)."""
+    if isinstance(value, bool):
+        return value
+    lowered = str(value).strip().lower()
+    if lowered in ("true", "1", "yes", "on"):
+        return True
+    if lowered in ("false", "0", "no", "off"):
+        return False
+    raise _UsageError(f"expected a boolean, got '{value}'")
+
+
+def _signature(func: Callable[..., Any]) -> inspect.Signature:
+    try:
+        return inspect.signature(func)
+    except (ValueError, TypeError) as exc:
+        raise _UsageError(f"cannot introspect command signature: {exc}")
+
+
+def _print_error(name: str, message: str) -> None:
+    """Print a structured error object to stderr."""
+    import sys
+
+    print(
+        json.dumps({"error": {"name": name, "message": message}}, ensure_ascii=False),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _print_command_error(exc: Exception) -> None:
+    """Print a command exception, reusing CommandError code/message (§4.4)."""
+    import sys
+
+    payload: Dict[str, Any]
+    try:
+        from .commands import CommandError
+
+        if isinstance(exc, CommandError):
+            payload = {"error": {"name": exc.code.value, "message": exc.message}}
+            if exc.details:
+                payload["error"]["details"] = exc.details
+        else:
+            payload = {"error": {"name": type(exc).__name__, "message": str(exc)}}
+    except Exception:  # noqa: BLE001 - defensive: never fail while reporting
+        payload = {"error": {"name": type(exc).__name__, "message": str(exc)}}
+
+    print(json.dumps(payload, ensure_ascii=False), file=sys.stderr, flush=True)

--- a/python/auroraview/core/cli_invoke.py
+++ b/python/auroraview/core/cli_invoke.py
@@ -107,8 +107,7 @@ def _parse_args(func: Callable[..., Any], raw_args: List[str]) -> Dict[str, Any]
         p
         for p in sig.parameters.values()
         if p.name != "self"
-        and p.kind
-        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
     ]
     by_name = {p.name: p for p in params}
 
@@ -116,8 +115,7 @@ def _parse_args(func: Callable[..., Any], raw_args: List[str]) -> Dict[str, Any]
 
     if len(positionals) > len(params):
         raise _UsageError(
-            f"too many positional arguments: expected at most {len(params)}, "
-            f"got {len(positionals)}"
+            f"too many positional arguments: expected at most {len(params)}, got {len(positionals)}"
         )
 
     bound: Dict[str, Any] = {}
@@ -191,9 +189,7 @@ def _split_tokens(
             i += 2
         else:
             if seen_keyword:
-                raise _UsageError(
-                    f"positional argument '{token}' must come before keyword options"
-                )
+                raise _UsageError(f"positional argument '{token}' must come before keyword options")
             positionals.append(token)
             i += 1
 
@@ -224,12 +220,12 @@ def _coerce(param: inspect.Parameter, value: Any) -> Any:
         try:
             return int(value)
         except (TypeError, ValueError):
-            raise _UsageError(f"argument '{param.name}': expected int, got '{value}'")
+            raise _UsageError(f"argument '{param.name}': expected int, got '{value}'") from None
     if kind == "float":
         try:
             return float(value)
         except (TypeError, ValueError):
-            raise _UsageError(f"argument '{param.name}': expected float, got '{value}'")
+            raise _UsageError(f"argument '{param.name}': expected float, got '{value}'") from None
 
     # Complex / unknown annotations: parse as JSON, fall back to the raw string.
     try:
@@ -272,7 +268,7 @@ def _signature(func: Callable[..., Any]) -> inspect.Signature:
     try:
         return inspect.signature(func)
     except (ValueError, TypeError) as exc:
-        raise _UsageError(f"cannot introspect command signature: {exc}")
+        raise _UsageError(f"cannot introspect command signature: {exc}") from exc
 
 
 def _print_error(name: str, message: str) -> None:

--- a/python/auroraview/core/commands.py
+++ b/python/auroraview/core/commands.py
@@ -542,8 +542,7 @@ class CommandRegistry:
             # Collision with another command's canonical name.
             if alias != cmd_name and alias in self._commands:
                 raise ValueError(
-                    f"alias '{alias}' for command '{cmd_name}' collides with "
-                    f"command name '{alias}'"
+                    f"alias '{alias}' for command '{cmd_name}' collides with command name '{alias}'"
                 )
             # Collision with an alias owned by a different command.
             for other_name, other_meta in self._cli_meta.items():

--- a/python/auroraview/core/commands.py
+++ b/python/auroraview/core/commands.py
@@ -57,6 +57,22 @@ F = TypeVar("F", bound=Callable[..., Any])
 _RESERVED_CLI_VERBS = frozenset({"run", "list", "help", "version"})
 
 
+def _is_headless_cli_mode() -> bool:
+    """Whether we're in a packed headless CLI mode (RFC 0018 §7/§13.3).
+
+    In CLI invoke and pack-time dump modes there is no front-end and stdout is
+    reserved for the command result / metadata table, so internal events like
+    ``__command_registered__`` must not be emitted (it would go straight to
+    stdout via the packed-mode path and corrupt the output). Imported lazily to
+    avoid a circular import with :mod:`auroraview.core.packed`.
+    """
+    try:
+        from .packed import is_cli_dump_mode, is_cli_invoke_mode
+    except Exception:  # noqa: BLE001 - never let a probe break registration
+        return False
+    return is_cli_invoke_mode() or is_cli_dump_mode()
+
+
 def _normalize_cli(cli: "Union[bool, str, List[str]]") -> "tuple[bool, List[str]]":
     """Normalize a decorator ``cli`` value into ``(enabled, aliases)``.
 
@@ -446,8 +462,11 @@ class CommandRegistry:
             if enabled:
                 self._register_cli_meta(cmd_name, func, aliases, help, args_help)
 
-            # Emit registration to JS if webview is attached
-            if self._webview:
+            # Emit registration to JS if webview is attached. Skipped in the
+            # headless CLI modes (RFC 0018 §7/§13.3): there is no front-end to
+            # consume the event, and stdout is reserved for the command result
+            # (invoke) or the metadata table (dump) — emitting would corrupt it.
+            if self._webview and not _is_headless_cli_mode():
                 self._webview.emit(
                     "__command_registered__",
                     {"name": cmd_name, "params": list(inspect.signature(func).parameters.keys())},

--- a/python/auroraview/core/commands.py
+++ b/python/auroraview/core/commands.py
@@ -30,6 +30,7 @@ import asyncio
 import inspect
 import logging
 import traceback
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -49,6 +50,144 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+# RFC 0018 §12.4: reserved CLI verbs/flags a command alias must never collide
+# with. `run`/`list` are the trigger verbs; `help`/`version` back the -h/-V
+# flags. Kept lowercase for case-sensitive comparison against alias strings.
+_RESERVED_CLI_VERBS = frozenset({"run", "list", "help", "version"})
+
+
+def _normalize_cli(cli: "Union[bool, str, List[str]]") -> "tuple[bool, List[str]]":
+    """Normalize a decorator ``cli`` value into ``(enabled, aliases)``.
+
+    RFC 0018 §6.2 collapses the CLI on/off switch and the alias list into one
+    parameter:
+
+    =================  =========================================
+    ``cli`` value      meaning
+    =================  =========================================
+    ``False``          not exposed to the CLI (default)
+    ``True``           exposed, no alias
+    ``"exi"``          exposed, alias ``exi``
+    ``["exi","edi"]``  exposed, multiple aliases
+    =================  =========================================
+
+    Returns:
+        ``(enabled, aliases)`` where ``aliases`` is always a list (possibly
+        empty) of stripped, non-empty alias strings.
+
+    Raises:
+        ValueError: If an alias is empty/blank or not a string.
+    """
+    if cli is False:
+        return False, []
+    if cli is True:
+        return True, []
+    if isinstance(cli, str):
+        alias = cli.strip()
+        if not alias:
+            raise ValueError("cli alias string must not be empty")
+        return True, [alias]
+    if isinstance(cli, (list, tuple)):
+        aliases: List[str] = []
+        for item in cli:
+            if not isinstance(item, str):
+                raise ValueError(f"cli alias must be a string, got {type(item).__name__}")
+            alias = item.strip()
+            if not alias:
+                raise ValueError("cli alias string must not be empty")
+            aliases.append(alias)
+        return True, aliases
+    raise ValueError(f"cli must be bool, str, or list[str], got {type(cli).__name__}")
+
+
+def _resolve_help(help_text: Optional[str], func: Callable[..., Any]) -> str:
+    """Resolve a command's help text, falling back to the docstring first line.
+
+    RFC 0018 §6.2: when ``help`` is omitted, use the first non-empty line of
+    the function's docstring. Returns an empty string if neither is available.
+    """
+    if help_text:
+        return help_text
+    doc = inspect.getdoc(func)
+    if doc:
+        for line in doc.splitlines():
+            stripped = line.strip()
+            if stripped:
+                return stripped
+    return ""
+
+
+@dataclass
+class CliCommandMeta:
+    """CLI metadata for a single command (RFC 0018 §13.2).
+
+    Captured at registration time and serialized at pack time into the overlay
+    so the runtime ``-h``/``list`` path can render without starting Python.
+
+    Attributes:
+        name: Canonical command name (the registered name).
+        aliases: CLI aliases from ``cli="x"`` / ``cli=["x","y"]`` (empty for
+            ``cli=True``).
+        help: Help text; falls back to the docstring first line.
+        args_help: Per-parameter descriptions keyed by parameter name.
+    """
+
+    name: str
+    aliases: List[str] = field(default_factory=list)
+    help: str = ""
+    args_help: Dict[str, str] = field(default_factory=dict)
+
+    def params(self, func: Callable[..., Any]) -> List[Dict[str, Any]]:
+        """Introspect ``func`` to build the parameter metadata list (§13.2).
+
+        Each entry has ``name``, ``type`` (annotation name, ``"any"`` if
+        unannotated), ``required`` (no default), ``default``, and ``help``
+        (from ``args_help``). ``*args``/``**kwargs`` and ``self`` are skipped.
+        """
+        result: List[Dict[str, Any]] = []
+        try:
+            sig = inspect.signature(func)
+        except (ValueError, TypeError):
+            return result
+
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            if param.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                continue
+
+            annotation = param.annotation
+            if annotation is inspect.Parameter.empty:
+                type_name = "any"
+            elif isinstance(annotation, type):
+                type_name = annotation.__name__
+            else:
+                type_name = str(annotation)
+
+            has_default = param.default is not inspect.Parameter.empty
+            result.append(
+                {
+                    "name": pname,
+                    "type": type_name,
+                    "required": not has_default,
+                    "default": None if not has_default else param.default,
+                    "help": self.args_help.get(pname, ""),
+                }
+            )
+        return result
+
+    def to_dict(self, func: Callable[..., Any]) -> Dict[str, Any]:
+        """Serialize to the §13.2 overlay structure, introspecting ``func``."""
+        return {
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "help": self.help,
+            "params": self.params(func),
+        }
 
 
 class CommandErrorCode(Enum):
@@ -147,6 +286,10 @@ class CommandRegistry:
         """
         self._commands: Dict[str, Callable[..., Any]] = {}
         self._webview: Optional[WebView] = webview
+        # RFC 0018: CLI metadata keyed by command name. Only populated for
+        # commands that opt in via `cli != False`. Separate from `_commands`
+        # so non-CLI commands stay untouched and the JS path is unaffected.
+        self._cli_meta: Dict[str, "CliCommandMeta"] = {}
 
     def _attach_webview(self, webview: WebView) -> None:
         """Attach a WebView instance and register IPC handler.
@@ -258,7 +401,15 @@ class CommandRegistry:
     @overload
     def register(self, name: str) -> Callable[[F], F]: ...
 
-    def register(self, func_or_name: Union[F, str, None] = None) -> Union[F, Callable[[F], F]]:
+    def register(
+        self,
+        func_or_name: Union[F, str, None] = None,
+        *,
+        name: Optional[str] = None,
+        cli: Union[bool, str, List[str]] = False,
+        help: Optional[str] = None,
+        args_help: Optional[Dict[str, str]] = None,
+    ) -> Union[F, Callable[[F], F]]:
         """Register a command (decorator).
 
         Can be used with or without arguments:
@@ -269,16 +420,31 @@ class CommandRegistry:
             @commands.register("custom_name")
             def my_command(): ...
 
+        CLI exposure (RFC 0018 §6.2) is opt-in via ``cli``:
+
+            @commands.register("export", cli=True)            # exposed, no alias
+            @commands.register("export", cli="exp")           # exposed + alias
+            @commands.register("export", cli=["exp", "e"])    # multiple aliases
+
         Args:
             func_or_name: Function to register or custom command name
+            cli: CLI exposure switch + aliases. ``False`` (default) keeps the
+                command off the command line; ``True``/str/list opts in.
+            help: Help text for ``-h``; falls back to the docstring first line.
+            args_help: Per-parameter descriptions keyed by parameter name.
 
         Returns:
             Decorated function or decorator
         """
+        enabled, aliases = _normalize_cli(cli)
 
-        def decorator(func: F, name: Optional[str] = None) -> F:
-            cmd_name = name or func.__name__
+        def decorator(func: F, explicit_name: Optional[str] = None) -> F:
+            cmd_name = explicit_name or func.__name__
             self._commands[cmd_name] = func
+
+            # RFC 0018: record CLI metadata only when opted in.
+            if enabled:
+                self._register_cli_meta(cmd_name, func, aliases, help, args_help)
 
             # Emit registration to JS if webview is attached
             if self._webview:
@@ -290,9 +456,15 @@ class CommandRegistry:
             logger.debug(f"Registered command: {cmd_name}")
             return func
 
+        # An explicit `name=` keyword wins over a positional name.
+        if name is not None:
+            if callable(func_or_name):
+                return decorator(func_or_name, name)
+            return lambda f: decorator(f, name)
+
         # Handle different call patterns
         if func_or_name is None:
-            # @commands.register()
+            # @commands.register()  /  @commands.register(cli=...)
             return lambda f: decorator(f)
         elif callable(func_or_name):
             # @commands.register
@@ -300,6 +472,113 @@ class CommandRegistry:
         else:
             # @commands.register("name")
             return lambda f: decorator(f, func_or_name)
+
+    def _register_cli_meta(
+        self,
+        cmd_name: str,
+        func: Callable[..., Any],
+        aliases: List[str],
+        help_text: Optional[str],
+        args_help: Optional[Dict[str, str]],
+    ) -> None:
+        """Record CLI metadata for a command after conflict checking (§12.4).
+
+        Raises:
+            ValueError: On any alias conflict (reserved verb, canonical name,
+                or another command's alias).
+        """
+        self._check_alias_conflicts(cmd_name, aliases)
+        self._cli_meta[cmd_name] = CliCommandMeta(
+            name=cmd_name,
+            aliases=list(aliases),
+            help=_resolve_help(help_text, func),
+            args_help=dict(args_help or {}),
+        )
+
+    def _check_alias_conflicts(self, cmd_name: str, aliases: List[str]) -> None:
+        """Fail-fast alias conflict detection (RFC 0018 §12.4).
+
+        An alias must not collide with a reserved verb, any canonical command
+        name, or any alias already claimed by another command.
+
+        Args:
+            cmd_name: The command the aliases belong to (its own canonical
+                name is exempt so re-registration is allowed).
+            aliases: Aliases being registered.
+
+        Raises:
+            ValueError: On the first conflict found.
+        """
+        seen = set()
+        for alias in aliases:
+            if alias in seen:
+                raise ValueError(f"duplicate alias '{alias}' for command '{cmd_name}'")
+            seen.add(alias)
+
+            if alias in _RESERVED_CLI_VERBS:
+                raise ValueError(
+                    f"alias '{alias}' for command '{cmd_name}' collides with a "
+                    f"reserved CLI verb ({', '.join(sorted(_RESERVED_CLI_VERBS))})"
+                )
+            # Collision with another command's canonical name.
+            if alias != cmd_name and alias in self._commands:
+                raise ValueError(
+                    f"alias '{alias}' for command '{cmd_name}' collides with "
+                    f"command name '{alias}'"
+                )
+            # Collision with an alias owned by a different command.
+            for other_name, other_meta in self._cli_meta.items():
+                if other_name == cmd_name:
+                    continue
+                if alias in other_meta.aliases:
+                    raise ValueError(
+                        f"alias '{alias}' for command '{cmd_name}' already used "
+                        f"by command '{other_name}'"
+                    )
+
+    def enable_cli(self, *names: Any, **_unused: Any) -> None:
+        """Batch-enable CLI exposure for already-registered commands (§14.2).
+
+        Two calling styles:
+
+            webview.commands.enable_cli("export", "validate")             # no aliases
+            webview.commands.enable_cli({"export": "exp", "validate": "v"})# with aliases
+
+        A mapping value may be a single alias string or a list of aliases.
+        Help text falls back to each command's docstring first line.
+
+        Raises:
+            KeyError: If a named command is not registered.
+            ValueError: On alias conflicts (§12.4).
+        """
+        # Normalize the heterogeneous arguments into {name: cli_value}.
+        plan: Dict[str, Union[bool, str, List[str]]] = {}
+        for arg in names:
+            if isinstance(arg, dict):
+                for name, alias in arg.items():
+                    plan[name] = alias
+            elif isinstance(arg, str):
+                plan[arg] = True
+            else:
+                raise ValueError(
+                    f"enable_cli arguments must be str or dict, got {type(arg).__name__}"
+                )
+
+        for name, cli_value in plan.items():
+            if name not in self._commands:
+                raise KeyError(f"Unknown command: {name}")
+            enabled, aliases = _normalize_cli(cli_value)
+            if not enabled:
+                continue
+            self._register_cli_meta(name, self._commands[name], aliases, None, None)
+
+    def cli_meta(self, name: str) -> Optional["CliCommandMeta"]:
+        """Return the CLI metadata for a command, or ``None`` if not exposed."""
+        return self._cli_meta.get(name)
+
+    def list_cli_commands(self) -> List[str]:
+        """List the canonical names of all CLI-exposed commands."""
+        return list(self._cli_meta.keys())
 
     def unregister(self, name: str) -> bool:
         """Unregister a command.
@@ -312,6 +591,7 @@ class CommandRegistry:
         """
         if name in self._commands:
             del self._commands[name]
+            self._cli_meta.pop(name, None)
             logger.debug(f"Unregistered command: {name}")
             return True
         return False

--- a/python/auroraview/core/mixins/commands.py
+++ b/python/auroraview/core/mixins/commands.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from ..commands import CommandRegistry
@@ -35,13 +35,26 @@ class WebViewCommandsMixin:
             self._commands = CommandRegistry(self)
         return self._commands
 
-    def command(self, func_or_name=None):
+    def command(
+        self,
+        func_or_name=None,
+        *,
+        name: Optional[str] = None,
+        cli: Union[bool, str, List[str]] = False,
+        help: Optional[str] = None,
+        args_help: Optional[Dict[str, str]] = None,
+    ):
         """Decorator to register a command callable from JavaScript.
 
         This is a convenience shortcut for `webview.commands.register`.
 
         Args:
             func_or_name: Function to register or custom command name
+            cli: CLI exposure switch + aliases (RFC 0018 §6.2). ``False``
+                (default) keeps the command off the command line; ``True`` /
+                ``"alias"`` / ``["a", "b"]`` opts in.
+            help: Help text for ``-h``; falls back to the docstring first line.
+            args_help: Per-parameter descriptions keyed by parameter name.
 
         Returns:
             Decorated function
@@ -55,8 +68,18 @@ class WebViewCommandsMixin:
             >>> def add(x: int, y: int) -> int:
             ...     return x + y
 
+            >>> @webview.command(name="export", cli="exp", help="Export data")
+            >>> def export(path: str) -> dict:
+            ...     return {"written": path}
+
             >>> # In JavaScript:
             >>> # const msg = await auroraview.invoke("greet", {name: "World"});
             >>> # const sum = await auroraview.invoke("add_numbers", {x: 1, y: 2});
         """
-        return self.commands.register(func_or_name)
+        # When no CLI metadata is supplied, defer entirely to register()'s
+        # positional handling so all legacy call styles keep working.
+        if cli is False and help is None and args_help is None and name is None:
+            return self.commands.register(func_or_name)
+        return self.commands.register(
+            func_or_name, name=name, cli=cli, help=help, args_help=args_help
+        )

--- a/python/auroraview/core/mixins/lifecycle.py
+++ b/python/auroraview/core/mixins/lifecycle.py
@@ -79,7 +79,15 @@ class WebViewLifecycleMixin:
             >>> # to API server mode. All bind_call() handlers work seamlessly.
         """
         # Check for packed mode first - transparent to developers
-        from ..packed import is_packed_mode, run_api_server
+        from ..packed import dump_cli_metadata, is_cli_dump_mode, is_packed_mode, run_api_server
+
+        # RFC 0018 (section 13.3): pack-time metadata dump short-circuits
+        # before any window/server work. The packer runs the entry point with
+        # AURORAVIEW_CLI_DUMP=1 purely to harvest CLI command metadata.
+        if is_cli_dump_mode():
+            logger.info("CLI dump mode detected: emitting command metadata and exiting")
+            dump_cli_metadata(self)
+            return
 
         if is_packed_mode():
             logger.info("Packed mode detected: running as API server")

--- a/python/auroraview/core/mixins/lifecycle.py
+++ b/python/auroraview/core/mixins/lifecycle.py
@@ -79,7 +79,14 @@ class WebViewLifecycleMixin:
             >>> # to API server mode. All bind_call() handlers work seamlessly.
         """
         # Check for packed mode first - transparent to developers
-        from ..packed import dump_cli_metadata, is_cli_dump_mode, is_packed_mode, run_api_server
+        from ..packed import (
+            dump_cli_metadata,
+            invoke_cli_command,
+            is_cli_dump_mode,
+            is_cli_invoke_mode,
+            is_packed_mode,
+            run_api_server,
+        )
 
         # RFC 0018 (section 13.3): pack-time metadata dump short-circuits
         # before any window/server work. The packer runs the entry point with
@@ -87,6 +94,14 @@ class WebViewLifecycleMixin:
         if is_cli_dump_mode():
             logger.info("CLI dump mode detected: emitting command metadata and exiting")
             dump_cli_metadata(self)
+            return
+
+        # RFC 0018 (section 7): headless CLI invoke short-circuits before any
+        # window/server work. The Rust launcher sets AURORAVIEW_CLI_INVOKE to
+        # run one command and exit, without opening a window.
+        if is_cli_invoke_mode():
+            logger.info("CLI invoke mode detected: running command headlessly")
+            invoke_cli_command(self)
             return
 
         if is_packed_mode():

--- a/python/auroraview/core/packed.py
+++ b/python/auroraview/core/packed.py
@@ -32,6 +32,11 @@ PACKED_MODE = os.environ.get("AURORAVIEW_PACKED", "0") == "1"
 # of opening a window or starting the JSON-RPC server.
 CLI_DUMP_MODE = os.environ.get("AURORAVIEW_CLI_DUMP", "0") == "1"
 
+# RFC 0018 §7: headless command invocation. When set, the entry point builds the
+# WebView/commands (without calling show()), invokes the named command, prints
+# the JSON result, and exits with the §4.4 exit code.
+CLI_INVOKE_COMMAND = os.environ.get("AURORAVIEW_CLI_INVOKE") or None
+
 # Windows error codes
 _ERROR_NO_DATA = 232  # Pipe is being closed
 _ERROR_BROKEN_PIPE = 109  # The pipe has been ended
@@ -124,6 +129,11 @@ def is_packed_mode() -> bool:
 def is_cli_dump_mode() -> bool:
     """Check if running in pack-time CLI metadata dump mode (RFC 0018 §13.3)."""
     return CLI_DUMP_MODE
+
+
+def is_cli_invoke_mode() -> bool:
+    """Check if running in headless CLI invoke mode (RFC 0018 §7)."""
+    return CLI_INVOKE_COMMAND is not None
 
 
 def is_pipe_closed() -> bool:
@@ -267,6 +277,31 @@ def dump_cli_metadata(webview: "WebView") -> None:
     # Write directly to stdout (not the StdioWriter pipe-detection path) so the
     # packer subprocess captures clean JSON regardless of packed-mode state.
     print(json.dumps(payload, ensure_ascii=False), flush=True)
+
+
+def invoke_cli_command(webview: "WebView") -> None:
+    """Invoke a single command headlessly and exit (RFC 0018 §7).
+
+    Called at runtime (under ``AURORAVIEW_CLI_INVOKE=<name>``) after the entry
+    point builds the WebView/commands but before ``show()`` would open a
+    window. Reads the raw argument tokens from ``AURORAVIEW_CLI_ARGS`` (a JSON
+    list), runs the command, and exits with the §4.4 exit code.
+
+    The window / JSON-RPC server is never started in this mode.
+    """
+    from .cli_invoke import run_cli_invoke
+
+    command = CLI_INVOKE_COMMAND or ""
+    raw = os.environ.get("AURORAVIEW_CLI_ARGS", "[]")
+    try:
+        args = json.loads(raw)
+        if not isinstance(args, list):
+            args = []
+    except (ValueError, json.JSONDecodeError):
+        args = []
+
+    exit_code = run_cli_invoke(webview, command, [str(a) for a in args])
+    sys.exit(exit_code)
 
 
 def run_api_server(webview: "WebView") -> None:

--- a/python/auroraview/core/packed.py
+++ b/python/auroraview/core/packed.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
 # Check if running in packed mode (set by Rust CLI)
 PACKED_MODE = os.environ.get("AURORAVIEW_PACKED", "0") == "1"
 
+# RFC 0018: pack-time metadata dump request. When set, the entry point builds
+# the WebView/commands (without calling show()) and dumps CLI metadata instead
+# of opening a window or starting the JSON-RPC server.
+CLI_DUMP_MODE = os.environ.get("AURORAVIEW_CLI_DUMP", "0") == "1"
+
 # Windows error codes
 _ERROR_NO_DATA = 232  # Pipe is being closed
 _ERROR_BROKEN_PIPE = 109  # The pipe has been ended
@@ -116,6 +121,11 @@ def is_packed_mode() -> bool:
     return PACKED_MODE
 
 
+def is_cli_dump_mode() -> bool:
+    """Check if running in pack-time CLI metadata dump mode (RFC 0018 §13.3)."""
+    return CLI_DUMP_MODE
+
+
 def is_pipe_closed() -> bool:
     """Check if the stdout pipe has been closed.
 
@@ -194,6 +204,69 @@ def send_event(event: str, data: Optional[Dict[str, Any]] = None) -> bool:
         "data": data or {},
     }
     return _get_writer().write_json(message)
+
+
+def iter_cli_commands(webview: "WebView") -> "list[Dict[str, Any]]":
+    """Collect CLI command metadata from both registries (RFC 0018 §15.3).
+
+    Walks the two independent registries that expose Python callables:
+
+    1. ``CommandRegistry`` (``@webview.command`` / ``commands.register``) —
+       carries the CLI metadata captured at registration time (§6).
+    2. ``_bound_functions`` (``bind_call`` / ``bind_api``) — currently has no
+       per-command CLI metadata, so these are *not* CLI-exposed unless a future
+       opt-in path adds it. They are still iterated here so the single source
+       of truth used by ``-h``/``list`` and ``run`` stays consistent.
+
+    Only commands that opted in via ``cli != False`` are returned. Each entry
+    is the §13.2 overlay structure (name, aliases, help, params).
+
+    Args:
+        webview: The WebView whose registries are inspected.
+
+    Returns:
+        A list of command metadata dicts, ordered by registration.
+    """
+    commands: "list[Dict[str, Any]]" = []
+
+    # 1. CommandRegistry-registered commands with CLI metadata.
+    registry = getattr(webview, "_commands", None)
+    if registry is not None:
+        for name in registry.list_cli_commands():
+            meta = registry.cli_meta(name)
+            func = registry._commands.get(name)
+            if meta is None or func is None:
+                continue
+            commands.append(meta.to_dict(func))
+
+    return commands
+
+
+def collect_cli_commands(webview: "WebView") -> "list[Dict[str, Any]]":
+    """Build the full CLI command table for pack-time embedding (§13.3).
+
+    Thin wrapper over :func:`iter_cli_commands` kept as the named entry point
+    referenced by the RFC; future deduplication/normalization across the two
+    registries lives here.
+    """
+    return iter_cli_commands(webview)
+
+
+def dump_cli_metadata(webview: "WebView") -> None:
+    """Serialize CLI command metadata to stdout and exit (RFC 0018 §13.3).
+
+    Called at *pack time* (under ``AURORAVIEW_CLI_DUMP=1``) after the entry
+    point builds the WebView/commands but before ``show()`` would open a
+    window. Writes a single ``{"type": "cli_metadata", "commands": [...]}``
+    JSON object so the packer can embed it into the overlay, then exits 0.
+
+    The window/JSON-RPC server is never started in this mode.
+    """
+    table = collect_cli_commands(webview)
+    payload = {"type": "cli_metadata", "commands": table}
+    # Write directly to stdout (not the StdioWriter pipe-detection path) so the
+    # packer subprocess captures clean JSON regardless of packed-mode state.
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
 
 
 def run_api_server(webview: "WebView") -> None:

--- a/scripts/unsafe_allowlist.txt
+++ b/scripts/unsafe_allowlist.txt
@@ -7,6 +7,7 @@
 # path without explaining why safe Rust cannot express that boundary.
 
 crates/auroraview-browser/src/browser.rs | 3 | Win32 child window enumeration callback and HWND FFI for browser embedding.
+crates/auroraview-cli/src/packed/console.rs | 2 | Win32 console attach (AttachConsole/SetConsoleOutputCP) and std stream reopen (CreateFileW/SetStdHandle) for packed headless CLI stdio.
 crates/auroraview-cli/src/packed/mod.rs | 1 | Windows handle and process setup for packed executable launch.
 crates/auroraview-cli/src/packed/warmup.rs | 2 | Optional Windows WebView2 DLL warmup through dynamically loaded native symbols.
 crates/auroraview-cli/tests/packed_env_var_tests.rs | 4 | Forward-compatible env-var mutation for Rust 2024 edition; serialized via Mutex per std::env::set_var safety contract.

--- a/tests/python/unit/test_cli_invoke.py
+++ b/tests/python/unit/test_cli_invoke.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2025 Long Hao
+# Licensed under the MIT License
+"""Unit tests for headless CLI invoke (RFC 0018 §7 / §15.2).
+
+Covers argument parsing (positional, ``--key value``, mixed, bool flags, type
+coercion, JSON), command lookup across both registries, and the §4.4 exit
+codes.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from unittest.mock import patch
+
+from auroraview.core.cli_invoke import (
+    EXIT_COMMAND_ERROR,
+    EXIT_OK,
+    EXIT_USAGE,
+    _parse_args,
+    _UsageError,
+    run_cli_invoke,
+)
+from auroraview.core.commands import CommandError, CommandErrorCode, CommandRegistry
+
+
+class _FakeWebView:
+    """Minimal stand-in exposing the two registries used by §15.2 lookup."""
+
+    def __init__(self, registry=None, bound=None):
+        self._commands = registry
+        self._bound_functions = bound or {}
+
+
+def _registry_webview():
+    wv = _FakeWebView(registry=CommandRegistry())
+    return wv
+
+
+class TestArgParsing:
+    """Test _parse_args (§6.3)."""
+
+    def test_keyword_args(self):
+        def export(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        assert _parse_args(export, ["--path", "./out", "--dpi", "600"]) == {
+            "path": "./out",
+            "dpi": 600,
+        }
+
+    def test_positional_args(self):
+        def export(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        assert _parse_args(export, ["./out", "600"]) == {"path": "./out", "dpi": 600}
+
+    def test_mixed_positional_then_keyword(self):
+        def export(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        assert _parse_args(export, ["./out", "--dpi", "600"]) == {
+            "path": "./out",
+            "dpi": 600,
+        }
+
+    def test_positional_after_keyword_is_error(self):
+        def export(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        try:
+            _parse_args(export, ["--dpi", "600", "./out"])
+        except _UsageError as exc:
+            assert "must come before" in str(exc)
+        else:
+            raise AssertionError("expected _UsageError")
+
+    def test_double_assignment_is_error(self):
+        def export(path: str) -> dict:
+            return {}
+
+        try:
+            _parse_args(export, ["./out", "--path", "./other"])
+        except _UsageError as exc:
+            assert "both positionally" in str(exc)
+        else:
+            raise AssertionError("expected _UsageError")
+
+    def test_unknown_option_is_error(self):
+        def export(path: str) -> dict:
+            return {}
+
+        try:
+            _parse_args(export, ["--unknown", "x"])
+        except _UsageError as exc:
+            assert "unknown option" in str(exc)
+        else:
+            raise AssertionError("expected _UsageError")
+
+    def test_missing_required_is_error(self):
+        def export(path: str) -> dict:
+            return {}
+
+        try:
+            _parse_args(export, [])
+        except _UsageError as exc:
+            assert "missing required" in str(exc)
+        else:
+            raise AssertionError("expected _UsageError")
+
+    def test_too_many_positionals_is_error(self):
+        def export(path: str) -> dict:
+            return {}
+
+        try:
+            _parse_args(export, ["a", "b"])
+        except _UsageError as exc:
+            assert "too many positional" in str(exc)
+        else:
+            raise AssertionError("expected _UsageError")
+
+    def test_bool_flag_true(self):
+        def sync(force: bool = False) -> dict:
+            return {}
+
+        assert _parse_args(sync, ["--force"]) == {"force": True}
+
+    def test_bool_flag_no_prefix_false(self):
+        def sync(force: bool = True) -> dict:
+            return {}
+
+        assert _parse_args(sync, ["--no-force"]) == {"force": False}
+
+    def test_bool_positional_parses_truthy(self):
+        def sync(force: bool = False) -> dict:
+            return {}
+
+        assert _parse_args(sync, ["true"]) == {"force": True}
+        assert _parse_args(sync, ["0"]) == {"force": False}
+
+    def test_float_coercion(self):
+        def scale(factor: float) -> dict:
+            return {}
+
+        assert _parse_args(scale, ["--factor", "1.5"]) == {"factor": 1.5}
+
+    def test_int_coercion_error(self):
+        def export(dpi: int) -> dict:
+            return {}
+
+        try:
+            _parse_args(export, ["--dpi", "abc"])
+        except _UsageError as exc:
+            assert "expected int" in str(exc)
+        else:
+            raise AssertionError("expected _UsageError")
+
+    def test_json_for_complex_annotation(self):
+        def configure(config: dict) -> dict:
+            return {}
+
+        assert _parse_args(configure, ["--config", '{"a": 1}']) == {"config": {"a": 1}}
+
+    def test_unannotated_stays_string(self):
+        def echo(value) -> dict:
+            return {}
+
+        assert _parse_args(echo, ["--value", "hello"]) == {"value": "hello"}
+
+
+class TestRunCliInvoke:
+    """Test run_cli_invoke end-to-end (lookup + invoke + exit code)."""
+
+    def test_invokes_registry_command(self):
+        wv = _registry_webview()
+
+        @wv._commands.register("export", cli=True)
+        def export(path: str) -> dict:
+            return {"written": path}
+
+        out = StringIO()
+        with patch("sys.stdout", out):
+            code = run_cli_invoke(wv, "export", ["--path", "./out"])
+
+        assert code == EXIT_OK
+        assert json.loads(out.getvalue()) == {"written": "./out"}
+
+    def test_falls_back_to_bound_functions(self):
+        def handler(name: str) -> dict:
+            return {"hello": name}
+
+        wv = _FakeWebView(bound={"greet": handler})
+
+        out = StringIO()
+        with patch("sys.stdout", out):
+            code = run_cli_invoke(wv, "greet", ["--name", "world"])
+
+        assert code == EXIT_OK
+        assert json.loads(out.getvalue()) == {"hello": "world"}
+
+    def test_command_not_found_exit_2(self):
+        wv = _registry_webview()
+
+        err = StringIO()
+        with patch("sys.stderr", err):
+            code = run_cli_invoke(wv, "missing", [])
+
+        assert code == EXIT_USAGE
+        assert "command not found" in err.getvalue()
+
+    def test_usage_error_exit_2(self):
+        wv = _registry_webview()
+
+        @wv._commands.register("export", cli=True)
+        def export(path: str) -> dict:
+            return {}
+
+        err = StringIO()
+        with patch("sys.stderr", err):
+            code = run_cli_invoke(wv, "export", [])  # missing required
+
+        assert code == EXIT_USAGE
+        assert "missing required" in err.getvalue()
+
+    def test_command_exception_exit_1(self):
+        wv = _registry_webview()
+
+        @wv._commands.register("boom", cli=True)
+        def boom() -> dict:
+            raise ValueError("kaboom")
+
+        err = StringIO()
+        with patch("sys.stderr", err):
+            code = run_cli_invoke(wv, "boom", [])
+
+        assert code == EXIT_COMMAND_ERROR
+        payload = json.loads(err.getvalue())
+        assert payload["error"]["name"] == "ValueError"
+        assert "kaboom" in payload["error"]["message"]
+
+    def test_command_error_reuses_code(self):
+        wv = _registry_webview()
+
+        @wv._commands.register("denied", cli=True)
+        def denied() -> dict:
+            raise CommandError(CommandErrorCode.PERMISSION_DENIED, "nope")
+
+        err = StringIO()
+        with patch("sys.stderr", err):
+            code = run_cli_invoke(wv, "denied", [])
+
+        assert code == EXIT_COMMAND_ERROR
+        payload = json.loads(err.getvalue())
+        assert payload["error"]["name"] == "PERMISSION_DENIED"
+        assert payload["error"]["message"] == "nope"

--- a/tests/python/unit/test_cli_invoke.py
+++ b/tests/python/unit/test_cli_invoke.py
@@ -185,18 +185,51 @@ class TestRunCliInvoke:
         assert code == EXIT_OK
         assert json.loads(out.getvalue()) == {"written": "./out"}
 
-    def test_falls_back_to_bound_functions(self):
-        def handler(name: str) -> dict:
-            return {"hello": name}
+    def test_invokes_by_alias(self):
+        wv = _registry_webview()
 
-        wv = _FakeWebView(bound={"greet": handler})
+        @wv._commands.register("export", cli=["exp", "e"])
+        def export(path: str) -> dict:
+            return {"written": path}
 
         out = StringIO()
         with patch("sys.stdout", out):
-            code = run_cli_invoke(wv, "greet", ["--name", "world"])
+            code = run_cli_invoke(wv, "exp", ["--path", "./out"])
 
         assert code == EXIT_OK
-        assert json.loads(out.getvalue()) == {"hello": "world"}
+        assert json.loads(out.getvalue()) == {"written": "./out"}
+
+    def test_non_cli_command_is_not_resolvable(self):
+        # Registered but NOT CLI-exposed (cli defaults to False): a hand-set
+        # AURORAVIEW_CLI_INVOKE must not be able to reach it (defense in depth,
+        # mirroring the Rust resolve_command gate).
+        wv = _registry_webview()
+
+        @wv._commands.register("internal")
+        def internal() -> dict:
+            return {"ran": True}
+
+        err = StringIO()
+        with patch("sys.stderr", err):
+            code = run_cli_invoke(wv, "internal", [])
+
+        assert code == EXIT_USAGE
+        assert "command not found" in err.getvalue()
+
+    def test_bound_functions_are_not_cli_resolvable(self):
+        # bind_call/bind_api handlers carry no CLI metadata, so they are never
+        # CLI-exposed and must not be invocable via the headless CLI path.
+        def handler(name: str) -> dict:
+            return {"hello": name}
+
+        wv = _FakeWebView(registry=CommandRegistry(), bound={"greet": handler})
+
+        err = StringIO()
+        with patch("sys.stderr", err):
+            code = run_cli_invoke(wv, "greet", ["--name", "world"])
+
+        assert code == EXIT_USAGE
+        assert "command not found" in err.getvalue()
 
     def test_command_not_found_exit_2(self):
         wv = _registry_webview()

--- a/tests/python/unit/test_commands.py
+++ b/tests/python/unit/test_commands.py
@@ -440,6 +440,61 @@ class TestCliRegistration:
                 pass
 
 
+class TestCommandRegisteredEmitSuppression:
+    """RFC 0018 §7/§13.3: __command_registered__ must not hit stdout in the
+    headless CLI modes, where stdout is reserved for the command result /
+    metadata table and there is no front-end to consume the event."""
+
+    def _registry_with_fake_webview(self):
+        class FakeWebView:
+            def __init__(self) -> None:
+                self.events: list = []
+
+            def emit(self, name, data) -> None:
+                self.events.append((name, data))
+
+        registry = CommandRegistry()
+        webview = FakeWebView()
+        registry._webview = webview
+        return registry, webview
+
+    def test_emits_registration_event_in_normal_mode(self):
+        """Outside headless CLI mode the front-end still gets the event."""
+        registry, webview = self._registry_with_fake_webview()
+
+        @registry.register("greet", cli=True)
+        def greet(name: str) -> str:
+            return name
+
+        assert [e[0] for e in webview.events] == ["__command_registered__"]
+
+    def test_suppressed_in_cli_invoke_mode(self, monkeypatch):
+        """cli invoke mode skips the emit so stdout stays clean."""
+        import auroraview.core.commands as commands_mod
+
+        monkeypatch.setattr(commands_mod, "_is_headless_cli_mode", lambda: True)
+        registry, webview = self._registry_with_fake_webview()
+
+        @registry.register("greet", cli=True)
+        def greet(name: str) -> str:
+            return name
+
+        assert webview.events == []
+
+    def test_helper_reads_packed_flags(self, monkeypatch):
+        """_is_headless_cli_mode reflects the packed invoke/dump flags."""
+        import auroraview.core.packed as packed
+
+        monkeypatch.setattr(packed, "CLI_INVOKE_COMMAND", "get-time")
+        monkeypatch.setattr(packed, "CLI_DUMP_MODE", False)
+        from auroraview.core.commands import _is_headless_cli_mode
+
+        assert _is_headless_cli_mode() is True
+
+        monkeypatch.setattr(packed, "CLI_INVOKE_COMMAND", None)
+        assert _is_headless_cli_mode() is False
+
+
 class TestCliParamIntrospection:
     """Test CliCommandMeta parameter introspection (§13.2)."""
 

--- a/tests/python/unit/test_commands.py
+++ b/tests/python/unit/test_commands.py
@@ -345,3 +345,309 @@ class TestCommandRegistryAsync:
         )
 
         assert result["result"] == 3
+
+
+class TestCliRegistration:
+    """Test RFC 0018 CLI decorator metadata (cli / help / args_help)."""
+
+    def test_cli_false_default_not_exposed(self):
+        """A command without `cli` is not CLI-exposed."""
+        registry = CommandRegistry()
+
+        @registry.register
+        def plain(x: int) -> int:
+            return x
+
+        assert registry.cli_meta("plain") is None
+        assert registry.list_cli_commands() == []
+
+    def test_cli_true_no_alias(self):
+        """cli=True exposes the command with no aliases."""
+        registry = CommandRegistry()
+
+        @registry.register("sync", cli=True)
+        def sync_cmd() -> None:
+            """Sync everything."""
+
+        meta = registry.cli_meta("sync")
+        assert meta is not None
+        assert meta.aliases == []
+        assert meta.help == "Sync everything."
+
+    def test_cli_str_alias(self):
+        """cli='exi' exposes the command with a single alias."""
+        registry = CommandRegistry()
+
+        @registry.register("export-image", cli="exi", help="Export image")
+        def export_image(path: str, dpi: int = 300) -> dict:
+            return {"path": path, "dpi": dpi}
+
+        meta = registry.cli_meta("export-image")
+        assert meta.aliases == ["exi"]
+        assert meta.help == "Export image"
+
+    def test_cli_list_aliases(self):
+        """cli=['val','v'] exposes multiple aliases."""
+        registry = CommandRegistry()
+
+        @registry.register("validate", cli=["val", "v"])
+        def validate() -> bool:
+            return True
+
+        assert registry.cli_meta("validate").aliases == ["val", "v"]
+
+    def test_help_falls_back_to_docstring(self):
+        """Help text defaults to the docstring first non-empty line."""
+        registry = CommandRegistry()
+
+        @registry.register("doc", cli=True)
+        def doc_cmd() -> None:
+            """First line of help.
+
+            More detail here.
+            """
+
+        assert registry.cli_meta("doc").help == "First line of help."
+
+    def test_help_empty_when_no_doc_no_help(self):
+        """Help is empty string when neither help= nor docstring present."""
+        registry = CommandRegistry()
+
+        @registry.register("nodoc", cli=True)
+        def nodoc_cmd() -> None:
+            pass
+
+        assert registry.cli_meta("nodoc").help == ""
+
+    def test_invalid_cli_value_raises(self):
+        """A non-bool/str/list cli value raises ValueError."""
+        registry = CommandRegistry()
+
+        with pytest.raises(ValueError):
+
+            @registry.register("bad", cli=123)
+            def bad_cmd() -> None:
+                pass
+
+    def test_empty_alias_raises(self):
+        """A blank alias string raises ValueError."""
+        registry = CommandRegistry()
+
+        with pytest.raises(ValueError):
+
+            @registry.register("blank", cli="   ")
+            def blank_cmd() -> None:
+                pass
+
+
+class TestCliParamIntrospection:
+    """Test CliCommandMeta parameter introspection (§13.2)."""
+
+    def test_params_types_defaults_required(self):
+        registry = CommandRegistry()
+
+        @registry.register(
+            "exi",
+            cli=True,
+            args_help={"path": "output dir", "dpi": "resolution"},
+        )
+        def exi(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        meta = registry.cli_meta("exi")
+        params = meta.params(registry._commands["exi"])
+        assert params == [
+            {"name": "path", "type": "str", "required": True, "default": None, "help": "output dir"},
+            {"name": "dpi", "type": "int", "required": False, "default": 300, "help": "resolution"},
+        ]
+
+    def test_params_unannotated_is_any(self):
+        registry = CommandRegistry()
+
+        @registry.register("anyp", cli=True)
+        def anyp(x) -> None:
+            pass
+
+        params = registry.cli_meta("anyp").params(registry._commands["anyp"])
+        assert params[0]["type"] == "any"
+
+    def test_to_dict_structure(self):
+        registry = CommandRegistry()
+
+        @registry.register("export-image", cli="exi", help="Export image")
+        def export_image(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        meta = registry.cli_meta("export-image")
+        d = meta.to_dict(registry._commands["export-image"])
+        assert d["name"] == "export-image"
+        assert d["aliases"] == ["exi"]
+        assert d["help"] == "Export image"
+        assert len(d["params"]) == 2
+
+
+class TestCliAliasConflicts:
+    """Test fail-fast alias conflict detection (§12.4)."""
+
+    def test_alias_collides_with_reserved_verb(self):
+        registry = CommandRegistry()
+
+        with pytest.raises(ValueError, match="reserved CLI verb"):
+
+            @registry.register("export", cli="run")
+            def export() -> None:
+                pass
+
+    def test_alias_collides_with_command_name(self):
+        registry = CommandRegistry()
+
+        @registry.register("validate", cli=True)
+        def validate() -> None:
+            pass
+
+        with pytest.raises(ValueError, match="collides with command name"):
+
+            @registry.register("export", cli="validate")
+            def export() -> None:
+                pass
+
+    def test_alias_collides_with_other_alias(self):
+        registry = CommandRegistry()
+
+        @registry.register("validate", cli="v")
+        def validate() -> None:
+            pass
+
+        with pytest.raises(ValueError, match="already used by command"):
+
+            @registry.register("verify", cli="v")
+            def verify() -> None:
+                pass
+
+    def test_duplicate_alias_in_same_command(self):
+        registry = CommandRegistry()
+
+        with pytest.raises(ValueError, match="duplicate alias"):
+
+            @registry.register("export", cli=["e", "e"])
+            def export() -> None:
+                pass
+
+    def test_reregister_same_command_allowed(self):
+        """Re-registering a command's own name/alias is not a conflict."""
+        registry = CommandRegistry()
+
+        @registry.register("export", cli="exp")
+        def export_v1() -> None:
+            pass
+
+        # Re-register same name + same alias: should not raise.
+        @registry.register("export", cli="exp")
+        def export_v2() -> None:
+            pass
+
+        assert registry.cli_meta("export").aliases == ["exp"]
+
+
+class TestEnableCli:
+    """Test batch CLI enablement (§14.2)."""
+
+    def test_enable_cli_names_only(self):
+        registry = CommandRegistry()
+
+        @registry.register("export")
+        def export() -> None:
+            pass
+
+        @registry.register("validate")
+        def validate() -> None:
+            pass
+
+        registry.enable_cli("export", "validate")
+        assert set(registry.list_cli_commands()) == {"export", "validate"}
+        assert registry.cli_meta("export").aliases == []
+
+    def test_enable_cli_with_aliases(self):
+        registry = CommandRegistry()
+
+        @registry.register("export")
+        def export() -> None:
+            pass
+
+        registry.enable_cli({"export": "exp"})
+        assert registry.cli_meta("export").aliases == ["exp"]
+
+    def test_enable_cli_unknown_command_raises(self):
+        registry = CommandRegistry()
+
+        with pytest.raises(KeyError):
+            registry.enable_cli("nope")
+
+    def test_unregister_clears_cli_meta(self):
+        registry = CommandRegistry()
+
+        @registry.register("export", cli="exp")
+        def export() -> None:
+            pass
+
+        assert registry.cli_meta("export") is not None
+        registry.unregister("export")
+        assert registry.cli_meta("export") is None
+
+
+class TestCommandDecoratorMixin:
+    """Test the public @webview.command decorator path (RFC 0018 §6.2)."""
+
+    def _webview(self):
+        from auroraview.core.mixins.commands import WebViewCommandsMixin
+
+        class _FakeWebView(WebViewCommandsMixin):
+            def __init__(self):
+                self._commands = None
+
+            def emit(self, *args, **kwargs):
+                pass
+
+        return _FakeWebView()
+
+    def test_bare_decorator_legacy(self):
+        wv = self._webview()
+
+        @wv.command
+        def greet(name: str) -> str:
+            return name
+
+        assert "greet" in wv.commands
+        assert wv.commands.cli_meta("greet") is None
+
+    def test_positional_name_legacy(self):
+        wv = self._webview()
+
+        @wv.command("add")
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        assert wv.commands.invoke("add", x=2, y=3) == 5
+
+    def test_name_keyword_with_cli(self):
+        wv = self._webview()
+
+        @wv.command(name="export", cli="exp", help="Export data", args_help={"path": "out dir"})
+        def export(path: str, dpi: int = 300) -> dict:
+            return {"path": path}
+
+        meta = wv.commands.cli_meta("export")
+        assert meta is not None
+        assert meta.aliases == ["exp"]
+        assert meta.help == "Export data"
+        assert "export" in wv.commands
+        assert wv.commands.invoke("export", path="/tmp")["path"] == "/tmp"
+
+    def test_cli_true_no_name(self):
+        wv = self._webview()
+
+        @wv.command(cli=True)
+        def sync() -> None:
+            """Sync it."""
+
+        assert wv.commands.cli_meta("sync").help == "Sync it."

--- a/tests/python/unit/test_commands.py
+++ b/tests/python/unit/test_commands.py
@@ -532,7 +532,13 @@ class TestCliParamIntrospection:
         meta = registry.cli_meta("exi")
         params = meta.params(registry._commands["exi"])
         assert params == [
-            {"name": "path", "type": "str", "required": True, "default": None, "help": "output dir"},
+            {
+                "name": "path",
+                "type": "str",
+                "required": True,
+                "default": None,
+                "help": "output dir",
+            },
             {"name": "dpi", "type": "int", "required": False, "default": 300, "help": "resolution"},
         ]
 
@@ -590,8 +596,6 @@ class TestCliParamIntrospection:
             side_effect=ValueError("no signature"),
         ):
             assert meta.params(builtin_wrap) == []
-
-
 
     def test_to_dict_structure(self):
         registry = CommandRegistry()

--- a/tests/python/unit/test_commands.py
+++ b/tests/python/unit/test_commands.py
@@ -439,6 +439,26 @@ class TestCliRegistration:
             def blank_cmd() -> None:
                 pass
 
+    def test_cli_list_non_str_item_raises(self):
+        """A non-string item inside the cli list raises ValueError."""
+        registry = CommandRegistry()
+
+        with pytest.raises(ValueError, match="cli alias must be a string"):
+
+            @registry.register("bad", cli=["ok", 123])
+            def bad_cmd() -> None:
+                pass
+
+    def test_cli_list_blank_item_raises(self):
+        """A blank string inside the cli list raises ValueError."""
+        registry = CommandRegistry()
+
+        with pytest.raises(ValueError, match="must not be empty"):
+
+            @registry.register("bad", cli=["ok", "  "])
+            def bad_cmd() -> None:
+                pass
+
 
 class TestCommandRegisteredEmitSuppression:
     """RFC 0018 §7/§13.3: __command_registered__ must not hit stdout in the
@@ -525,6 +545,53 @@ class TestCliParamIntrospection:
 
         params = registry.cli_meta("anyp").params(registry._commands["anyp"])
         assert params[0]["type"] == "any"
+
+    def test_params_non_type_annotation_uses_str_repr(self):
+        """A typing construct (not a plain class) falls back to str()."""
+        from typing import Optional
+
+        registry = CommandRegistry()
+
+        @registry.register("opt", cli=True)
+        def opt(x: Optional[str] = None) -> None:
+            pass
+
+        params = registry.cli_meta("opt").params(registry._commands["opt"])
+        assert params[0]["name"] == "x"
+        # Optional[str] is not a bare ``type``; the introspector stringifies it.
+        assert "str" in params[0]["type"]
+
+    def test_params_skips_var_args_and_self(self):
+        """*args/**kwargs and self are excluded from the param table."""
+        registry = CommandRegistry()
+
+        @registry.register("varp", cli=True)
+        def varp(self, a: int, *args, **kwargs) -> None:
+            pass
+
+        params = registry.cli_meta("varp").params(registry._commands["varp"])
+        assert [p["name"] for p in params] == ["a"]
+
+    def test_params_empty_on_uninspectable_callable(self):
+        """A callable whose signature can't be read yields an empty table."""
+        registry = CommandRegistry()
+
+        @registry.register("builtin", cli=True)
+        def builtin_wrap() -> None:
+            pass
+
+        meta = registry.cli_meta("builtin")
+
+        # Force inspect.signature to raise to exercise the defensive guard.
+        from unittest.mock import patch
+
+        with patch(
+            "auroraview.core.commands.inspect.signature",
+            side_effect=ValueError("no signature"),
+        ):
+            assert meta.params(builtin_wrap) == []
+
+
 
     def test_to_dict_structure(self):
         registry = CommandRegistry()
@@ -637,6 +704,28 @@ class TestEnableCli:
 
         with pytest.raises(KeyError):
             registry.enable_cli("nope")
+
+    def test_enable_cli_invalid_arg_type_raises(self):
+        registry = CommandRegistry()
+
+        @registry.register("export")
+        def export() -> None:
+            pass
+
+        with pytest.raises(ValueError, match="enable_cli arguments must be str or dict"):
+            registry.enable_cli(123)
+
+    def test_enable_cli_disabled_value_skips(self):
+        registry = CommandRegistry()
+
+        @registry.register("export")
+        def export() -> None:
+            pass
+
+        # A dict value of False normalizes to "not enabled" -> command stays
+        # off the CLI table without raising.
+        registry.enable_cli({"export": False})
+        assert "export" not in registry.list_cli_commands()
 
     def test_unregister_clears_cli_meta(self):
         registry = CommandRegistry()

--- a/tests/python/unit/test_lifecycle_dispatch.py
+++ b/tests/python/unit/test_lifecycle_dispatch.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2025 Long Hao
+# Licensed under the MIT License
+"""Unit tests for WebView.show() mode dispatch (RFC 0018 §7 / §13.3).
+
+The ``show()`` method short-circuits before any window/server work when the
+process is running under one of the packed-mode env switches:
+
+* ``AURORAVIEW_CLI_DUMP=1``    -> dump CLI metadata and return (§13.3)
+* ``AURORAVIEW_CLI_INVOKE=...`` -> run one command headlessly and return (§7)
+* ``AURORAVIEW_PACKED=1``       -> serve JSON-RPC over stdio
+
+These tests drive the real :meth:`WebViewLifecycleMixin.show` dispatch on a
+bare mixin instance so the branch logic itself is exercised, with the packed
+module functions patched to observe which path was taken.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from auroraview.core.mixins.lifecycle import WebViewLifecycleMixin
+
+
+class _Mixin(WebViewLifecycleMixin):
+    """Minimal carrier so ``show()`` can be invoked without a real core."""
+
+    def __init__(self) -> None:
+        self._core = None
+        self._parent = None
+
+
+def _patch_packed(**flags):
+    """Patch the packed-module functions imported inside ``show()``.
+
+    ``flags`` overrides the default (all modes off) return values. Returns a
+    dict of started mocks keyed by the function name.
+    """
+    defaults = {
+        "is_cli_dump_mode": False,
+        "is_cli_invoke_mode": False,
+        "is_packed_mode": False,
+    }
+    defaults.update(flags)
+    patchers = {}
+    mocks = {}
+    for name, ret in defaults.items():
+        p = patch(f"auroraview.core.packed.{name}", return_value=ret)
+        mocks[name] = p.start()
+        patchers[name] = p
+    for action in ("dump_cli_metadata", "invoke_cli_command", "run_api_server"):
+        p = patch(f"auroraview.core.packed.{action}")
+        mocks[action] = p.start()
+        patchers[action] = p
+    return patchers, mocks
+
+
+def _stop(patchers):
+    for p in patchers.values():
+        p.stop()
+
+
+class TestShowDispatch:
+    """show() routes to the correct headless handler per env mode."""
+
+    def test_cli_dump_mode_dumps_and_returns(self):
+        patchers, mocks = _patch_packed(is_cli_dump_mode=True)
+        try:
+            wv = _Mixin()
+            wv.show()
+            mocks["dump_cli_metadata"].assert_called_once_with(wv)
+            mocks["invoke_cli_command"].assert_not_called()
+            mocks["run_api_server"].assert_not_called()
+        finally:
+            _stop(patchers)
+
+    def test_cli_invoke_mode_invokes_and_returns(self):
+        patchers, mocks = _patch_packed(is_cli_invoke_mode=True)
+        try:
+            wv = _Mixin()
+            wv.show()
+            mocks["invoke_cli_command"].assert_called_once_with(wv)
+            mocks["dump_cli_metadata"].assert_not_called()
+            mocks["run_api_server"].assert_not_called()
+        finally:
+            _stop(patchers)
+
+    def test_packed_mode_runs_api_server(self):
+        patchers, mocks = _patch_packed(is_packed_mode=True)
+        try:
+            wv = _Mixin()
+            wv.show()
+            mocks["run_api_server"].assert_called_once_with(wv)
+            mocks["dump_cli_metadata"].assert_not_called()
+            mocks["invoke_cli_command"].assert_not_called()
+        finally:
+            _stop(patchers)
+
+    def test_cli_dump_takes_priority_over_invoke_and_packed(self):
+        """§13.3 dump short-circuits before invoke/packed checks."""
+        patchers, mocks = _patch_packed(
+            is_cli_dump_mode=True,
+            is_cli_invoke_mode=True,
+            is_packed_mode=True,
+        )
+        try:
+            wv = _Mixin()
+            wv.show()
+            mocks["dump_cli_metadata"].assert_called_once_with(wv)
+            mocks["invoke_cli_command"].assert_not_called()
+            mocks["run_api_server"].assert_not_called()
+        finally:
+            _stop(patchers)
+
+    def test_cli_invoke_takes_priority_over_packed(self):
+        """§7 invoke short-circuits before the packed API-server path."""
+        patchers, mocks = _patch_packed(
+            is_cli_invoke_mode=True,
+            is_packed_mode=True,
+        )
+        try:
+            wv = _Mixin()
+            wv.show()
+            mocks["invoke_cli_command"].assert_called_once_with(wv)
+            mocks["run_api_server"].assert_not_called()
+        finally:
+            _stop(patchers)

--- a/tests/python/unit/test_packed.py
+++ b/tests/python/unit/test_packed.py
@@ -15,8 +15,6 @@ from io import StringIO
 from typing import Any, Callable, Dict
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestIsPackedMode:
     """Test is_packed_mode() function."""
@@ -580,9 +578,7 @@ class TestInvokeCliCommand:
         with patch.object(packed_module, "CLI_INVOKE_COMMAND", "greet"), patch.dict(
             os.environ, {"AURORAVIEW_CLI_ARGS": '["world"]'}
         ):
-            with patch(
-                "auroraview.core.cli_invoke.run_cli_invoke", return_value=0
-            ) as mock_run:
+            with patch("auroraview.core.cli_invoke.run_cli_invoke", return_value=0) as mock_run:
                 with __import__("pytest").raises(SystemExit) as exc:
                     packed_module.invoke_cli_command(wv)
         assert exc.value.code == 0
@@ -595,9 +591,7 @@ class TestInvokeCliCommand:
         with patch.object(packed_module, "CLI_INVOKE_COMMAND", "ping"), patch.dict(
             os.environ, {"AURORAVIEW_CLI_ARGS": '{"not": "a list"}'}
         ):
-            with patch(
-                "auroraview.core.cli_invoke.run_cli_invoke", return_value=2
-            ) as mock_run:
+            with patch("auroraview.core.cli_invoke.run_cli_invoke", return_value=2) as mock_run:
                 with __import__("pytest").raises(SystemExit) as exc:
                     packed_module.invoke_cli_command(wv)
         assert exc.value.code == 2
@@ -610,9 +604,7 @@ class TestInvokeCliCommand:
         with patch.object(packed_module, "CLI_INVOKE_COMMAND", "ping"), patch.dict(
             os.environ, {"AURORAVIEW_CLI_ARGS": "not-json"}
         ):
-            with patch(
-                "auroraview.core.cli_invoke.run_cli_invoke", return_value=1
-            ) as mock_run:
+            with patch("auroraview.core.cli_invoke.run_cli_invoke", return_value=1) as mock_run:
                 with __import__("pytest").raises(SystemExit) as exc:
                     packed_module.invoke_cli_command(wv)
         assert exc.value.code == 1
@@ -625,9 +617,7 @@ class TestInvokeCliCommand:
         with patch.object(packed_module, "CLI_INVOKE_COMMAND", "run"), patch.dict(
             os.environ, {}, clear=True
         ):
-            with patch(
-                "auroraview.core.cli_invoke.run_cli_invoke", return_value=0
-            ) as mock_run:
+            with patch("auroraview.core.cli_invoke.run_cli_invoke", return_value=0) as mock_run:
                 with __import__("pytest").raises(SystemExit):
                     packed_module.invoke_cli_command(wv)
         mock_run.assert_called_once_with(wv, "run", [])
@@ -639,9 +629,7 @@ class TestInvokeCliCommand:
         with patch.object(packed_module, "CLI_INVOKE_COMMAND", None), patch.dict(
             os.environ, {"AURORAVIEW_CLI_ARGS": "[]"}
         ):
-            with patch(
-                "auroraview.core.cli_invoke.run_cli_invoke", return_value=2
-            ) as mock_run:
+            with patch("auroraview.core.cli_invoke.run_cli_invoke", return_value=2) as mock_run:
                 with __import__("pytest").raises(SystemExit):
                     packed_module.invoke_cli_command(wv)
         mock_run.assert_called_once_with(wv, "", [])
@@ -653,9 +641,7 @@ class TestInvokeCliCommand:
         with patch.object(packed_module, "CLI_INVOKE_COMMAND", "calc"), patch.dict(
             os.environ, {"AURORAVIEW_CLI_ARGS": "[1, 2, true]"}
         ):
-            with patch(
-                "auroraview.core.cli_invoke.run_cli_invoke", return_value=0
-            ) as mock_run:
+            with patch("auroraview.core.cli_invoke.run_cli_invoke", return_value=0) as mock_run:
                 with __import__("pytest").raises(SystemExit):
                     packed_module.invoke_cli_command(wv)
         mock_run.assert_called_once_with(wv, "calc", ["1", "2", "True"])
@@ -701,102 +687,3 @@ class TestIsCliDumpMode:
                 assert packed_module.is_cli_dump_mode() is True
             finally:
                 packed_module.CLI_DUMP_MODE = original
-
-
-class TestIsCliInvokeMode:
-    """Test is_cli_invoke_mode() env detection (RFC 0018 §7)."""
-
-    def test_false_when_unset(self, monkeypatch):
-        import auroraview.core.packed as packed_module
-
-        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", None)
-        assert packed_module.is_cli_invoke_mode() is False
-
-    def test_true_when_command_set(self, monkeypatch):
-        import auroraview.core.packed as packed_module
-
-        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "export")
-        assert packed_module.is_cli_invoke_mode() is True
-
-
-class TestInvokeCliCommand:
-    """Test invoke_cli_command() headless dispatch (RFC 0018 §7)."""
-
-    def test_parses_args_and_exits_with_run_code(self, monkeypatch):
-        """Reads command + JSON args, forwards to run_cli_invoke, exits with
-        the returned code."""
-        import auroraview.core.packed as packed_module
-
-        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "export")
-        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", '["./out", "600"]')
-
-        captured: Dict[str, Any] = {}
-
-        def fake_run(webview, command, args):
-            captured["command"] = command
-            captured["args"] = args
-            return 0
-
-        monkeypatch.setattr(
-            "auroraview.core.cli_invoke.run_cli_invoke", fake_run
-        )
-
-        wv = MagicMock()
-        with pytest.raises(SystemExit) as exc:
-            packed_module.invoke_cli_command(wv)
-
-        assert exc.value.code == 0
-        assert captured["command"] == "export"
-        assert captured["args"] == ["./out", "600"]
-
-    def test_propagates_nonzero_exit_code(self, monkeypatch):
-        """A command error (exit 1) from run_cli_invoke is propagated."""
-        import auroraview.core.packed as packed_module
-
-        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "boom")
-        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", "[]")
-        monkeypatch.setattr(
-            "auroraview.core.cli_invoke.run_cli_invoke", lambda *a: 1
-        )
-
-        with pytest.raises(SystemExit) as exc:
-            packed_module.invoke_cli_command(MagicMock())
-        assert exc.value.code == 1
-
-    def test_malformed_args_fall_back_to_empty_list(self, monkeypatch):
-        """Invalid JSON in AURORAVIEW_CLI_ARGS degrades to no args, not a crash."""
-        import auroraview.core.packed as packed_module
-
-        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "ping")
-        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", "not-json{")
-
-        seen: Dict[str, Any] = {}
-
-        def fake_run(webview, command, args):
-            seen["args"] = args
-            return 0
-
-        monkeypatch.setattr(
-            "auroraview.core.cli_invoke.run_cli_invoke", fake_run
-        )
-
-        with pytest.raises(SystemExit):
-            packed_module.invoke_cli_command(MagicMock())
-        assert seen["args"] == []
-
-    def test_non_list_json_args_fall_back_to_empty_list(self, monkeypatch):
-        """A JSON object (not a list) in CLI_ARGS degrades to no args."""
-        import auroraview.core.packed as packed_module
-
-        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "ping")
-        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", '{"a": 1}')
-
-        seen: Dict[str, Any] = {}
-        monkeypatch.setattr(
-            "auroraview.core.cli_invoke.run_cli_invoke",
-            lambda wv, cmd, args: seen.update(args=args) or 0,
-        )
-
-        with pytest.raises(SystemExit):
-            packed_module.invoke_cli_command(MagicMock())
-        assert seen["args"] == []

--- a/tests/python/unit/test_packed.py
+++ b/tests/python/unit/test_packed.py
@@ -15,6 +15,8 @@ from io import StringIO
 from typing import Any, Callable, Dict
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestIsPackedMode:
     """Test is_packed_mode() function."""
@@ -540,6 +542,140 @@ class TestCliMetadataCollection:
         assert payload["commands"][0]["name"] == "export"
         assert payload["commands"][0]["aliases"] == ["exp"]
 
+    def test_iter_skips_command_with_missing_func(self):
+        """A CLI-listed name whose callable vanished is skipped (§13.2 guard)."""
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        reg = wv._commands
+
+        @reg.register("export", cli="exp")
+        def export(path: str) -> dict:
+            return {}
+
+        # Drop the underlying callable while leaving CLI metadata in place.
+        reg._commands.pop("export", None)
+
+        assert packed_module.iter_cli_commands(wv) == []
+
+
+class TestInvokeCliCommand:
+    """Test invoke_cli_command() headless dispatch (RFC 0018 §7)."""
+
+    def _registry_webview(self):
+        from auroraview.core.commands import CommandRegistry
+
+        class _FakeWebView:
+            pass
+
+        wv = _FakeWebView()
+        wv._commands = CommandRegistry()
+        wv._bound_functions = {}
+        return wv
+
+    def test_runs_command_and_exits_with_code(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", "greet"), patch.dict(
+            os.environ, {"AURORAVIEW_CLI_ARGS": '["world"]'}
+        ):
+            with patch(
+                "auroraview.core.cli_invoke.run_cli_invoke", return_value=0
+            ) as mock_run:
+                with __import__("pytest").raises(SystemExit) as exc:
+                    packed_module.invoke_cli_command(wv)
+        assert exc.value.code == 0
+        mock_run.assert_called_once_with(wv, "greet", ["world"])
+
+    def test_non_list_args_become_empty(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", "ping"), patch.dict(
+            os.environ, {"AURORAVIEW_CLI_ARGS": '{"not": "a list"}'}
+        ):
+            with patch(
+                "auroraview.core.cli_invoke.run_cli_invoke", return_value=2
+            ) as mock_run:
+                with __import__("pytest").raises(SystemExit) as exc:
+                    packed_module.invoke_cli_command(wv)
+        assert exc.value.code == 2
+        mock_run.assert_called_once_with(wv, "ping", [])
+
+    def test_invalid_json_args_become_empty(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", "ping"), patch.dict(
+            os.environ, {"AURORAVIEW_CLI_ARGS": "not-json"}
+        ):
+            with patch(
+                "auroraview.core.cli_invoke.run_cli_invoke", return_value=1
+            ) as mock_run:
+                with __import__("pytest").raises(SystemExit) as exc:
+                    packed_module.invoke_cli_command(wv)
+        assert exc.value.code == 1
+        mock_run.assert_called_once_with(wv, "ping", [])
+
+    def test_missing_args_env_defaults_to_empty_list(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", "run"), patch.dict(
+            os.environ, {}, clear=True
+        ):
+            with patch(
+                "auroraview.core.cli_invoke.run_cli_invoke", return_value=0
+            ) as mock_run:
+                with __import__("pytest").raises(SystemExit):
+                    packed_module.invoke_cli_command(wv)
+        mock_run.assert_called_once_with(wv, "run", [])
+
+    def test_none_command_falls_back_to_empty_string(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", None), patch.dict(
+            os.environ, {"AURORAVIEW_CLI_ARGS": "[]"}
+        ):
+            with patch(
+                "auroraview.core.cli_invoke.run_cli_invoke", return_value=2
+            ) as mock_run:
+                with __import__("pytest").raises(SystemExit):
+                    packed_module.invoke_cli_command(wv)
+        mock_run.assert_called_once_with(wv, "", [])
+
+    def test_args_coerced_to_strings(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", "calc"), patch.dict(
+            os.environ, {"AURORAVIEW_CLI_ARGS": "[1, 2, true]"}
+        ):
+            with patch(
+                "auroraview.core.cli_invoke.run_cli_invoke", return_value=0
+            ) as mock_run:
+                with __import__("pytest").raises(SystemExit):
+                    packed_module.invoke_cli_command(wv)
+        mock_run.assert_called_once_with(wv, "calc", ["1", "2", "True"])
+
+
+class TestIsCliInvokeMode:
+    """Test is_cli_invoke_mode() detection (RFC 0018 §7)."""
+
+    def test_false_when_command_none(self):
+        import auroraview.core.packed as packed_module
+
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", None):
+            assert packed_module.is_cli_invoke_mode() is False
+
+    def test_true_when_command_set(self):
+        import auroraview.core.packed as packed_module
+
+        with patch.object(packed_module, "CLI_INVOKE_COMMAND", "greet"):
+            assert packed_module.is_cli_invoke_mode() is True
+
 
 class TestIsCliDumpMode:
     """Test is_cli_dump_mode() env detection."""
@@ -565,3 +701,102 @@ class TestIsCliDumpMode:
                 assert packed_module.is_cli_dump_mode() is True
             finally:
                 packed_module.CLI_DUMP_MODE = original
+
+
+class TestIsCliInvokeMode:
+    """Test is_cli_invoke_mode() env detection (RFC 0018 §7)."""
+
+    def test_false_when_unset(self, monkeypatch):
+        import auroraview.core.packed as packed_module
+
+        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", None)
+        assert packed_module.is_cli_invoke_mode() is False
+
+    def test_true_when_command_set(self, monkeypatch):
+        import auroraview.core.packed as packed_module
+
+        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "export")
+        assert packed_module.is_cli_invoke_mode() is True
+
+
+class TestInvokeCliCommand:
+    """Test invoke_cli_command() headless dispatch (RFC 0018 §7)."""
+
+    def test_parses_args_and_exits_with_run_code(self, monkeypatch):
+        """Reads command + JSON args, forwards to run_cli_invoke, exits with
+        the returned code."""
+        import auroraview.core.packed as packed_module
+
+        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "export")
+        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", '["./out", "600"]')
+
+        captured: Dict[str, Any] = {}
+
+        def fake_run(webview, command, args):
+            captured["command"] = command
+            captured["args"] = args
+            return 0
+
+        monkeypatch.setattr(
+            "auroraview.core.cli_invoke.run_cli_invoke", fake_run
+        )
+
+        wv = MagicMock()
+        with pytest.raises(SystemExit) as exc:
+            packed_module.invoke_cli_command(wv)
+
+        assert exc.value.code == 0
+        assert captured["command"] == "export"
+        assert captured["args"] == ["./out", "600"]
+
+    def test_propagates_nonzero_exit_code(self, monkeypatch):
+        """A command error (exit 1) from run_cli_invoke is propagated."""
+        import auroraview.core.packed as packed_module
+
+        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "boom")
+        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", "[]")
+        monkeypatch.setattr(
+            "auroraview.core.cli_invoke.run_cli_invoke", lambda *a: 1
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            packed_module.invoke_cli_command(MagicMock())
+        assert exc.value.code == 1
+
+    def test_malformed_args_fall_back_to_empty_list(self, monkeypatch):
+        """Invalid JSON in AURORAVIEW_CLI_ARGS degrades to no args, not a crash."""
+        import auroraview.core.packed as packed_module
+
+        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "ping")
+        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", "not-json{")
+
+        seen: Dict[str, Any] = {}
+
+        def fake_run(webview, command, args):
+            seen["args"] = args
+            return 0
+
+        monkeypatch.setattr(
+            "auroraview.core.cli_invoke.run_cli_invoke", fake_run
+        )
+
+        with pytest.raises(SystemExit):
+            packed_module.invoke_cli_command(MagicMock())
+        assert seen["args"] == []
+
+    def test_non_list_json_args_fall_back_to_empty_list(self, monkeypatch):
+        """A JSON object (not a list) in CLI_ARGS degrades to no args."""
+        import auroraview.core.packed as packed_module
+
+        monkeypatch.setattr(packed_module, "CLI_INVOKE_COMMAND", "ping")
+        monkeypatch.setenv("AURORAVIEW_CLI_ARGS", '{"a": 1}')
+
+        seen: Dict[str, Any] = {}
+        monkeypatch.setattr(
+            "auroraview.core.cli_invoke.run_cli_invoke",
+            lambda wv, cmd, args: seen.update(args=args) or 0,
+        )
+
+        with pytest.raises(SystemExit):
+            packed_module.invoke_cli_command(MagicMock())
+        assert seen["args"] == []

--- a/tests/python/unit/test_packed.py
+++ b/tests/python/unit/test_packed.py
@@ -464,3 +464,104 @@ class TestPackedModeIntegration:
         assert error["ok"] is False
         assert "name" in error["error"]
         assert "message" in error["error"]
+
+
+class TestCliMetadataCollection:
+    """Test RFC 0018 CLI metadata collection (iter/collect/dump)."""
+
+    def _registry_webview(self):
+        """Build a lightweight object exposing a real CommandRegistry as
+        `_commands`, mirroring WebView's attribute layout."""
+        from auroraview.core.commands import CommandRegistry
+
+        class _FakeWebView:
+            pass
+
+        wv = _FakeWebView()
+        wv._commands = CommandRegistry()
+        return wv
+
+    def test_iter_collects_only_cli_commands(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+        reg = wv._commands
+
+        @reg.register("export", cli="exp", help="Export data")
+        def export(path: str, dpi: int = 300) -> dict:
+            return {}
+
+        @reg.register("internal")  # not CLI-exposed
+        def internal() -> None:
+            pass
+
+        commands = packed_module.iter_cli_commands(wv)
+        assert len(commands) == 1
+        meta = commands[0]
+        assert meta["name"] == "export"
+        assert meta["aliases"] == ["exp"]
+        assert meta["help"] == "Export data"
+        assert [p["name"] for p in meta["params"]] == ["path", "dpi"]
+
+    def test_iter_empty_when_no_registry(self):
+        import auroraview.core.packed as packed_module
+
+        class _Bare:
+            pass
+
+        assert packed_module.iter_cli_commands(_Bare()) == []
+
+    def test_collect_matches_iter(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+
+        @wv._commands.register("sync", cli=True)
+        def sync() -> None:
+            pass
+
+        assert packed_module.collect_cli_commands(wv) == packed_module.iter_cli_commands(wv)
+
+    def test_dump_cli_metadata_writes_json(self):
+        import auroraview.core.packed as packed_module
+
+        wv = self._registry_webview()
+
+        @wv._commands.register("export", cli="exp")
+        def export(path: str) -> dict:
+            return {}
+
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            packed_module.dump_cli_metadata(wv)
+
+        payload = json.loads(buf.getvalue())
+        assert payload["type"] == "cli_metadata"
+        assert payload["commands"][0]["name"] == "export"
+        assert payload["commands"][0]["aliases"] == ["exp"]
+
+
+class TestIsCliDumpMode:
+    """Test is_cli_dump_mode() env detection."""
+
+    def test_false_when_unset(self):
+        with patch.dict(os.environ, {}, clear=True):
+            import auroraview.core.packed as packed_module
+
+            original = packed_module.CLI_DUMP_MODE
+            packed_module.CLI_DUMP_MODE = os.environ.get("AURORAVIEW_CLI_DUMP", "0") == "1"
+            try:
+                assert packed_module.is_cli_dump_mode() is False
+            finally:
+                packed_module.CLI_DUMP_MODE = original
+
+    def test_true_when_one(self):
+        with patch.dict(os.environ, {"AURORAVIEW_CLI_DUMP": "1"}):
+            import auroraview.core.packed as packed_module
+
+            original = packed_module.CLI_DUMP_MODE
+            packed_module.CLI_DUMP_MODE = os.environ.get("AURORAVIEW_CLI_DUMP", "0") == "1"
+            try:
+                assert packed_module.is_cli_dump_mode() is True
+            finally:
+                packed_module.CLI_DUMP_MODE = original


### PR DESCRIPTION
## Summary

Add headless CLI mode to AuroraView's packed executables (RFC 0018): the same
packed exe opens its GUI on double-click yet runs `@command(cli=...)` commands
straight from a terminal via `app.exe run <name>` / `list` / `-h`. CLI metadata
is embedded into the pack overlay at build time, so help/list render with zero
Python startup and `run` invokes the command in a one-shot process.

24 commits · 33 files · **additive** (no public API change for existing GUI/JS callers).

## Key changes

### `crates/auroraview-cli/src/packed/` (new) — packed CLI runtime

- `cli.rs`: `classify_packed_invocation()` routes argv to GUI vs headless CLI,
  triggering CLI only on reserved verbs/flags (`run`/`list`/`-h`/`-V`) so
  file-association and drag-drop launches stay GUI.
- `render.rs`: renders `-h` / `list` / `list --json` purely from the embedded
  overlay table.
- `run.rs`: resolves alias, extracts the runtime (shared hash cache), and
  invokes the command in a one-shot process.
- `console.rs`: `attach_parent_console()` reconnects stdio to the launching
  terminal (Windows) and sets the console code page to UTF-8; no-op elsewhere.
- Help/error text and the headless command lookup use the real pack-time exe
  name and are gated on actual CLI exposure.

### `crates/auroraview-pack/` — pack-time metadata dump & .cmd shim

- `cli_dump.rs` (new): runs the bundled entry point with `AURORAVIEW_CLI_DUMP=1`
  to harvest CLI command metadata into the overlay. Best-effort: skips on
  cross-platform packing or non-standalone strategy; hard-fails only on alias
  conflict (§12.4).
- `config.rs`: new `CliCommandMeta` / `CliParamMeta` types and a `cli_commands`
  field on `PackConfig`.
- `builder/win.rs`: writes a `<name>.cmd` shim beside a GUI-subsystem exe that
  runs it via `start /wait`, so terminals block synchronously and exit codes
  propagate. Best-effort — a write failure only logs.

### `python/auroraview/core/` — CLI metadata & invocation

- `commands.py`: `@webview.command` / `register()` gain `cli` (`False`/`True`/
  `str`/`list`), `help`, and `args_help`, with fail-fast alias conflict
  detection and a batch `enable_cli()`. Metadata lives in a parallel map so the
  JS path is untouched; legacy decorator styles still work.
- `cli_invoke.py` (new): Python-side arg parsing (positional + `--key value`,
  bool flags, type coercion, JSON, PEP 563 string annotations) with §4.4 exit
  codes and `CommandError` reuse.
- `packed.py` (new): `iter_cli_commands` / `collect_cli_commands` /
  `dump_cli_metadata`; `show()` short-circuits on `AURORAVIEW_CLI_DUMP`.
- `mixins/`: suppress the `__command_registered__` emit in packed invoke/dump
  modes so it doesn't corrupt the reserved stdout result/metadata stream.

### `examples/` & `docs/` — demo and references

- `packed_cli_demo.py` + `packed-cli-demo.pack.toml` + `web/index.html`:
  end-to-end demo covering the `cli=` alias forms plus a GUI-only default command.
- "Headless CLI Mode" feature bullet in both READMEs; EN/zh CLI references
  deep-link to the packing guide; new ".cmd shim" subsection in both packing
  guides.

## Type

- [x] feat · [x] fix · [x] docs · [x] test

## Breaking changes

None. The CLI metadata is kept in a parallel map; existing GUI/JS command
registration and dispatch are unchanged.

## Validation

- Rust unit tests: `crates/auroraview-pack/tests/overlay_tests.rs`, plus
  inline tests in `cli_dump.rs`, `packed/cli.rs`, `packed/run.rs`,
  `inspect.rs` (run_inspect overlay branches).
- Python unit tests: `test_cli_invoke.py`, `test_commands.py`,
  `test_lifecycle_dispatch.py`, `test_packed.py` — show() mode dispatch,
  arg parsing, CLI list validation, param introspection, overlay round-trip.
- Environment-limited (not covered automatically): Win32 console FFI, process
  spawn + `process::exit`, the full `build()` pipeline, and pack-time Python
  subprocesses — these need a real packed exe or display environment.
