### PR TITLE
fix: install llvm-tools-preview in llvm-cov-install recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -281,6 +281,8 @@ nextest-install:
 # Ensure cargo-llvm-cov is available for local Rust coverage runs
 [unix]
 llvm-cov-install:
+    @echo "Ensuring llvm-tools-preview Rust component..."
+    vx rustup component add llvm-tools-preview
     @if vx cargo llvm-cov --version >/dev/null 2>&1; then \
         echo "cargo-llvm-cov already available"; \
     else \

--- a/tests/test_gallery_cdp.py
+++ b/tests/test_gallery_cdp.py
@@ -55,7 +55,9 @@ GALLERY_EXE = PROJECT_ROOT / "gallery" / "pack-output" / "auroraview-gallery.exe
 STARTUP_TIMEOUT = 120  # Gallery startup timeout (WebView2 cold-start on CI can be slow)
 API_TIMEOUT = 60  # API call timeout (some DCC samples need more time)
 EXAMPLE_RUN_TIMEOUT = 2  # Example run duration (reduced for faster tests)
-LOADING_TIMEOUT = 50  # Loading screen timeout before force-navigate (must be < _wait_for_ready timeout)
+LOADING_TIMEOUT = (
+    50  # Loading screen timeout before force-navigate (must be < _wait_for_ready timeout)
+)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Fix `llvm-profdata` missing under vx-managed Rust toolchain in CI
- Add `vx rustup component add llvm-tools-preview` to the `llvm-cov-install` recipe so it runs before each coverage job
- `cargo-llvm-cov` requires `llvm-profdata` from the `llvm-tools-preview` component to merge profile data

## Root Cause

The `llvm-tools-preview` Rust component was never installed for the vx-managed toolchain. The `ci-rust-coverage-lcov` recipe's prerequisite `llvm-cov-install` only installed `cargo-llvm-cov` itself. When `vx cargo llvm-cov report --lcov` tried to merge profile data, it looked for `llvm-profdata` at:

```
~/.vx/store/rust/1.29.0/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/.../bin/llvm-profdata
```

which did not exist because `llvm-tools-preview` was missing. `vx rustup component add` is idempotent — it's a no-op when already installed.

## Test Plan

- [ ] CI `Rust Tests & Coverage` job passes on this PR
- [ ] `rust-coverage.lcov` artifact is generated
- [ ] Existing tests stay green (no coverage behavior change)