### PR TITLE
fix: resolve Windows E2E test failures from asyncio loop conflict

### DIFF
--- a/tests/test_gallery_cdp.py
+++ b/tests/test_gallery_cdp.py
@@ -55,7 +55,7 @@ GALLERY_EXE = PROJECT_ROOT / "gallery" / "pack-output" / "auroraview-gallery.exe
 STARTUP_TIMEOUT = 120  # Gallery startup timeout (WebView2 cold-start on CI can be slow)
 API_TIMEOUT = 60  # API call timeout (some DCC samples need more time)
 EXAMPLE_RUN_TIMEOUT = 2  # Example run duration (reduced for faster tests)
-LOADING_TIMEOUT = 90  # Loading screen timeout (WebView2 cold-start on CI runners)
+LOADING_TIMEOUT = 50  # Loading screen timeout before force-navigate (must be < _wait_for_ready timeout)
 
 
 @dataclass
@@ -166,35 +166,46 @@ class GalleryTestClient:
         self._playwright = None
         self._browser = None
         self._page = None
-        self._playwright_loop = None
         self._original_event_loop = None
 
     def _prepare_playwright_loop(self):
         """Prepare a compatible event loop for Playwright sync API.
 
-        Some environments (including CI runners with preload hooks) may have
-        an asyncio loop already running in the main thread. Playwright's sync API
-        cannot start in that situation, so we temporarily isolate it to a
-        dedicated loop.
+        Playwright's sync API calls asyncio.get_running_loop() internally and
+        raises an error if it detects a running loop. Some environments
+        (including CI runners with pytest-asyncio's asyncio_mode=strict) have
+        an asyncio loop already running in the main thread.
+
+        The fix: set the event loop to None so asyncio.get_running_loop()
+        raises RuntimeError (the expected "no running loop" state for sync
+        code). This is safe because the E2E tests use Playwright's sync API
+        and do not need an active asyncio loop.
         """
         try:
-            running_loop = asyncio.get_running_loop()
+            self._original_event_loop = asyncio.get_running_loop()
         except RuntimeError:
+            # No running loop — nothing to do
             return
 
-        # Keep a reference so tests can run without mutating the caller's loop.
-        self._original_event_loop = running_loop
-        self._playwright_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._playwright_loop)
+        # Save the current loop and unset it so Playwright can initialize.
+        # We must close the old loop that was set via set_event_loop()
+        # but isn't running, to avoid leaks.
+        try:
+            old_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            old_loop = None
+
+        if old_loop is not None and old_loop is not self._original_event_loop:
+            try:
+                old_loop.close()
+            except Exception:
+                pass
+
+        # Unset the event loop so asyncio.get_running_loop() raises RuntimeError
+        asyncio.set_event_loop(None)
 
     def _restore_playwright_loop(self):
         """Restore the original event loop after Playwright operations."""
-        if self._playwright_loop is not None and self._original_event_loop is not None:
-            try:
-                self._playwright_loop.close()
-            except Exception:
-                pass
-        self._playwright_loop = None
         if self._original_event_loop is not None:
             try:
                 asyncio.set_event_loop(self._original_event_loop)
@@ -216,6 +227,11 @@ class GalleryTestClient:
                 self._playwright = None
             self._restore_playwright_loop()
             raise
+
+        # Restore the original event loop now that Playwright is initialized.
+        # Playwright's sync API only needs the "no running loop" state during
+        # sync_playwright().start() — after that it uses its own greenlets.
+        self._restore_playwright_loop()
 
         # Find the correct page (not about:blank)
         self._page = self._find_gallery_page()
@@ -301,11 +317,12 @@ class GalleryTestClient:
         print(f"[CDP] Fallback to first page: {all_pages[0]['url']}")
         return all_pages[0]["page"]
 
-    def _wait_for_ready(self, timeout: int = 30):
+    def _wait_for_ready(self, timeout: int = 60):
         """Wait for gallery to be fully loaded.
 
         This method handles both the loading screen and the main app.
-        It uses the AI automation helper for smart waiting.
+        On Windows CI, WebView2 cold-start can take 30-60s, so we use a
+        generous timeout.
         """
         start = time.time()
 


### PR DESCRIPTION
## Summary

Fix two root causes of the `build-gallery / E2E Tests (Windows)` failures in CI run https://github.com/loonghao/auroraview/actions/runs/27661467660.

## Root Cause Analysis

The CI log showed 14 errors across all test classes:

### 1. Playwright sync API + asyncio loop conflict (10 errors)
```
playwright._impl._errors.Error: It looks like you are using Playwright Sync API inside the asyncio loop.
```
When `asyncio_mode=strict` is configured in `tests/pytest.ini`, pytest-asyncio creates a running event loop. Playwright's sync API calls `asyncio.get_running_loop()` internally and refuses to initialize when it detects a running loop. The existing `_prepare_playwright_loop()` workaround created a new loop but didn't properly isolate Playwright from the running loop.

### 2. Gallery startup timeout (4 errors)
```
TimeoutError: Gallery not ready within timeout
```
The `_wait_for_ready()` method had a 30s timeout, insufficient for WebView2 cold-start on Windows CI runners. Also, `LOADING_TIMEOUT` (90s) exceeded the overall `_wait_for_ready` timeout (30s), making force-navigate unreachable.

## Changes

### `tests/test_gallery_cdp.py`
- **`_prepare_playwright_loop()`**: Instead of creating a new event loop, set the event loop to `None` via `asyncio.set_event_loop(None)`. This ensures `asyncio.get_running_loop()` raises `RuntimeError` (the expected state for sync code), allowing Playwright to initialize properly. Restore the original loop after `sync_playwright().start()` completes.
- **`connect()`**: Call `_restore_playwright_loop()` after successful Playwright initialization to restore the original event loop state.
- **`_wait_for_ready()`**: Increase timeout from 30s to 60s.
- **`LOADING_TIMEOUT`**: Adjusted from 90s to 50s to ensure force-navigate triggers within the overall `_wait_for_ready` timeout window.
- Removed unused `_playwright_loop` attribute.

## Testing

- The fix addresses the exact error patterns observed in the failed CI run
- No behavior change for non-Windows platforms or environments without asyncio_mode=strict
