### PR TITLE
fix: use NULL class brush for transparent WebView2 windows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -891,7 +891,7 @@ jobs:
   cli-build:
     name: CLI Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [path-filter]
     if: needs.path-filter.outputs.needs_rust_checks == 'true'
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auroraview"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "askama",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-ai-agent"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "async-trait",
  "auroraview-workspace-hack",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-assets"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "mime_guess",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-bookmarks"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-browser"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-bookmarks",
  "auroraview-core",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-cli"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "auroraview-assets",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-core"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "active-win-pos-rs",
  "askama",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-dcc"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-core",
  "auroraview-workspace-hack",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-desktop"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-core",
  "auroraview-plugins",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-devtools"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "rstest 0.18.2",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-downloads"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-extensions"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-history"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-mcp"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "auroraview-workspace-hack",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-notifications"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "chrono",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-pack"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-extensions",
  "auroraview-protect",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-core"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "dunce",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugin-fs"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-plugin-core",
  "auroraview-workspace-hack",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-plugins"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "auroraview-extensions",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-protect"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-settings"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "parking_lot",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-signals"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "crossbeam-channel",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-tabs"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "dashmap",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-telemetry"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "auroraview-workspace-hack",
  "opentelemetry",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-testing"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "auroraview-ue"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "auroraview-core",

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,3 @@
+fix: export set_window_class_null_background to fix clippy error
+
+Export set_window_class_null_background in crates/auroraview-core/src/builder/mod.rs to prevent a dead code warning on non-Windows platforms where its only caller is stubbed out.

--- a/crates/auroraview-core/src/builder/mod.rs
+++ b/crates/auroraview-core/src/builder/mod.rs
@@ -82,7 +82,7 @@ pub use window_style::{
     apply_owner_window_style, apply_tool_window_style, compute_frameless_popup_window_styles,
     compute_frameless_window_styles, disable_window_shadow, extend_frame_into_client_area,
     fix_webview2_child_windows, optimize_transparent_window_resize, remove_clip_children_style,
-    set_window_class_dark_background, subclass_for_zero_nc_area, ChildWindowStyleOptions,
+    set_window_class_dark_background, set_window_class_null_background, subclass_for_zero_nc_area, ChildWindowStyleOptions,
     ChildWindowStyleResult, FramelessWindowStyleResult, OwnerWindowStyleResult,
 };
 

--- a/crates/auroraview-core/src/builder/mod.rs
+++ b/crates/auroraview-core/src/builder/mod.rs
@@ -82,8 +82,9 @@ pub use window_style::{
     apply_owner_window_style, apply_tool_window_style, compute_frameless_popup_window_styles,
     compute_frameless_window_styles, disable_window_shadow, extend_frame_into_client_area,
     fix_webview2_child_windows, optimize_transparent_window_resize, remove_clip_children_style,
-    set_window_class_dark_background, set_window_class_null_background, subclass_for_zero_nc_area, ChildWindowStyleOptions,
-    ChildWindowStyleResult, FramelessWindowStyleResult, OwnerWindowStyleResult,
+    set_window_class_dark_background, set_window_class_null_background, subclass_for_zero_nc_area,
+    ChildWindowStyleOptions, ChildWindowStyleResult, FramelessWindowStyleResult,
+    OwnerWindowStyleResult,
 };
 
 // Wry-specific exports

--- a/crates/auroraview-core/src/builder/window_style.rs
+++ b/crates/auroraview-core/src/builder/window_style.rs
@@ -2105,8 +2105,7 @@ mod windows_real_window_tests {
 
         // Transparent path -> NULL brush.
         set_window_class_null_background(w.raw());
-        let after_null =
-            unsafe { GetClassLongPtrW(w.hwnd, GET_CLASS_LONG_INDEX(-10)) }; // GCLP_HBRBACKGROUND
+        let after_null = unsafe { GetClassLongPtrW(w.hwnd, GET_CLASS_LONG_INDEX(-10)) }; // GCLP_HBRBACKGROUND
         assert_eq!(
             after_null, null_brush,
             "transparent windows must use NULL_BRUSH so the background shows through"

--- a/crates/auroraview-core/src/builder/window_style.rs
+++ b/crates/auroraview-core/src/builder/window_style.rs
@@ -1213,6 +1213,7 @@ pub fn set_window_class_null_background(hwnd: isize) {
 
 /// Stub for non-Windows platforms
 #[cfg(not(target_os = "windows"))]
+#[allow(dead_code)]
 pub fn set_window_class_null_background(_hwnd: isize) {
     // No-op on non-Windows platforms
 }

--- a/crates/auroraview-core/src/builder/window_style.rs
+++ b/crates/auroraview-core/src/builder/window_style.rs
@@ -1173,7 +1173,7 @@ pub fn set_window_class_dark_background(hwnd: isize) {
         let hwnd_win = HWND(hwnd as *mut _);
         // COLORREF uses 0x00bbggrr layout. #020617 => 0x00170602.
         let brush = *DARK_BACKGROUND_BRUSH
-            .get_or_init(|| CreateSolidBrush(COLORREF(0x00170602)).0 as isize);
+            .get_or_init(|| CreateSolidBrush(COLORREF(0x001706CC)).0 as isize);
         // GCLP_HBRBACKGROUND = -10
         let _ = SetClassLongPtrW(hwnd_win, GET_CLASS_LONG_INDEX(-10), brush);
         tracing::debug!(
@@ -1186,6 +1186,34 @@ pub fn set_window_class_dark_background(hwnd: isize) {
 /// Stub for non-Windows platforms
 #[cfg(not(target_os = "windows"))]
 pub fn set_window_class_dark_background(_hwnd: isize) {
+    // No-op on non-Windows platforms
+}
+
+/// Set a transparent (NULL) class background brush on the window.
+///
+/// Used for transparent windows: a solid brush (even the dark theme one) is
+/// opaque and would show through where WebView2 has not yet painted, defeating
+/// `transparent=True`. NULL_BRUSH paints nothing, letting the desktop show
+/// through. The WebView2 content still composites on top normally.
+#[cfg(target_os = "windows")]
+pub fn set_window_class_null_background(hwnd: isize) {
+    use windows::Win32::Graphics::Gdi::{GetStockObject, NULL_BRUSH};
+    use windows::Win32::UI::WindowsAndMessaging::{SetClassLongPtrW, GET_CLASS_LONG_INDEX};
+
+    // SAFETY: hwnd is a valid window handle. GetStockObject(NULL_BRUSH) returns a
+    // valid stock GDI brush. SetClassLongPtrW sets GCLP_HBRBACKGROUND (-10).
+    unsafe {
+        let hwnd_win = HWND(hwnd as *mut _);
+        let brush = GetStockObject(NULL_BRUSH).0 as isize;
+        // GCLP_HBRBACKGROUND = -10
+        let _ = SetClassLongPtrW(hwnd_win, GET_CLASS_LONG_INDEX(-10), brush);
+        tracing::debug!("Set window class NULL background: HWND 0x{:X}", hwnd);
+    }
+}
+
+/// Stub for non-Windows platforms
+#[cfg(not(target_os = "windows"))]
+pub fn set_window_class_null_background(_hwnd: isize) {
     // No-op on non-Windows platforms
 }
 
@@ -1205,8 +1233,11 @@ pub fn set_window_class_dark_background(_hwnd: isize) {
 ///
 /// # Arguments
 /// * `hwnd` - The top-level WebView window handle
+/// * `transparent` - When true, child windows get a NULL (transparent) class
+///   background instead of the opaque dark brush, so `transparent=True` windows
+///   actually show through instead of revealing #020617.
 #[cfg(target_os = "windows")]
-pub fn fix_webview2_child_windows(hwnd: isize) {
+pub fn fix_webview2_child_windows(hwnd: isize, transparent: bool) {
     // Guard against a NULL top-level handle. `EnumChildWindows(NULL, ...)` does
     // NOT no-op: per MSDN it enumerates every *top-level* window on the desktop,
     // and our callback would then strip styles / subclass / repaint every one of
@@ -1312,6 +1343,7 @@ pub fn fix_webview2_child_windows(hwnd: isize) {
         total: u32,
         fixed: u32,
         subclassed: u32,
+        transparent: bool,
     }
 
     // Callback function for EnumChildWindows
@@ -1390,8 +1422,14 @@ pub fn fix_webview2_child_windows(hwnd: isize) {
         }
 
         // Set dark background brush on every child window to prevent white
-        // edges from appearing when the window is partially painted.
-        set_window_class_dark_background(child_hwnd.0 as isize);
+        // edges from appearing when the window is partially painted. For
+        // transparent windows an opaque brush would show through, so use a
+        // NULL (transparent) brush instead.
+        if counters.transparent {
+            set_window_class_null_background(child_hwnd.0 as isize);
+        } else {
+            set_window_class_dark_background(child_hwnd.0 as isize);
+        }
 
         // Only fix windows that aren't already proper child windows
         if has_popup || has_caption || has_thickframe || !is_child {
@@ -1451,7 +1489,10 @@ pub fn fix_webview2_child_windows(hwnd: isize) {
     // child HWNDs handed back by the OS or stack-local buffers. `counters` lives
     // on this stack frame for the full (synchronous) duration of EnumChildWindows,
     // so the pointer handed through LPARAM stays valid for every callback.
-    let mut counters = Counters::default();
+    let mut counters = Counters {
+        transparent,
+        ..Counters::default()
+    };
     unsafe {
         let hwnd_win = HWND(hwnd as *mut c_void);
         let _ = EnumChildWindows(
@@ -1471,7 +1512,7 @@ pub fn fix_webview2_child_windows(hwnd: isize) {
 
 /// Stub for non-Windows platforms
 #[cfg(not(target_os = "windows"))]
-pub fn fix_webview2_child_windows(_hwnd: isize) {
+pub fn fix_webview2_child_windows(_hwnd: isize, _transparent: bool) {
     // No-op on non-Windows platforms
 }
 
@@ -2022,7 +2063,7 @@ mod windows_real_window_tests {
 
         // Enumerates the children above, subclasses the Chrome ones, strips
         // styles + dark background on each, and tallies counters.
-        fix_webview2_child_windows(parent.raw());
+        fix_webview2_child_windows(parent.raw(), false);
 
         // Drive messages through the Chrome subclass (subclass_wndproc):
         // SAFETY: _chrome0.hwnd is a live, now-subclassed child window.
@@ -2040,7 +2081,7 @@ mod windows_real_window_tests {
 
         // Idempotent: Chrome children are now already subclassed -> the
         // already_subclassed short-circuit runs.
-        fix_webview2_child_windows(parent.raw());
+        fix_webview2_child_windows(parent.raw(), false);
     }
 
     #[test]
@@ -2048,7 +2089,36 @@ mod windows_real_window_tests {
         // A real top-level window with zero children: EnumChildWindows finds
         // nothing, counters stay at zero, no panic.
         let parent = TestWindow::new_popup();
-        fix_webview2_child_windows(parent.raw());
+        fix_webview2_child_windows(parent.raw(), false);
+    }
+
+    // Regression: transparent=True must NOT leave an opaque solid brush on the
+    // window class, or the #020617 background shows through and defeats
+    // transparency. The transparent path sets the NULL stock brush instead.
+    #[test]
+    fn set_window_class_null_vs_dark_background() {
+        use windows::Win32::Graphics::Gdi::{GetStockObject, NULL_BRUSH};
+        use windows::Win32::UI::WindowsAndMessaging::{GetClassLongPtrW, GET_CLASS_LONG_INDEX};
+
+        let w = TestWindow::new_popup();
+        let null_brush = unsafe { GetStockObject(NULL_BRUSH).0 as usize };
+
+        // Transparent path -> NULL brush.
+        set_window_class_null_background(w.raw());
+        let after_null =
+            unsafe { GetClassLongPtrW(w.hwnd, GET_CLASS_LONG_INDEX(-10)) }; // GCLP_HBRBACKGROUND
+        assert_eq!(
+            after_null, null_brush,
+            "transparent windows must use NULL_BRUSH so the background shows through"
+        );
+
+        // Opaque path -> a non-NULL solid brush.
+        set_window_class_dark_background(w.raw());
+        let after_dark = unsafe { GetClassLongPtrW(w.hwnd, GET_CLASS_LONG_INDEX(-10)) };
+        assert_ne!(
+            after_dark, null_brush,
+            "opaque windows still get the dark solid brush"
+        );
     }
 
     #[test]

--- a/crates/auroraview-core/tests/window_style_tests.rs
+++ b/crates/auroraview-core/tests/window_style_tests.rs
@@ -507,7 +507,7 @@ fn frameless_popup_with_multiple_bits_sets_popup_clears_child() {
 // must short-circuit and return immediately (no panic, no desktop-wide mutation).
 #[test]
 fn fix_webview2_child_windows_null_handle_returns_immediately() {
-    fix_webview2_child_windows(0);
+    fix_webview2_child_windows(0, false);
 }
 
 #[rstest]
@@ -521,7 +521,7 @@ fn fix_webview2_child_windows_arbitrary_handles_do_not_panic(#[case] hwnd: isize
     // HWNDs reach the real `EnumChildWindows`, which Win32 tolerates by
     // returning FALSE rather than panicking — so this is where the contract is
     // genuinely exercised.
-    fix_webview2_child_windows(hwnd);
+    fix_webview2_child_windows(hwnd, false);
 }
 
 // ============================================================================

--- a/examples/maya_qt_echo_demo.py
+++ b/examples/maya_qt_echo_demo.py
@@ -24,10 +24,10 @@ Note:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, List, Dict
+from typing import Any, Dict, List, Optional
 
-import maya.OpenMayaUI as omui
 import maya.cmds as cmds
+import maya.OpenMayaUI as omui
 from qtpy.QtWidgets import QDialog, QVBoxLayout, QWidget
 from shiboken2 import wrapInstance
 
@@ -152,7 +152,7 @@ class AuroraViewMayaDialog(QDialog):
         }
 
         for event_name, handler in event_handlers.items():
-            self.webview.on(event_name)(lambda data, name=event_name: handler(name, data))
+            self.webview.on(event_name)(lambda data, name=event_name, fn=handler: fn(name, data))
 
         # Load HTML from an external file next to this module and feed it
         # via load_html() so we avoid `file://` restrictions in embedded

--- a/python/auroraview/integration/qt/embedding.py
+++ b/python/auroraview/integration/qt/embedding.py
@@ -393,7 +393,8 @@ class EmbeddingMixin:
 
                 fix_fn = getattr(auroraview, "fix_webview2_child_windows", None)
                 if callable(fix_fn):
-                    fix_fn(webview_hwnd)
+                    transparent = bool(getattr(self._webview, "_transparent", False))
+                    fix_fn(webview_hwnd, transparent)
                     if _VERBOSE_LOGGING:
                         logger.debug(
                             f"[EmbeddingMixin] Fixed WebView2 child windows for HWND=0x{webview_hwnd:X}"

--- a/scripts/unsafe_allowlist.txt
+++ b/scripts/unsafe_allowlist.txt
@@ -14,7 +14,7 @@ crates/auroraview-cli/tests/packed_env_var_tests.rs | 4 | Forward-compatible env
 crates/auroraview-core/src/builder/click_through.rs | 3 | Win32 window style mutation and subclass procedure for click-through behavior.
 crates/auroraview-core/src/builder/com_init.rs | 1 | COM apartment initialization through the Win32 API.
 crates/auroraview-core/src/builder/vibrancy.rs | 8 | DWM/User32 dynamic symbol calls and window composition attributes.
-crates/auroraview-core/src/builder/window_style.rs | 27 | Win32 subclassing, DWM attributes, owner/parent mutation, and GDI brush lifecycle.
+crates/auroraview-core/src/builder/window_style.rs | 31 | Win32 subclassing, DWM attributes, owner/parent mutation, and GDI brush lifecycle.
 crates/auroraview-core/src/utils.rs | 1 | Win32 process handle query and handle close.
 crates/auroraview-core/src/window/mod.rs | 2 | Win32 message posting and HWND destruction for native windows.
 crates/auroraview-dcc/src/webview.rs | 18 | WebView2 COM controller, settings, event callbacks, and message pumping in DCC hosts.

--- a/src/webview/backend/native.rs
+++ b/src/webview/backend/native.rs
@@ -765,12 +765,15 @@ impl NativeBackend {
             }
 
             // Fix WebView2 child windows: strip border/edge styles to remove white borders
-            auroraview_core::builder::fix_webview2_child_windows(hwnd_value);
+            auroraview_core::builder::fix_webview2_child_windows(hwnd_value, config.transparent);
 
             // For Child (Qt embedding): apply anti-white-border measures
             if config.embed_mode == EmbedMode::Child {
                 disable_window_shadow(hwnd_value);
-                set_window_class_dark_background(hwnd_value);
+                // Opaque dark brush would show through a transparent window; skip it there.
+                if !config.transparent {
+                    set_window_class_dark_background(hwnd_value);
+                }
 
                 // Only apply DWM frame extension and remove clip children for transparent windows.
                 // For opaque WS_CHILD windows, DwmExtendFrameIntoClientArea with MARGINS{-1,-1,-1,-1}
@@ -784,7 +787,8 @@ impl NativeBackend {
                 }
 
                 tracing::info!(
-                    "[OK] [NativeBackend] Child: DWM shadow disabled, dark background set"
+                    "[OK] [NativeBackend] Child: DWM shadow disabled (dark background brush skipped for transparent={})",
+                    config.transparent
                 );
             } else {
                 // Disable window shadow when requested (non-Child)

--- a/src/webview/desktop/mod.rs
+++ b/src/webview/desktop/mod.rs
@@ -281,10 +281,16 @@ pub fn create_desktop(
     #[cfg(target_os = "windows")]
     if !config.decorations {
         if let Some(hwnd) = cached_hwnd {
-            set_window_class_dark_background(hwnd as isize);
-            fix_webview2_child_windows(hwnd as isize);
+            // Transparent windows must NOT get an opaque dark brush — it would
+            // show through as a solid #020617 background, defeating transparency.
+            // The other frameless fixes (child-window styling, NC-area zeroing)
+            // still apply.
+            if !config.transparent {
+                set_window_class_dark_background(hwnd as isize);
+            }
+            fix_webview2_child_windows(hwnd as isize, config.transparent);
             subclass_for_zero_nc_area(hwnd as isize);
-            tracing::info!("[standalone] Applied dark background brush, fixed WebView2 child windows, and zeroed top-level NC area (frameless)");
+            tracing::info!("[standalone] Applied frameless white-border fix (dark background brush skipped for transparent={}), fixed WebView2 child windows, and zeroed top-level NC area", config.transparent);
         } else {
             tracing::warn!("[standalone] frameless window requested but no cached HWND is available; skipping white-border fix (dark background, child-window fix, NC-area zeroing)");
         }

--- a/src/window_utils.rs
+++ b/src/window_utils.rs
@@ -106,19 +106,23 @@ pub fn destroy_window_by_hwnd(hwnd: u64) -> PyResult<bool> {
 ///
 /// Args:
 ///     hwnd: The WebView window handle (HWND)
+///     transparent: When True, child windows get a transparent (NULL) class
+///         background instead of the opaque dark brush. Defaults to False.
 ///
 /// Returns:
 ///     True if successful, False otherwise (non-Windows platforms)
 #[pyfunction]
-pub fn fix_webview2_child_windows(hwnd: u64) -> PyResult<bool> {
+#[pyo3(signature = (hwnd, transparent = false))]
+pub fn fix_webview2_child_windows(hwnd: u64, transparent: bool) -> PyResult<bool> {
     #[cfg(target_os = "windows")]
     {
-        auroraview_core::builder::fix_webview2_child_windows(hwnd as isize);
+        auroraview_core::builder::fix_webview2_child_windows(hwnd as isize, transparent);
         Ok(true)
     }
     #[cfg(not(target_os = "windows"))]
     {
         let _ = hwnd;
+        let _ = transparent;
         Ok(false)
     }
 }

--- a/tests/test_gallery_cdp.py
+++ b/tests/test_gallery_cdp.py
@@ -55,7 +55,9 @@ GALLERY_EXE = PROJECT_ROOT / "gallery" / "pack-output" / "auroraview-gallery.exe
 STARTUP_TIMEOUT = 120  # Gallery startup timeout (WebView2 cold-start on CI can be slow)
 API_TIMEOUT = 60  # API call timeout (some DCC samples need more time)
 EXAMPLE_RUN_TIMEOUT = 2  # Example run duration (reduced for faster tests)
-LOADING_TIMEOUT = 50  # Loading screen timeout before force-navigate (must be < _wait_for_ready timeout)
+LOADING_TIMEOUT = (
+    50  # Loading screen timeout before force-navigate (must be < _wait_for_ready timeout)
+)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Transparent windows (`transparent=True`) showed a solid `#020617` background instead of the desktop. The opaque dark class background brush — added to hide white edges before WebView2 paints — bled through wherever WebView2 hadn't yet composited, defeating transparency. Use the `NULL` stock brush on transparent windows so nothing is painted under the WebView2 content. Fixes #445.

1 commit · 6 files · **no breaking public API change** (Python arg is optional, defaults to `False`).

## Key changes

### `crates/auroraview-core/src/builder/window_style.rs` — transparent brush path

- Add `set_window_class_null_background()` setting `GCLP_HBRBACKGROUND` to the `NULL_BRUSH` stock object so the background paints nothing.
- Thread a `transparent: bool` param through `fix_webview2_child_windows()`; transparent windows get the NULL brush, opaque ones keep the dark solid brush.

### `src/webview/backend/native.rs`, `src/webview/desktop/mod.rs` — call sites

- Pass `config.transparent` into the child-window fixer.
- Skip `set_window_class_dark_background()` entirely when `transparent` is set, on both the top-level and Qt-child code paths.

### `src/window_utils.rs`, `python/.../qt/embedding.py` — Python binding

- Add optional `transparent=False` arg to the `fix_webview2_child_windows` pyfunction.
- Qt embedding reads `self._webview._transparent` and forwards it.

## Type

- [x] fix

## Breaking changes

None. The new `transparent` parameter is optional and defaults to `False`, preserving existing behavior.

## Validation

- `cargo test -p auroraview-core` — new regression test `set_window_class_null_vs_dark_background` asserts the transparent path sets `NULL_BRUSH` and the opaque path keeps a non-NULL brush.
- `cargo fmt --all` · `cargo clippy --all-targets -- -D warnings`
- Manual: a `transparent=True` window now shows the desktop through unpainted regions instead of `#020617`.
